### PR TITLE
Update Application constructor docblock

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -82,10 +82,9 @@ class Application extends MiddlewarePipe
      * Constructor
      *
      * Calls on the parent constructor, and then uses the provided arguments
-     * to set internal properties. On completion, pipes its own
-     * `routeMiddleware()` method to its internal pipeline.
+     * to set internal properties.
      *
-     * @param Dispatcher $dispatcher
+     * @param Router\RouterInterface $router
      * @param null|ContainerInterface $container IoC container from which to pull services, if any.
      * @param null|callable $finalHandler Final handler to use when $out is not
      *     provided on invocation.


### PR DESCRIPTION
Per @Stanimirdim92 in #20, this updates the Application constructor docblock:

- Fixes the typehint and argument name for the first argument to
  reference a router instead of the dispatcher (which no longer exists).
- Updatese the description to remove the verbiage about piping the route
  middleware, as that's now delayed until first call to `route()`.