### PR TITLE
Provide documentation around injecting Aura.Router

### DIFF
--- a/doc/book/router.aura.md
+++ b/doc/book/router.aura.md
@@ -36,7 +36,7 @@ The answer, then, is to use dependency injection. This can be done in two ways:
 programmatically, or via a factory to use in conjunction with your container
 instance.
 
-## Programmtic Aura.Router Creation
+## Programmatic Aura.Router Creation
 
 To handle it programmatically, you will need to setup the Aura.Router instance
 manually, inject it into a `Zend\Expressive\Router\Aura` instance, and inject
@@ -115,7 +115,7 @@ namespace Application\Container;
 use Interop\Container\ContainerInterface;
 use Zend\Expressive\Router\Aura as AuraBridge;
 
-class AuraRouterFactory
+class RouterFactory
 {
     /**
      * @param ContainerInterface $services

--- a/doc/book/router.aura.md
+++ b/doc/book/router.aura.md
@@ -1,4 +1,4 @@
-# Advanced Aura.Router usage
+# Aura.Router Usage
 
 [Aura.Router](https://github.com/auraphp/Aura.Router) provides a plethora of
 methods for further configuring the router instance. One of the more useful
@@ -36,7 +36,7 @@ The answer, then, is to use dependency injection. This can be done in two ways:
 programmatically, or via a factory to use in conjunction with your container
 instance.
 
-## Programmatic Aura.Router Creation
+## Programmatic Creation
 
 To handle it programmatically, you will need to setup the Aura.Router instance
 manually, inject it into a `Zend\Expressive\Router\Aura` instance, and inject
@@ -61,7 +61,7 @@ $router = new AuraBridge($auraRouter);
 $app = AppFactory::create(null, $router);
 ```
 
-## Factory-Driven Aura.Router Creation
+## Factory-Driven Creation
 
 We recommend using an Inversion of Control container for your applications;
 doing so provides the ability to substitute alternate implementations, and

--- a/doc/book/router.aura.md
+++ b/doc/book/router.aura.md
@@ -1,0 +1,172 @@
+# Advanced Aura.Router usage
+
+[Aura.Router](https://github.com/auraphp/Aura.Router) provides a plethora of
+methods for further configuring the router instance. One of the more useful
+configuration is to provide default specifications:
+
+- A regular expression that applies the same for a given routing match:
+
+  ```php
+  // Parameters named "id" will only match digits by default:
+  $router->addTokens([
+    'id' => '\d+',
+  ]);
+  ```
+
+- A default parameter and/or its default value to always provide:
+
+  ```php
+  // mediatype defaults to "application/xhtml+xml" and will be available in all
+  // requests:
+  $router->addValues([
+    'mediatype' => 'application/xhtml+xml',
+  ]);
+  ```
+
+- Only match if secure (i.e., under HTTPS):
+
+  ```php
+  $router->setSecure(true);
+  ```
+
+In order to specify these, you need access to the underlying Aura.Router
+instance, however, and the `RouterInterface` does not provide an accessor!
+
+The answer, then, is to use dependency injection. This can be done in two ways:
+programmatically, or via a factory to use in conjunction with your container
+instance.
+
+## Programmtic Aura.Router Creation
+
+To handle it programmatically, you will need to setup the Aura.Router instance
+manually, inject it into a `Zend\Expressive\Router\Aura` instance, and inject
+use that when creating your `Application` instance.
+
+```php
+<?php
+use Aura\Router\RouterFactory;
+use Zend\Expressive\AppFactory;
+use Zend\Expressive\Router\Aura as AuraBridge;
+
+$auraRouter = (new RouterFactory())->newInstance();
+$auraRouter->setSecure(true);
+$auraRouter->addValues([
+    'mediatype' => 'application/xhtml+xml',
+]);
+
+$router = new AuraBridge($auraRouter);
+
+// First argument is the container to use, if not using the default;
+// second is the router.
+$app = AppFactory::create(null, $router);
+```
+
+## Factory-Driven Aura.Router Creation
+
+We recommend using an Inversion of Control container for your applications;
+doing so provides the ability to substitute alternate implementations, and
+removes the logic of creating instances from your code, so you can focus on the
+business logic.
+
+Some containers will auto-wire based on discovery in your code. Other IoC
+containers require your to register factories with the code for
+creating and configuring your instances. We tend to prefer code-driven
+factories, as they allow you to fully shape the instantiation and configuration
+process.
+
+In this case, we'll define two factories:
+
+- A factory to register as and generate an `Aura\Router\Router` instance.
+- A factory registered as `Zend\Expressive\Router\RouterInterface`, which
+  creates and returns a `Zend\Expressive\Router\Aura` instance composing the
+  `Aura\Router\Router` instance.
+
+Sound difficult? It's not; we've essentially done it above already!
+
+```php
+<?php
+// in src/Application/Container/AuraRouterFactory.php:
+namespace Application\Container;
+
+use Aura\Router\RouterFactory;
+use Interop\Container\ContainerInterface;
+
+class AuraRouterFactory
+{
+    /**
+     * @param ContainerInterface $services
+     * @return \Aura\Router\Router
+     */
+    public function __invoke(ContainerInterface $services)
+    {
+        $router = (new RouterFactory())->newInstance();
+        $router->setSecure(true);
+        $router->addValues([
+            'mediatype' => 'application/xhtml+xml',
+        ]);
+
+        return $router;
+    }
+}
+
+// in src/Application/Container/RouterFactory.php
+namespace Application\Container;
+
+use Interop\Container\ContainerInterface;
+use Zend\Expressive\Router\Aura as AuraBridge;
+
+class AuraRouterFactory
+{
+    /**
+     * @param ContainerInterface $services
+     * @return \Aura\Router\Router
+     */
+    public function __invoke(ContainerInterface $services)
+    {
+        return new AuraBridge($services->get('Aura\Router\Router'));
+    }
+}
+```
+
+From here, you will need to register your factories with your IoC container.
+
+If you are using `Zend\ServiceManager`, this might look like the following:
+
+```php
+use Zend\ServiceManager\ServiceManager;
+
+$services = new ServiceManager();
+$services->addFactory(
+    'Aura\Router\Router',
+    'Application\Container\AuraRouterFactory'
+);
+$services->addFactory(
+    'Zend\Expressive\Router\RouterInterface',
+    'Application\Container\RouterFactory'
+);
+
+// alternately, via service_manager configuration:
+return [
+    'service_manager' => [
+        'factories' => [
+            'Aura\Router\Router' => 'Application\Container\AuraRouterFactory',
+            'Zend\Expressive\Router\RouterInterface' => 'Application\Container\RouterFactory',
+        ],
+    ],
+];
+```
+
+[Pimple-interop](https://github.com/moufmouf/pimple-interop) is a version of
+[Pimple](http://pimple.sensiolabs.org/) that supports
+[container-interop](https://github.com/container-interop/container-interop).
+Configuration of that container looks like the following.
+
+```php
+use Application\Container\AuraRouterFactory;
+use Application\Container\RouterFactory;
+use Interop\Container\Pimple\PimpleInterop;
+
+$pimple = new PimpleInterop();
+$pimple['Aura\Router\Router'] = new AuraRouterFactory();
+$pimple['Zend\Expressive\Router\RouterInterface'] = new RouterFactory();
+```

--- a/doc/book/router.aura.md
+++ b/doc/book/router.aura.md
@@ -94,10 +94,10 @@ use Interop\Container\ContainerInterface;
 class AuraRouterFactory
 {
     /**
-     * @param ContainerInterface $services
+     * @param ContainerInterface $container
      * @return \Aura\Router\Router
      */
-    public function __invoke(ContainerInterface $services)
+    public function __invoke(ContainerInterface $container)
     {
         $router = (new RouterFactory())->newInstance();
         $router->setSecure(true);
@@ -118,12 +118,12 @@ use Zend\Expressive\Router\Aura as AuraBridge;
 class RouterFactory
 {
     /**
-     * @param ContainerInterface $services
+     * @param ContainerInterface $container
      * @return AuraBridge
      */
-    public function __invoke(ContainerInterface $services)
+    public function __invoke(ContainerInterface $container)
     {
-        return new AuraBridge($services->get('Aura\Router\Router'));
+        return new AuraBridge($container->get('Aura\Router\Router'));
     }
 }
 ```
@@ -135,12 +135,12 @@ If you are using `Zend\ServiceManager`, this might look like the following:
 ```php
 use Zend\ServiceManager\ServiceManager;
 
-$services = new ServiceManager();
-$services->addFactory(
+$container = new ServiceManager();
+$container->addFactory(
     'Aura\Router\Router',
     'Application\Container\AuraRouterFactory'
 );
-$services->addFactory(
+$container->addFactory(
     'Zend\Expressive\Router\RouterInterface',
     'Application\Container\RouterFactory'
 );
@@ -166,7 +166,7 @@ use Application\Container\AuraRouterFactory;
 use Application\Container\RouterFactory;
 use Interop\Container\Pimple\PimpleInterop;
 
-$pimple = new PimpleInterop();
-$pimple['Aura\Router\Router'] = new AuraRouterFactory();
-$pimple['Zend\Expressive\Router\RouterInterface'] = new RouterFactory();
+$container = new PimpleInterop();
+$container['Aura\Router\Router'] = new AuraRouterFactory();
+$container['Zend\Expressive\Router\RouterInterface'] = new RouterFactory();
 ```

--- a/doc/book/router.aura.md
+++ b/doc/book/router.aura.md
@@ -119,7 +119,7 @@ class AuraRouterFactory
 {
     /**
      * @param ContainerInterface $services
-     * @return \Aura\Router\Router
+     * @return AuraBridge
      */
     public function __invoke(ContainerInterface $services)
     {

--- a/doc/bookdown.json
+++ b/doc/bookdown.json
@@ -3,7 +3,8 @@
   "content": [
     "book/intro.md",
     "book/install.md",
-    "book/usage-examples.md"
+    "book/usage-examples.md",
+    "book/router.aura.md"
   ],
   "target": "./html"
 }


### PR DESCRIPTION
Provides documentation around creating your own Aura.Router instance, configuring it, and injecting it into your router instance for zend-expressive. Both programmatic and IoC approaches are detailed.