### PR TITLE
Invoke error middleware for 405 results

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -183,6 +183,11 @@ class Application extends MiddlewarePipe
      * Uses the router to route the incoming request, dispatching matched
      * middleware on a request success condition.
      *
+     * If routing fails, `$next()` is called; if routing fails due to HTTP
+     * method negotiation, the response is set to a 405, injected with an
+     * Allow header, and `$next()` is called with its `$error` argument set
+     * to the value `405` (invoking the next error middleware).
+     *
      * @param  ServerRequestInterface $request
      * @param  ResponseInterface $response
      * @param  callable $next
@@ -199,6 +204,7 @@ class Application extends MiddlewarePipe
             if ($result->isMethodFailure()) {
                 $response = $response->withStatus(405)
                     ->withHeader('Allow', implode(',', $result->getAllowedMethods()));
+                return $next($request, $response, 405);
             }
             return $next($request, $response);
         }

--- a/test/RouteMiddlewareTest.php
+++ b/test/RouteMiddlewareTest.php
@@ -31,7 +31,7 @@ class RouteMiddlewareTest extends TestCase
         );
     }
 
-    public function testRoutingFailureDueToHttpMethodCallsNextWithNotAllowedResponse()
+    public function testRoutingFailureDueToHttpMethodCallsNextWithNotAllowedResponseAndError()
     {
         $request  = new ServerRequest();
         $response = new Response();
@@ -39,7 +39,9 @@ class RouteMiddlewareTest extends TestCase
 
         $this->router->match($request)->willReturn($result);
 
-        $next = function ($request, $response) {
+        $next = function ($request, $response, $error = false) {
+            $this->assertEquals(405, $error);
+            $this->assertEquals(405, $response->getStatusCode());
             return $response;
         };
 
@@ -61,7 +63,8 @@ class RouteMiddlewareTest extends TestCase
         $this->router->match($request)->willReturn($result);
 
         $called = false;
-        $next = function ($req, $res) use (&$called, $request, $response) {
+        $next = function ($req, $res, $error = null) use (&$called, $request, $response) {
+            $this->assertNull($error);
             $this->assertSame($request, $req);
             $this->assertSame($response, $res);
             $called = true;


### PR DESCRIPTION
If a 405 occurs, invoke error middleware instead of the next middleware in the series.

(This is *not* done for general routing failure, as that is expected; the next standard middleware in the pipeline will be invoked in that situation, and, if no more middleware is present or none can handle the request, the final handler will report the 404.)