### PR TITLE
Allow ApplicationFactory to handle routes for any method

### DIFF
--- a/src/Container/ApplicationFactory.php
+++ b/src/Container/ApplicationFactory.php
@@ -162,7 +162,7 @@ class ApplicationFactory
 
             $methods = (isset($spec['allowed_methods']) && is_array($spec['allowed_methods']))
                 ? $spec['allowed_methods']
-                : Route::HTTP_METHOD_ANY;
+                : null;
             $route = $app->route($spec['path'], $spec['middleware'], $methods);
 
             if (isset($spec['options']) && is_array($spec['options'])) {


### PR DESCRIPTION
`Application::route()` expects an array or null for its third argument, with null (or absence of the argument) mapping to `Route::HTTP_METHOD_ANY`.

`ApplicationFactory` was passing `Route::HTTP_METHOD_ANY` for the argument, which was raising a fatal error.