### PR TITLE
change service naming: Zend\Expressive\FinalHandler to Zend\Stratigility\FinalHandler

### DIFF
--- a/src/Container/ApplicationFactory.php
+++ b/src/Container/ApplicationFactory.php
@@ -23,7 +23,7 @@ use Zend\Expressive\Router\Route;
  *
  * - Zend\Expressive\Router\RouterInterface. If missing, an Aura router bridge
  *   will be instantiated and used.
- * - Zend\Expressive\FinalHandler. The service should be a callable to use as
+ * - Zend\Stratigility\FinalHandler. The service should be a callable to use as
  *   the final handler when the middleware pipeline is exhausted.
  * - Zend\Diactoros\Response\EmitterInterface. If missing, an EmitterStack is
  *   created, adding a SapiEmitter to the bottom of the stack.
@@ -79,8 +79,8 @@ class ApplicationFactory
             ? $services->get('Zend\Expressive\Router\RouterInterface')
             : new AuraRouter();
 
-        $finalHandler = $services->has('Zend\Expressive\FinalHandler')
-            ? $services->get('Zend\Expressive\FinalHandler')
+        $finalHandler = $services->has('Zend\Stratigility\FinalHandler')
+            ? $services->get('Zend\Stratigility\FinalHandler')
             : null;
 
         $emitter = $services->has('Zend\Diactoros\Response\EmitterInterface')

--- a/test/Container/ApplicationFactoryTest.php
+++ b/test/Container/ApplicationFactoryTest.php
@@ -78,10 +78,10 @@ class ApplicationFactoryTest extends TestCase
             });
 
         $this->container
-            ->has('Zend\Expressive\FinalHandler')
+            ->has('Zend\Stratigility\FinalHandler')
             ->willReturn(true);
         $this->container
-            ->get('Zend\Expressive\FinalHandler')
+            ->get('Zend\Stratigility\FinalHandler')
             ->willReturn($finalHandler);
 
         $this->container
@@ -138,10 +138,10 @@ class ApplicationFactoryTest extends TestCase
             });
 
         $this->container
-            ->has('Zend\Expressive\FinalHandler')
+            ->has('Zend\Stratigility\FinalHandler')
             ->willReturn(true);
         $this->container
-            ->get('Zend\Expressive\FinalHandler')
+            ->get('Zend\Stratigility\FinalHandler')
             ->willReturn($finalHandler);
 
         $this->container
@@ -180,10 +180,10 @@ class ApplicationFactoryTest extends TestCase
             ->shouldNotBeCalled();
 
         $this->container
-            ->has('Zend\Expressive\FinalHandler')
+            ->has('Zend\Stratigility\FinalHandler')
             ->willReturn(false);
         $this->container
-            ->get('Zend\Expressive\FinalHandler')
+            ->get('Zend\Stratigility\FinalHandler')
             ->shouldNotBeCalled();
 
         $this->container


### PR DESCRIPTION
as <code>FinalHandler</code> class is in <code>Zend\Stratigility</code> components.