### PR TITLE
Less restrictive `$params` for `TemplateInterface`

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -18,4 +18,5 @@
     <!-- Paths to check -->
     <file>src</file>
     <file>test</file>
+    <exclude-pattern>*/test/Template/TestAsset/plates-null.php</exclude-pattern>
 </ruleset>

--- a/src/Template/ArrayParametersTrait.php
+++ b/src/Template/ArrayParametersTrait.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Template;
+
+use Traversable;
+use Zend\Expressive\Exception;
+
+trait ArrayParametersTrait
+{
+    /**
+     * Cast params to an array, if possible.
+     *
+     * @param mixed $params
+     * @return array
+     * @throws Exception\InvalidArgumentException for non-array, non-object parameters.
+     */
+    private function normalizeParams($params)
+    {
+        if (null === $params) {
+            return [];
+        }
+
+        if (is_array($params)) {
+            return $params;
+        }
+
+        if ($params instanceof Traversable) {
+            return iterator_to_array($params);
+        }
+
+        if (is_object($params)) {
+            return (array) $params;
+        }
+
+        throw new Exception\InvalidArgumentException(sprintf(
+            'Twig template adapter can only handle arrays, Traversables, and objects '
+            . 'when rendering; received %s',
+            gettype($params)
+        ));
+    }
+}

--- a/src/Template/Plates.php
+++ b/src/Template/Plates.php
@@ -17,6 +17,8 @@ use ReflectionProperty;
  */
 class Plates implements TemplateInterface
 {
+    use ArrayParametersTrait;
+
     /**
      * @var Engine
      */
@@ -34,11 +36,12 @@ class Plates implements TemplateInterface
      * Render
      *
      * @param string $name
-     * @param array $params
+     * @param array|object $params
      * @return string
      */
-    public function render($name, array $params)
+    public function render($name, $params = [])
     {
+        $params = $this->normalizeParams($params);
         return $this->template->render($name, $params);
     }
 

--- a/src/Template/TemplateInterface.php
+++ b/src/Template/TemplateInterface.php
@@ -16,10 +16,10 @@ interface TemplateInterface
 {
     /**
      * @param string $name
-     * @param array $params
+     * @param array|object $params
      * @return string
      */
-    public function render($name, array $params);
+    public function render($name, $params = []);
 
     /**
      * @param string $path

--- a/src/Template/Twig.php
+++ b/src/Template/Twig.php
@@ -17,6 +17,8 @@ use Twig_Environment as TwigEnvironment;
  */
 class Twig implements TemplateInterface
 {
+    use ArrayParametersTrait;
+
     /**
      * @var TwigFilesystem
      */
@@ -68,11 +70,13 @@ class Twig implements TemplateInterface
      * Render
      *
      * @param string $name
-     * @param array $params
+     * @param array|object $params
      * @return string
+     * @throws \Zend\Expressive\Exception\InvalidArgumentException for non-array, non-object parameters.
      */
-    public function render($name, array $params)
+    public function render($name, $params = [])
     {
+        $params = $this->normalizeParams($params);
         return $this->template->render($name, $params);
     }
 

--- a/test/Template/TestAsset/plates-null.php
+++ b/test/Template/TestAsset/plates-null.php
@@ -1,0 +1,1 @@
+<h1>This is a template file for Plates</h1>

--- a/test/Template/TestAsset/twig-null.html
+++ b/test/Template/TestAsset/twig-null.html
@@ -1,0 +1,1 @@
+<h1>This is a template file for Twig</h1>


### PR DESCRIPTION
I'm working on a [phly-mustache](https://github.com/phly/phly_mustache) template renderer, and discovered one area that becomes more difficult, and one that will also come up for zend-view: by typehinting `$params` on `array`, we do not allow for view models of any sort.

This parameter should drop the typehint, while still retaining the default empty array value.

Additionally, we should allow for passing _no_ parameters; the value is currently required.