### PR TITLE
Added the Template interface + plates and twig adapters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "require": {
         "php": ">=5.5",
         "aura/router": "^2.3",
+        "league/plates": "^3.1",
         "container-interop/container-interop": "^1.1",
         "psr/http-message": "^1.0",
         "zendframework/zend-diactoros": "^1.1",
@@ -20,6 +21,7 @@
     },
     "require-dev": {
         "nikic/fast-route": "^0.6.0",
+        "twig/twig": "^1.19",
         "phpunit/phpunit": "^4.7",
         "squizlabs/php_codesniffer": "^2.3",
         "zendframework/zend-mvc": "^2.5",
@@ -38,6 +40,7 @@
     "suggest": {
         "nikic/fast-route": "^0.6.0 to use the FastRoute routing adapter",
         "zendframework/zend-mvc": "^2.5 to use the zend-mvc TreeRouteStack routing adapter",
-        "zendframework/zend-psr7bridge": "^0.1.0 to use the zend-mvc TreeRouteStack routing adapter"
+        "zendframework/zend-psr7bridge": "^0.1.0 to use the zend-mvc TreeRouteStack routing adapter",
+        "twig/twig": "^1.19 to use the Twig template adapter"
     }
 }

--- a/src/Template/Plates.php
+++ b/src/Template/Plates.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Template;
+
+use League\Plates\Engine;
+
+/**
+ * Template implementation bridging league/plates
+ */
+class Plates implements TemplateInterface
+{
+    /**
+     * @var Engine
+     */
+    protected $template;
+
+    public function __construct(Engine $template = null)
+    {
+        if (null === $template) {
+            $template = $this->createTemplate();
+        }
+        $this->template = $template;
+    }
+
+    /**
+     * Create a default Plates engine
+     *
+     * @params string $path
+     * @return Engine
+     */
+    private function createTemplate()
+    {
+        return new Engine();
+    }
+
+    /**
+     * Render
+     *
+     * @param string $name
+     * @param array $params
+     * @return string
+     */
+    public function render($name, array $params)
+    {
+        return $this->template->render($name, $params);
+    }
+
+    /**
+     * Set the template directory
+     *
+     * @param string $path
+     */
+    public function setPath($path)
+    {
+        $this->template->setDirectory($path);
+    }
+
+    /**
+     * Get the template directory
+     *
+     * @return string
+     */
+    public function getPath()
+    {
+        return $this->template->getDirectory();
+    }
+}

--- a/src/Template/Plates.php
+++ b/src/Template/Plates.php
@@ -53,22 +53,34 @@ class Plates implements TemplateInterface
     }
 
     /**
-     * Set the template directory
+     * Add a path for template
      *
      * @param string $path
+     * @param string $namespace
      */
-    public function setPath($path)
+    public function addPath($path, $namespace = null)
     {
-        $this->template->setDirectory($path);
+        if (!$namespace && !$this->template->getDirectory()) {
+            $this->template->setDirectory($path);
+            return;
+        }
+        $this->template->addFolder($namespace, $path, true);
     }
 
     /**
      * Get the template directory
      *
-     * @return string
+     * @return TemplatePath[]
      */
-    public function getPath()
+    public function getPaths()
     {
-        return $this->template->getDirectory();
+        $paths = [];
+        if ($this->template->getDirectory()) {
+            $paths[] = new TemplatePath($this->template->getDirectory());
+        }
+        foreach ($this->template->getFolders() as $folder) {
+            $paths[] = new TemplatePath($folder->getPath(), $folder->getName());
+        }
+        return $paths;
     }
 }

--- a/src/Template/TemplateInterface.php
+++ b/src/Template/TemplateInterface.php
@@ -23,11 +23,12 @@ interface TemplateInterface
 
     /**
      * @param string $path
+     * @param string $namespace
      */
-    public function setPath($path);
+    public function addPath($path, $namespace = null);
 
     /**
-     * @return string
+     * @return TemplatePath[]
      */
-    public function getPath();
+    public function getPaths();
 }

--- a/src/Template/TemplateInterface.php
+++ b/src/Template/TemplateInterface.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Template;
+
+/**
+ * Interface defining required template capabilities.
+ */
+interface TemplateInterface
+{
+    /**
+     * @param string $name
+     * @param array $params
+     * @return string
+     */
+    public function render($name, array $params);
+
+    /**
+     * @param string $path
+     */
+    public function setPath($path);
+
+    /**
+     * @return string
+     */
+    public function getPath();
+}

--- a/src/Template/TemplatePath.php
+++ b/src/Template/TemplatePath.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Template;
+
+class TemplatePath
+{
+    /**
+     * @var string
+     */
+    protected $path;
+
+    /**
+     * @var string
+     */
+    protected $namespace;
+
+    /**
+     * Constructor
+     *
+     * @param string $path
+     * @param string $namespace
+     */
+    public function __construct($path, $namespace = null)
+    {
+        $this->path      = $path;
+        $this->namespace = $namespace;
+    }
+
+    /**
+     * __toString
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->path;
+    }
+
+    /**
+     * Get the namespace
+     *
+     * @return string
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Get the path
+     *
+     * @return string
+     */
+    public function getPath()
+    {
+        return $this->path;
+    }
+}

--- a/src/Template/Twig.php
+++ b/src/Template/Twig.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Template;
+
+use Twig_Loader_Filesystem as TwigFilesystem;
+use Twig_Environment as TwigEnvironment;
+
+/**
+ * Template implementation bridging league/plates
+ */
+class Twig implements TemplateInterface
+{
+    /**
+     * @var TwigFilesystem
+     */
+    protected $twigLoader;
+
+    /**
+     * @var TwigEnvironment
+     */
+    protected $template;
+
+    public function __construct(TwigEnvironment $template = null)
+    {
+        if (null === $template) {
+            $template = $this->createTemplate();
+        } else {
+            if (!$template->getLoader()) {
+                $this->twigLoader = new TwigFilesystem();
+                $template->setLoader($this->twigLoader);
+            } else {
+                $this->twigLoader = $template->getLoader();
+            }
+        }
+        $this->template = $template;
+    }
+
+    /**
+     * Create a default Twig environment
+     *
+     * @params string $path
+     * @return TwigEnvironment
+     */
+    private function createTemplate()
+    {
+        $this->twigLoader = new TwigFilesystem();
+        return new TwigEnvironment($this->twigLoader);
+    }
+
+    /**
+     * Render
+     *
+     * @param string $name
+     * @param array $params
+     * @return string
+     */
+    public function render($name, array $params)
+    {
+        return $this->template->render($name, $params);
+    }
+
+    /**
+     * Set the template directory
+     *
+     * @param string $path
+     */
+    public function setPath($path)
+    {
+        $this->twigLoader->setPaths($path);
+    }
+
+    /**
+     * Get the template directory
+     *
+     * @return string
+     */
+    public function getPath()
+    {
+        $path = $this->twigLoader->getPaths();
+        if (empty($path)) {
+            return null;
+        }
+        return is_array($path) ? $path[0] : $path;
+    }
+}

--- a/test/Template/PlatesTest.php
+++ b/test/Template/PlatesTest.php
@@ -12,40 +12,46 @@ namespace ZendTest\Expressive\Template;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Expressive\Template\Plates as PlatesTemplate;
 use League\Plates\Engine;
+use Zend\Expressive\Template\TemplatePath;
 
 class PlatesTest extends TestCase
 {
     public function setUp()
     {
-        $this->platesEngine = $this->prophesize('League\Plates\Engine');
+        $this->platesEngine = new Engine();
     }
 
     public function testConstructorWithEngine()
     {
-        $template = new PlatesTemplate($this->platesEngine->reveal());
+        $template = new PlatesTemplate($this->platesEngine);
         $this->assertTrue($template instanceof PlatesTemplate);
-        $this->assertEmpty($template->getPath());
+        $this->assertEmpty($template->getPaths());
     }
 
     public function testConstructorWithoutEngine()
     {
         $template = new PlatesTemplate();
         $this->assertTrue($template instanceof PlatesTemplate);
-        $this->assertEmpty($template->getPath());
+        $this->assertEmpty($template->getPaths());
     }
 
     public function testSetPath()
     {
         $template = new PlatesTemplate();
-        $template->setPath(__DIR__ . '/TestAsset');
-        $this->assertTrue($template instanceof PlatesTemplate);
-        $this->assertEquals(__DIR__ . '/TestAsset', $template->getPath());
+        $template->addPath(__DIR__ . '/TestAsset');
+        $paths = $template->getPaths();
+        $this->assertTrue(is_array($paths));
+        $this->assertEquals(1, count($paths));
+        $this->assertTrue($paths[0] instanceof TemplatePath);
+        $this->assertEquals($paths[0]->getPath(), __DIR__ . '/TestAsset');
+        $this->assertEquals((string) $paths[0], __DIR__ . '/TestAsset');
+        $this->assertEmpty($paths[0]->getNamespace());
     }
 
     public function testRender()
     {
         $template = new PlatesTemplate();
-        $template->setPath(__DIR__ . '/TestAsset');
+        $template->addPath(__DIR__ . '/TestAsset');
         $name = 'Plates';
         $result = $template->render('plates', [ 'name' => $name ]);
         $this->assertContains($name, $result);

--- a/test/Template/PlatesTest.php
+++ b/test/Template/PlatesTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive\Template;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Expressive\Template\Plates as PlatesTemplate;
+use League\Plates\Engine;
+
+class PlatesTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->platesEngine = $this->prophesize('League\Plates\Engine');
+    }
+
+    public function testConstructorWithEngine()
+    {
+        $template = new PlatesTemplate($this->platesEngine->reveal());
+        $this->assertTrue($template instanceof PlatesTemplate);
+        $this->assertEmpty($template->getPath());
+    }
+
+    public function testConstructorWithoutEngine()
+    {
+        $template = new PlatesTemplate();
+        $this->assertTrue($template instanceof PlatesTemplate);
+        $this->assertEmpty($template->getPath());
+    }
+
+    public function testSetPath()
+    {
+        $template = new PlatesTemplate();
+        $template->setPath(__DIR__ . '/TestAsset');
+        $this->assertTrue($template instanceof PlatesTemplate);
+        $this->assertEquals(__DIR__ . '/TestAsset', $template->getPath());
+    }
+
+    public function testRender()
+    {
+        $template = new PlatesTemplate();
+        $template->setPath(__DIR__ . '/TestAsset');
+        $name = 'Plates';
+        $result = $template->render('plates', [ 'name' => $name ]);
+        $this->assertContains($name, $result);
+        $content = file_get_contents(__DIR__ . '/TestAsset/plates.php');
+        $content = str_replace('<?=$this->e($name)?>', $name, $content);
+        $this->assertEquals($content, $result);
+    }
+}

--- a/test/Template/TemplatePathTest.php
+++ b/test/Template/TemplatePathTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive\Template;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Expressive\Template\TemplatePath;
+
+class TemplatePathTest extends TestCase
+{
+    public function testConstructWithNamespace()
+    {
+        $templatePath = new TemplatePath('/tmp', 'test');
+        $this->assertTrue($templatePath instanceof TemplatePath);
+        $this->assertEquals('/tmp', $templatePath->getPath());
+        $this->assertEquals('test', $templatePath->getNamespace());
+    }
+
+    public function testConstructWithoutNamespace()
+    {
+        $templatePath = new TemplatePath('/tmp');
+        $this->assertTrue($templatePath instanceof TemplatePath);
+        $this->assertEquals('/tmp', $templatePath->getPath());
+        $this->assertEmpty($templatePath->getNamespace());
+    }
+
+    public function testToString()
+    {
+        $templatePath = new TemplatePath('/tmp');
+        $this->assertEquals('/tmp', (string) $templatePath);
+
+        $templatePath = new TemplatePath('/tmp', 'test');
+        $this->assertEquals('/tmp', (string) $templatePath);
+    }
+}

--- a/test/Template/TestAsset/plates.php
+++ b/test/Template/TestAsset/plates.php
@@ -1,0 +1,3 @@
+<h1>This is a template file for Plates</h1>
+
+<p>You are using <strong><?=$this->e($name)?></strong>!</p>

--- a/test/Template/TestAsset/twig.html
+++ b/test/Template/TestAsset/twig.html
@@ -1,0 +1,3 @@
+<h1>This is a template file for Twig</h1>
+
+<p>You are using <strong>{{ name }}</strong>!</p>

--- a/test/Template/TwigTest.php
+++ b/test/Template/TwigTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive\Template;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Expressive\Template\Twig as TwigTemplate;
+use Twig_Loader_Filesystem;
+use Twig_Environment;
+
+class TwigTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->twigFilesystem  = $this->prophesize('Twig_Loader_Filesystem');
+        $this->twigEnvironment = $this->prophesize('Twig_Environment');
+    }
+
+    public function testConstructorWithEngine()
+    {
+        $template = new TwigTemplate($this->twigEnvironment->reveal());
+        $this->assertTrue($template instanceof TwigTemplate);
+        $this->assertEmpty($template->getPath());
+    }
+
+    public function testConstructorWithoutEngine()
+    {
+        $template = new TwigTemplate();
+        $this->assertTrue($template instanceof TwigTemplate);
+        $this->assertEmpty($template->getPath());
+    }
+
+    public function testSetPath()
+    {
+        $template = new TwigTemplate();
+        $template->setPath(__DIR__ . '/TestAsset');
+        $this->assertTrue($template instanceof TwigTemplate);
+        $this->assertEquals(__DIR__ . '/TestAsset', $template->getPath());
+    }
+
+    public function testRender()
+    {
+        $template = new TwigTemplate();
+        $template->setPath(__DIR__ . '/TestAsset');
+        $name = 'Twig';
+        $result = $template->render('twig.html', [ 'name' => $name ]);
+        $this->assertContains($name, $result);
+        $content = file_get_contents(__DIR__ . '/TestAsset/twig.html');
+        $content = str_replace('{{ name }}', $name, $content);
+        $this->assertEquals($content, $result);
+    }
+}


### PR DESCRIPTION
This PR adds a Template interface and the adapters for [Plates](https://github.com/thephpleague/plates) and [Twig](https://github.com/twigphp/Twig) templating systems.

**Note:** we should think how to offer a template into a middleware callback. One solution can be to use a Factory class for middleware invokable components, like the one reported [here](https://github.com/ezimuel/zend-stratigility-skeleton/blob/master/app/src/Action/HomepageFactory.php).