### PR TITLE
remove ! $template->getLoader() check in Twig::__construct

### DIFF
--- a/src/Template/Twig.php
+++ b/src/Template/Twig.php
@@ -39,9 +39,6 @@ class Twig implements TemplateInterface
         if (null === $template) {
             $template = $this->createTemplate($this->getDefaultLoader());
         }
-        if (! $template->getLoader()) {
-            $template->setLoader($this->getDefaultLoader());
-        }
         $this->template   = $template;
         $this->twigLoader = $template->getLoader();
     }

--- a/test/Template/TwigTest.php
+++ b/test/Template/TwigTest.php
@@ -27,6 +27,13 @@ class TwigTest extends TestCase
         $this->twigEnvironment = new Twig_Environment($this->twigFilesystem);
     }
 
+    public function testIfNoneProvidedInTwigEnvironmentWillRaiseLogicExceptionOnCallGetLoader()
+    {
+        $twigEnvironment = new Twig_Environment();
+        $this->setExpectedException('LogicException');
+        $template = new TwigTemplate($twigEnvironment);
+    }
+
     public function testCanPassEngineToConstructor()
     {
         $template = new TwigTemplate($this->twigEnvironment);


### PR DESCRIPTION
as `getLoader()` on `TwigEnvironment` will call `\LogicException` when loader not defined