### PR TITLE
Delay routing middleware registration to allow pipelines

### DIFF
--- a/doc/book/usage-examples.md
+++ b/doc/book/usage-examples.md
@@ -425,7 +425,7 @@ along to the next by calling `$next()`.
 `Zend\Expressive\Application` extends `Zend\Stratigility\MiddlewarePipe`,
 allowing composition of multiple middleware.
 
-It also implements routing middleware (`Application\RouteMiddleware`), which it
+It also implements routing middleware (`Application::routeMiddleware()`), which it
 pipes to itself the first time a route is added.
 
 As such, if you want to execute middleware on every request, you have several


### PR DESCRIPTION
This patch alters the workflow of `Application` to delay registration of the routing middleware until the first call to `route()` (which may be via one of the proxy calls via `__call()`). This allows sculpting a full middleware pipeline with early interceptors and/or piping to subpaths.

Additionally, the `Container\ApplicationFactory` implementation was updated to allow specifying middleware for the pipeline. To accomplish this, it uses a new configuration key, `middleware_pipeline`, with up to two subkeys, `pre_routing` and `post_routing`. Each specifies an ordered array of middleware or services resolving to middleware; `pre_routing` middleware are registered prior to any routing middleware, and `post_routing` afterwards.

Finally, if services names are used for `middleware_pipeline` entries, and the service is known by the container, the factory will register a closure:

```php
function ($request, $response, $next = null) use ($services, $middleware) {
    $invokable = $services->get($middleware);
    if (! is_callable($invokable)) {
        throw new Exception\InvalidMiddlewareException(sprintf(
            'Lazy-loaded middleware "%s" is not invokable',
            $middleware
        ));
    }
    return $invokable($request, $response, $next);
};
```

This implements lazy-loading for such services, delaying retrieval from the container until the middleware is actually used. This also means that if the retrieved service is not valid middleware, you will not find out until runtime.