### PR TITLE
Document middleware_pipeline accurately

### DIFF
--- a/doc/book/usage-examples.md
+++ b/doc/book/usage-examples.md
@@ -471,14 +471,10 @@ return [
     ],
     'middleware_pipeline' => [
         'pre_routing' => [
-            'middleware services',
-            'to register BEFORE',
-            'routing',
+            // See specification below
         ],
         'post_routing' => [
-            'middleware services',
-            'to register AFTER',
-            'routing',
+            // See specification below
         ],
     ],
 ];
@@ -492,8 +488,24 @@ routes, and thus before the routing middleware, while those specified
 `post_routing` will be `pipe()`'d afterwards (again, also in the order
 specified).
 
+Each middleware specified in either `pre_routing` or `post_routing` must be in
+the following form:
+
+```php
+[
+    // required:
+    'middleware' => 'Name of middleware service, or a callable',
+    // optional:
+    'path' => '/path/to/match',
+]
+```
+
 Middleware may be any callable, `Zend\Stratigility\MiddlewareInterface`
 implementation, or a service name that resolves to one of the two.
+
+The path, if specified, can only be a literal path to match, and is typically
+used for segregating middleware applications or applying rules to subsets of an
+application that match a common path root.
 
 > #### Lazy-loaded Middleware
 >

--- a/src/Container/ApplicationFactory.php
+++ b/src/Container/ApplicationFactory.php
@@ -84,6 +84,20 @@ use Zend\Expressive\Router\RouterInterface;
  * ];
  * </code>
  *
+ * Each item in either the `pre_routing` or `post_routing` array must be an
+ * array with the following specification:
+ *
+ * <code>
+ * [
+ *     // required:
+ *     'middleware' => 'Name of middleware service, or a callable',
+ *     // optional:
+ *     'path' => '/path/to/match',
+ * ]
+ * </code>
+ *
+ * Note that the `path` element can only be a literal.
+ *
  * Middleware are pipe()'d to the application instance in the order in which
  * they appear. "pre_routing" middleware will execute before the application's
  * routing middleware, while "post_routing" middleware will execute afterwards.


### PR DESCRIPTION
The documentation, both in the class as well as the formal documentation, was not correct with regards to the `middleware_pipeline` implementation. This patch updates it to properly indicate the structure.