### PR TITLE
Ensure that FinalHandler gets original response

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -116,7 +116,7 @@ class Application extends MiddlewarePipe
      */
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $out = null)
     {
-        $out = $out ?: $this->getFinalHandler();
+        $out = $out ?: $this->getFinalHandler($response);
         return parent::__invoke($request, $response, $out);
     }
 
@@ -334,12 +334,15 @@ class Application extends MiddlewarePipe
      * Creates an instance of Zend\Stratigility\FinalHandler if no handler is
      * already registered.
      *
+     * @param null|ResponseInterface Response instance with which to seed the
+     *     FinalHandler; used to determine if the response passed to the handler
+     *     represents the original or final response state.
      * @return callable
      */
-    public function getFinalHandler()
+    public function getFinalHandler(ResponseInterface $response = null)
     {
         if (! $this->finalHandler) {
-            $this->finalHandler = new FinalHandler();
+            $this->finalHandler = new FinalHandler([], $response);
         }
         return $this->finalHandler;
     }

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -265,6 +265,35 @@ class ApplicationTest extends TestCase
         $this->assertSame($finalResponse, $test);
     }
 
+    public function testFinalHandlerCreatedAtInvocationIsProvidedResponseInstance()
+    {
+        $routeResult = RouteResult::fromRouteFailure();
+        $this->router->match()->willReturn($routeResult);
+
+        $app = new Application($this->router->reveal());
+
+        $finalResponse = $this->prophesize('Psr\Http\Message\ResponseInterface');
+        $app->pipe(function ($req, $res, $next) use ($finalResponse) {
+            return $finalResponse->reveal();
+        });
+
+        $responseStream = $this->prophesize('Psr\Http\Message\StreamInterface');
+        $responseStream->getSize()->willReturn(0);
+
+        $request  = new Request([], [], 'http://example.com/');
+        $response = $this->prophesize('Psr\Http\Message\ResponseInterface');
+        $response->getBody()->willReturn($responseStream->reveal());
+
+        $test = $app($request, $response->reveal());
+
+        $finalHandler = $app->getFinalHandler();
+        $this->assertInstanceOf('Zend\Stratigility\FinalHandler', $finalHandler);
+        $r = new ReflectionProperty($finalHandler, 'response');
+        $r->setAccessible(true);
+        $handlerResponse = $r->getValue($finalHandler);
+        $this->assertSame($response->reveal(), $handlerResponse);
+    }
+
     public function testComposesSapiEmitterByDefault()
     {
         $app     = $this->getApp();


### PR DESCRIPTION
`FinalHandler` allows passing a `ResponseInterface` instance at instantiation. When invoked without an error, it then compares the received response with its original response to determine whether or not to raise a 404; if they are the same, it raises the 404, otherwise, it returns the received response.

`Application` was not passing the response to the `FinalHandler`, which broke this semantic. This patch does the following:

- adds a new optional argument to `getFinalHandler()`, a response instance. If the method creates a `FinalHandler,` it passes that instance to it.
- updates `__invoke()` to pass the response to `getFinalHandler()` if/when it calls that method.