### PR TITLE
Windows friendly built-in server command

### DIFF
--- a/doc/book/usage-examples.md
+++ b/doc/book/usage-examples.md
@@ -28,7 +28,7 @@ We assume also that:
 > You can use the built-in web server to run the examples. Run:
 >
 > ```bash
-> $ php -S 0:8080 -t public/
+> $ php -S 0.0.0.0:8080 -t public
 > ```
 >
 > from the application root to start up a web server running on port 8080, and


### PR DESCRIPTION
Using the command from the docs to start the build-in webserver gave me two errors on windows:

first error:
```
$ php -S 0:8080 -t public/
Directory public/ does not exist.
```

second error:
```
$ php -S 0:8080 -t public
<br />
<b>Warning</b>:  Unknown: php_network_getaddresses: getaddrinfo failed: 
Failed to listen on 0:8080 (reason: php_network_getaddresses: getaddrinfo failed: ... )
```

This PR fixes the docs so that windows users can enjoy zend-expressive from the first moment on too ;).