### PR TITLE
minimum php version requirement in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
       }
     ],
     "require": {
+        "php": ">=5.5",
         "aura/router": "^2.3",
         "container-interop/container-interop": "^1.1",
         "psr/http-message": "^1.0",


### PR DESCRIPTION
in composer.json, currently there is no minimum php version requirement yet.