### PR TITLE
Fix illegal type given when any method is allowed

### DIFF
--- a/src/Container/ApplicationFactory.php
+++ b/src/Container/ApplicationFactory.php
@@ -162,7 +162,7 @@ class ApplicationFactory
 
             $methods = (isset($spec['allowed_methods']) && is_array($spec['allowed_methods']))
                 ? $spec['allowed_methods']
-                : Route::HTTP_METHOD_ANY;
+                : null;
             $route = $app->route($spec['path'], $spec['middleware'], $methods);
 
             if (isset($spec['options']) && is_array($spec['options'])) {

--- a/test/Container/ApplicationFactoryTest.php
+++ b/test/Container/ApplicationFactoryTest.php
@@ -13,6 +13,7 @@ use PHPUnit_Framework_TestCase as TestCase;
 use ReflectionProperty;
 use Zend\Expressive\Application;
 use Zend\Expressive\Container\ApplicationFactory;
+use Zend\Expressive\Router\Route;
 
 class ApplicationFactoryTest extends TestCase
 {
@@ -37,8 +38,14 @@ class ApplicationFactoryTest extends TestCase
                 return false;
             }
 
-            if ($route->getAllowedMethods() !== $spec['allowed_methods']) {
-                return false;
+            if (isset($spec['allowed_methods'])) {
+                if ($route->getAllowedMethods() !== $spec['allowed_methods']) {
+                    return false;
+                }
+            } else {
+                if ($route->getAllowedMethods() !== Route::HTTP_METHOD_ANY) {
+                    return false;
+                }
             }
 
             return true;
@@ -115,6 +122,10 @@ class ApplicationFactoryTest extends TestCase
                     'path' => '/ping',
                     'middleware' => 'Ping',
                     'allowed_methods' => [ 'GET' ],
+                ],
+                [
+                    'path' => '/resource',
+                    'middleware' => 'Resource',
                 ],
             ],
         ];


### PR DESCRIPTION
Tried to add a route to the config similar to the one added in the ApplicationFactoryTest.
Running the modified test without the fix will give you the error:

```
There was 1 error:

1) ZendTest\Expressive\Container\ApplicationFactoryTest::testFactorySetsUpRoutesFromConfig
Argument 3 passed to Zend\Expressive\Application::route() must be of the type array, integer given
```

Not sure if my fix is the best solution. The other way would be to let the `route` method except the value of `Router\Route::HTTP_METHOD_ANY` instead of `null`. However, this was the easier fix :smile:.