### PR TITLE
Implement a ZF2 router implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,9 @@
     "require-dev": {
         "nikic/fast-route": "^0.6.0",
         "phpunit/phpunit": "^4.7",
-        "squizlabs/php_codesniffer": "^2.3"
+        "squizlabs/php_codesniffer": "^2.3",
+        "zendframework/zend-mvc": "^2.5",
+        "zendframework/zend-psr7bridge": "^0.1.0"
     },
     "autoload": {
       "psr-4": {
@@ -34,6 +36,8 @@
       }
     },
     "suggest": {
-        "nikic/fast-route": "^0.6.0 to use the FastRoute routing adapter"
+        "nikic/fast-route": "^0.6.0 to use the FastRoute routing adapter",
+        "zendframework/zend-mvc": "^2.5 to use the zend-mvc TreeRouteStack routing adapter",
+        "zendframework/zend-psr7bridge": "^0.1.0 to use the zend-mvc TreeRouteStack routing adapter"
     }
 }

--- a/doc/book/router.zf2.md
+++ b/doc/book/router.zf2.md
@@ -107,10 +107,10 @@ use Zend\Http\Mvc\Router\TreeRouteStack;
 class TreeRouteStackFactory
 {
     /**
-     * @param ContainerInterface $services
+     * @param ContainerInterface $container
      * @return TreeRouteStack
      */
-    public function __invoke(ContainerInterface $services)
+    public function __invoke(ContainerInterface $container)
     {
         $router = new TreeRouteStack();
         $router->addPrototypes(/* ... */);
@@ -120,21 +120,21 @@ class TreeRouteStackFactory
     }
 }
 
-// in src/Application/Container/Zf2RouterFactory.php
+// in src/Application/Container/RouterFactory.php
 namespace Application\Container;
 
 use Interop\Container\ContainerInterface;
 use Zend\Expressive\Router\Zf2 as Zf2Bridge;
 
-class Zf2RouterFactory
+class RouterFactory
 {
     /**
-     * @param ContainerInterface $services
+     * @param ContainerInterface $container
      * @return Zf2Bridge
      */
-    public function __invoke(ContainerInterface $services)
+    public function __invoke(ContainerInterface $container)
     {
-        return new Zf2Bridge($services->get('Zend\Mvc\Router\Http\TreeRouteStack'));
+        return new Zf2Bridge($container->get('Zend\Mvc\Router\Http\TreeRouteStack'));
     }
 }
 ```
@@ -146,14 +146,14 @@ If you are using `Zend\ServiceManager`, this might look like the following:
 ```php
 use Zend\ServiceManager\ServiceManager;
 
-$services = new ServiceManager();
-$services->addFactory(
+$container = new ServiceManager();
+$container->addFactory(
     'Zend\Mvc\Router\Http\TreeRouteStack',
     'Application\Container\TreeRouteStackFactory'
 );
-$services->addFactory(
+$container->addFactory(
     'Zend\Expressive\Router\RouterInterface',
-    'Application\Container\Zf2RouterFactory'
+    'Application\Container\RouterFactory'
 );
 
 // alternately, via service_manager configuration:
@@ -161,7 +161,7 @@ return [
     'service_manager' => [
         'factories' => [
             'Zend\Mvc\Router\Http\TreeRouteStack' => 'Application\Container\TreeRouteStackFactory',
-            'Zend\Expressive\Router\RouterInterface' => 'Application\Container\Zf2RouterFactory',
+            'Zend\Expressive\Router\RouterInterface' => 'Application\Container\RouterFactory',
         ],
     ],
 ];
@@ -177,7 +177,7 @@ use Application\Container\TreeRouteStackFactory;
 use Application\Container\ZfRouterFactory;
 use Interop\Container\Pimple\PimpleInterop;
 
-$pimple = new PimpleInterop();
-$pimple['Zend\Mvc\Router\Http\TreeRouteStackFactory'] = new TreeRouteStackFactory();
-$pimple['Zend\Expressive\Router\RouterInterface'] = new Zf2RouterFactory();
+$container = new PimpleInterop();
+$container['Zend\Mvc\Router\Http\TreeRouteStackFactory'] = new TreeRouteStackFactory();
+$container['Zend\Expressive\Router\RouterInterface'] = new RouterFactory();
 ```

--- a/doc/book/router.zf2.md
+++ b/doc/book/router.zf2.md
@@ -1,0 +1,183 @@
+# Using the ZF2 Router
+
+[zend-mvc](https://github.com/zendframework/zend-mvc) provides a router
+implementation; for HTTP applications, the default used in ZF2 applications it
+`Zend\Mvc\Router\Http\TreeRouteStack`, which can compose a number of different
+routes of differing types in order to perform routing.
+
+The ZF2 bridge we provide uses the `TreeRouteStack`, and injects `Segment`
+routes to it. We emulate HTTP method negotiation in the implementation, however,
+instead of creating `Method` routes, as the `TreeRouteStack` does not
+differentiate between failure to route and failure due to HTTP method
+negotiation.
+
+To use the ZF2 router, you will need to install two dependencies,
+`zendframework/zend-mvc`, and `zendframework/zend-psr7bridge`; the latter is
+used to convert the PSR-7 `ServerRequestInterface` request instances used by
+zend-expressive into zend-http equivalents to pass to the `TreeRouteStack`. You
+can add these via Composer by executing the following in your project root:
+
+```bash
+$ composer require zendframework/zend-mvc zendframework/zend-psr7bridge
+```
+
+`Zend\Expressive\Router\Zf2` is the zend-expressive router implementation that
+consumes a `TreeRouteStack`. If you instantiate it with no arguments, it will
+create an empty `TreeRouteStack`. Thus, the simplest way to start with this
+router is:
+
+```php
+use Zend\Expressive\AppFactory;
+use Zend\Expressive\Router\Zf2 as Zf2Router;
+
+$app = AppFactory(null, new Zf2Router());
+```
+
+The `TreeRouteStack` offers some unique features:
+
+- Route "prototypes". These are essentially like child routes that must *also*
+  match in order for a given route to match. These are useful for implementing
+  functionality such as ensuring the request comes in over HTTPS, or over a
+  specific subdomain.
+- Base URL functionality. If a base URL is injected, comparisons will be
+  relative to that URL. This is mostly unnecessary with Stratigility-based
+  middleware, but could solve some edge cases.
+
+To specify these, you need access to the underlying `TreeRouteStack`
+instance, however, and the `RouterInterface` does not provide an accessor!
+
+The answer, then, is to use dependency injection. This can be done in two ways:
+programmatically, or via a factory to use in conjunction with your container
+instance.
+
+## Programmtic Creation
+
+To handle it programmatically, you will need to setup the `TreeRouteStack` instance
+manually, inject it into a `Zend\Expressive\Router\Zf2` instance, and inject
+use that when creating your `Application` instance.
+
+```php
+<?php
+use Zend\Expressive\AppFactory;
+use Zend\Expressive\Router\Zf2 as Zf2Bridge;
+use Zend\Mvc\Router\Http\TreeRouteStack;
+
+$zf2Router = new TreeRouteStack();
+$zf2Router->addPrototypes(/* ... */);
+$zf2Router->setBaseUrl(/* ... */);
+
+$router = new Zf2Bridge($zf2Router);
+
+// First argument is the container to use, if not using the default;
+// second is the router.
+$app = AppFactory::create(null, $router);
+```
+
+## Factory-Driven Creation
+
+We recommend using an Inversion of Control container for your applications;
+doing so provides the ability to substitute alternate implementations, and
+removes the logic of creating instances from your code, so you can focus on the
+business logic.
+
+Some containers will auto-wire based on discovery in your code. Other IoC
+containers require your to register factories with the code for
+creating and configuring your instances. We tend to prefer code-driven
+factories, as they allow you to fully shape the instantiation and configuration
+process.
+
+In this case, we'll define two factories:
+
+- A factory to register as and generate an `Zend\Mvc\Router\Http\TreeRouteStack`
+  instance.
+- A factory registered as `Zend\Expressive\Router\RouterInterface`, which
+  creates and returns a `Zend\Expressive\Router\Zf2` instance composing the
+  `Zend\Mvc\Router\Http\TreeRouteStack` instance.
+
+Sound difficult? It's not; we've essentially done it above already!
+
+```php
+<?php
+// in src/Application/Container/TreeRouteStackFactory.php:
+namespace Application\Container;
+
+use Interop\Container\ContainerInterface;
+use Zend\Http\Mvc\Router\TreeRouteStack;
+
+class TreeRouteStackFactory
+{
+    /**
+     * @param ContainerInterface $services
+     * @return TreeRouteStack
+     */
+    public function __invoke(ContainerInterface $services)
+    {
+        $router = new TreeRouteStack();
+        $router->addPrototypes(/* ... */);
+        $router->setBaseUrl(/* ... */);
+
+        return $router;
+    }
+}
+
+// in src/Application/Container/Zf2RouterFactory.php
+namespace Application\Container;
+
+use Interop\Container\ContainerInterface;
+use Zend\Expressive\Router\Zf2 as Zf2Bridge;
+
+class Zf2RouterFactory
+{
+    /**
+     * @param ContainerInterface $services
+     * @return Zf2Bridge
+     */
+    public function __invoke(ContainerInterface $services)
+    {
+        return new Zf2Bridge($services->get('Zend\Mvc\Router\Http\TreeRouteStack'));
+    }
+}
+```
+
+From here, you will need to register your factories with your IoC container.
+
+If you are using `Zend\ServiceManager`, this might look like the following:
+
+```php
+use Zend\ServiceManager\ServiceManager;
+
+$services = new ServiceManager();
+$services->addFactory(
+    'Zend\Mvc\Router\Http\TreeRouteStack',
+    'Application\Container\TreeRouteStackFactory'
+);
+$services->addFactory(
+    'Zend\Expressive\Router\RouterInterface',
+    'Application\Container\Zf2RouterFactory'
+);
+
+// alternately, via service_manager configuration:
+return [
+    'service_manager' => [
+        'factories' => [
+            'Zend\Mvc\Router\Http\TreeRouteStack' => 'Application\Container\TreeRouteStackFactory',
+            'Zend\Expressive\Router\RouterInterface' => 'Application\Container\Zf2RouterFactory',
+        ],
+    ],
+];
+```
+
+[Pimple-interop](https://github.com/moufmouf/pimple-interop) is a version of
+[Pimple](http://pimple.sensiolabs.org/) that supports
+[container-interop](https://github.com/container-interop/container-interop).
+Configuration of that container looks like the following.
+
+```php
+use Application\Container\TreeRouteStackFactory;
+use Application\Container\ZfRouterFactory;
+use Interop\Container\Pimple\PimpleInterop;
+
+$pimple = new PimpleInterop();
+$pimple['Zend\Mvc\Router\Http\TreeRouteStackFactory'] = new TreeRouteStackFactory();
+$pimple['Zend\Expressive\Router\RouterInterface'] = new Zf2RouterFactory();
+```

--- a/doc/book/router.zf2.md
+++ b/doc/book/router.zf2.md
@@ -1,4 +1,4 @@
-# Using the ZF2 Router
+# ZF2 Router Usage
 
 [zend-mvc](https://github.com/zendframework/zend-mvc) provides a router
 implementation; for HTTP applications, the default used in ZF2 applications it
@@ -50,7 +50,7 @@ The answer, then, is to use dependency injection. This can be done in two ways:
 programmatically, or via a factory to use in conjunction with your container
 instance.
 
-## Programmtic Creation
+## Programmatic Creation
 
 To handle it programmatically, you will need to setup the `TreeRouteStack` instance
 manually, inject it into a `Zend\Expressive\Router\Zf2` instance, and inject

--- a/doc/bookdown.json
+++ b/doc/bookdown.json
@@ -5,7 +5,8 @@
     "book/install.md",
     "book/usage-examples.md",
     "book/router.aura.md",
-    "book/router.fast-route.md"
+    "book/router.fast-route.md",
+    "book/router.zf2.md"
   ],
   "target": "./html"
 }

--- a/src/Router/Zf2.php
+++ b/src/Router/Zf2.php
@@ -2,9 +2,9 @@
 /**
  * Zend Framework (http://framework.zend.com/)
  *
- * @see       http://github.com/zendframework/zend-diactoros for the canonical source repository
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
  * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\Expressive\Router;

--- a/src/Router/Zf2.php
+++ b/src/Router/Zf2.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       http://github.com/zendframework/zend-diactoros for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Router;
+
+use Psr\Http\Message\ServerRequestInterface as PsrRequest;
+use Zend\Mvc\Router\Http\TreeRouteStack;
+use Zend\Mvc\Router\RouteMatch;
+use Zend\Psr7Bridge\Psr7ServerRequest;
+
+/**
+ * Router implementation that consumes zend-mvc TreeRouteStack.
+ *
+ * This router implementation consumes zend-mvc's TreeRouteStack, (the default
+ * router implementation in a ZF2 application). The addRoute() method injects
+ * segment routes into the TreeRouteStack, and manages an internal route stack
+ * in order to do HTTP method negotiation after a successful match (as the ZF2
+ * "Method" router implementation will return a result indistinguishable from a
+ * 404 otherwise).
+ */
+class Zf2 implements RouterInterface
+{
+    /**
+     * @var Route[] Registered routes
+     */
+    private $routes = [];
+
+    /**
+     * @var TreeRouteStack
+     */
+    private $zf2Router;
+
+    /**
+     * @param null|TreeRouteStack $router
+     */
+    public function __construct(TreeRouteStack $router = null)
+    {
+        if (null === $router) {
+            $router = $this->createRouter();
+        }
+
+        $this->zf2Router = $router;
+    }
+
+    /**
+     * @param Route $route
+     */
+    public function addRoute(Route $route)
+    {
+        $options = $route->getOptions() ?: [];
+        $options = array_replace_recursive($options, [
+            'route'   => $route->getPath(),
+            'defaults' => [
+                'middleware' => $route->getMiddleware(),
+            ],
+        ]);
+
+        $spec = [
+            'type'    => 'segment',
+            'options' => $options,
+        ];
+
+        $this->zf2Router->addRoute($route->getPath(), $spec);
+        $this->routes[] = $route;
+    }
+
+    /**
+     * Attempt to match an incoming request to a registered route.
+     *
+     * @param PsrRequest $request
+     * @return RouteResult
+     */
+    public function match(PsrRequest $request)
+    {
+        $match = $this->zf2Router->match(Psr7ServerRequest::toZend($request, true));
+
+        if (null === $match) {
+            return RouteResult::fromRouteFailure();
+        }
+
+        $allowedMethods = $this->getAllowedMethods($match->getMatchedRouteName());
+        if (! $this->methodIsAllowed($request->getMethod(), $allowedMethods)) {
+            return RouteResult::fromRouteFailure($allowedMethods);
+        }
+
+        return $this->marshalSuccessResultFromRouteMatch($match);
+    }
+
+    /**
+     * @return TreeRouteStack
+     */
+    private function createRouter()
+    {
+        return new TreeRouteStack();
+    }
+
+    /**
+     * Create a succesful RouteResult from the given RouteMatch.
+     *
+     * @param RouteMatch $match
+     * @return RouteResult
+     */
+    private function marshalSuccessResultFromRouteMatch(RouteMatch $match)
+    {
+        $params = $match->getParams();
+        $middleware = isset($params['middleware'])
+            ? $params['middleware']
+            : $this->getMiddlewareFromRoute($match->getMatchedRouteName());
+
+        return RouteResult::fromRouteMatch(
+            $match->getMatchedRouteName(),
+            $middleware,
+            $params
+        );
+    }
+
+    /**
+     * Given a route name (the path), retrieve the middleware associated with it.
+     *
+     * @param string $name
+     * @return null|string|callable
+     */
+    private function getMiddlewareFromRoute($name)
+    {
+        return array_reduce($this->routes, function ($carry, $route) use ($name) {
+            if ($carry) {
+                return $carry;
+            }
+
+            if ($route->getPath() === $name) {
+                return $route->getMiddleware();
+            }
+
+            return null;
+        }, null);
+    }
+
+    /**
+     * Get list of allowed methods for this route.
+     *
+     * @param name $string
+     * @return int|string[]
+     */
+    private function getAllowedMethods($name)
+    {
+        $allowedMethods = array_reduce($this->routes, function ($carry, $route) use ($name) {
+            if (null !== $carry) {
+                return $carry;
+            }
+
+            if ($route->getPath() === $name) {
+                return $route->getAllowedMethods();
+            }
+
+            return null;
+        }, null);
+
+        return ($allowedMethods === null)
+            ? Route::HTTP_METHOD_ANY
+            : $allowedMethods;
+    }
+
+    /**
+     * Is the provided method in the list of allowed methods?
+     *
+     * @param string $method
+     * @param int|string[] $allowedMethods
+     * @return bool
+     */
+    private function methodIsAllowed($method, $allowedMethods)
+    {
+        if ($allowedMethods === Route::HTTP_METHOD_ANY) {
+            return true;
+        }
+
+        return in_array(strtoupper($method), array_map('strtoupper', $allowedMethods), true);
+    }
+}

--- a/test/Router/Zf2Test.php
+++ b/test/Router/Zf2Test.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       http://github.com/zendframework/zend-diactoros for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-diactoros/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive\Router;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Prophecy\Argument;
+use Zend\Expressive\Router\Zf2 as Zf2Router;
+use Zend\Expressive\Router\Route;
+
+class Zf2Test extends TestCase
+{
+    public function setUp()
+    {
+        $this->zf2Router = $this->prophesize('Zend\Mvc\Router\Http\TreeRouteStack');
+    }
+
+    public function getRouter()
+    {
+        return new Zf2Router($this->zf2Router->reveal());
+    }
+
+    public function createRequestProphecy()
+    {
+        $request = $this->prophesize('Psr\Http\Message\ServerRequestInterface');
+
+        $request->getMethod()->willReturn('GET');
+        $request->getUri()->willReturn('https://example.com/foo');
+        $request->getHeaders()->willReturn([]);
+        $request->getCookieParams()->willReturn([]);
+        $request->getQueryParams()->willReturn([]);
+        $request->getServerParams()->willReturn([]);
+
+        return $request;
+    }
+
+    public function testAddingRouteProxiesToZf2Router()
+    {
+        $route = new Route('/foo', 'foo', ['GET']);
+
+        $this->zf2Router->addRoute('/foo', [
+            'type' => 'segment',
+            'options' => [
+                'route' => '/foo',
+                'defaults' => [
+                    'middleware' => 'foo',
+                ],
+            ],
+        ])->shouldBeCalled();
+
+        $router = $this->getRouter();
+        $router->addRoute($route);
+    }
+
+    public function testCanSpecifyRouteOptions()
+    {
+        $route = new Route('/foo/:id', 'foo', ['GET']);
+        $route->setOptions([
+            'constraints' => [
+                'id' => '\d+',
+            ],
+            'defaults' => [
+                'bar' => 'baz',
+            ],
+        ]);
+
+        $this->zf2Router->addRoute('/foo/:id', [
+            'type' => 'segment',
+            'options' => [
+                'route' => '/foo/:id',
+                'constraints' => [
+                    'id' => '\d+',
+                ],
+                'defaults' => [
+                    'bar' => 'baz',
+                    'middleware' => 'foo',
+                ],
+            ],
+        ])->shouldBeCalled();
+
+        $router = $this->getRouter();
+        $router->addRoute($route);
+    }
+
+    public function routeResults()
+    {
+        $successRoute = new Route('/foo', 'bar');
+        return [
+            'success' => [
+                new Route('/foo', 'bar'),
+                RouteResult::fromRouteMatch('/foo', 'bar'),
+            ],
+            'failure' => [
+                new Route('/foo', 'bar'),
+                RouteResult::fromRouteFailure(),
+            ],
+        ];
+    }
+
+    /**
+     * @group match
+     */
+    public function testSuccessfulMatchIsPossible()
+    {
+        $routeMatch = $this->prophesize('Zend\Mvc\Router\RouteMatch');
+        $routeMatch->getMatchedRouteName()->willReturn('/foo');
+        $routeMatch->getParams()->willReturn([
+            'middleware' => 'bar',
+        ]);
+
+        $this->zf2Router
+            ->match(Argument::type('Zend\Http\PhpEnvironment\Request'))
+            ->willReturn($routeMatch->reveal());
+
+        $request = $this->createRequestProphecy();
+
+        $router = $this->getRouter();
+        $result = $router->match($request->reveal());
+        $this->assertInstanceOf('Zend\Expressive\Router\RouteResult', $result);
+        $this->assertTrue($result->isSuccess());
+        $this->assertEquals('/foo', $result->getMatchedRouteName());
+        $this->assertEquals('bar', $result->getMatchedMiddleware());
+    }
+
+    /**
+     * @group match
+     */
+    public function testNonSuccessfulMatchNotDueToHttpMethodsIsPossible()
+    {
+        $this->zf2Router
+            ->match(Argument::type('Zend\Http\PhpEnvironment\Request'))
+            ->willReturn(null);
+
+        $request = $this->createRequestProphecy();
+
+        $router = $this->getRouter();
+        $result = $router->match($request->reveal());
+        $this->assertInstanceOf('Zend\Expressive\Router\RouteResult', $result);
+        $this->assertTrue($result->isFailure());
+        $this->assertFalse($result->isMethodFailure());
+    }
+
+    /**
+     * @group match
+     */
+    public function testMatchFailureDueToHttpMethodReturnsRouteResultWithAllowedMethods()
+    {
+        $routeMatch = $this->prophesize('Zend\Mvc\Router\RouteMatch');
+        $routeMatch->getMatchedRouteName()->willReturn('/foo');
+        $routeMatch->getParams()->willReturn([
+            'middleware' => 'bar',
+        ]);
+
+        $this->zf2Router->addRoute('/foo', [
+            'type' => 'segment',
+            'options' => [
+                'route' => '/foo',
+                'defaults' => [
+                    'middleware' => 'bar',
+                ],
+            ],
+        ])->shouldBeCalled();
+        $this->zf2Router
+            ->match(Argument::type('Zend\Http\PhpEnvironment\Request'))
+            ->willReturn($routeMatch->reveal());
+
+
+        $router = $this->getRouter();
+        $router->addRoute(new Route('/foo', 'bar', ['POST', 'DELETE']));
+
+        $request = $this->createRequestProphecy();
+        $result = $router->match($request->reveal());
+
+        $this->assertInstanceOf('Zend\Expressive\Router\RouteResult', $result);
+        $this->assertTrue($result->isFailure());
+        $this->assertTrue($result->isMethodFailure());
+        $this->assertEquals(['POST', 'DELETE'], $result->getAllowedMethods());
+    }
+}


### PR DESCRIPTION
This patch implements a router that consumes `Zend\Mvc\Router\Http\TreeRouteStack` to provide routing capabilities. HTTP method negotiation is kept internal to the zend-expressive implementation, as the ZF2 router does not differentiate between failure to match the path versus the HTTP method.

Matching marshals a zend-http request using [zend-psr7bridge](https://github.com/zendframework/zend-psr7bridge).