### PR TITLE
Add error handling via Whoops

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "psr/http-message": "^1.0",
         "zendframework/zend-diactoros": "^1.1",
         "zendframework/zend-servicemanager": "^2.6",
-        "zendframework/zend-stratigility": "^1.1"
+        "zendframework/zend-stratigility": "^1.1",
+        "filp/whoops": "^1.1"
     },
     "require-dev": {
         "league/plates": "^3.1",

--- a/src/Container/ErrorHandlerFactory.php
+++ b/src/Container/ErrorHandlerFactory.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Container;
+
+use Interop\Container\ContainerInterface;
+use Zend\Expressive\ErrorHandler;
+
+/**
+ * Create and return an instance of the error handler.
+ *
+ * Register this factory as the service `Zend\Expressive\FinalHandler` in
+ * the container of your choice.
+ *
+ * This factory has optional dependencies on the following services:
+ *
+ * - Zend\Expressive\Template\TemplateInterface, which should return an
+ *   implementation of that interface. If not present, the error handler
+ *   will not create templated responses.
+ * - Config (which should return an array or array-like object with a
+ *   "zend-expressive" top-level key, and an "error_handler" subkey,
+ *   containing the configuration for the error handler).
+ *
+ * This factory has required dependencies on the following services:
+ *
+ * - Zend\Expressive\Whoops, which should return a Whoops\Run instance.
+ * - Zend\Expressive\WhoopsPageHandler, which should return a
+ *   Whoops\Handler\PrettyPageHandler instance.
+ *
+ * Configuration should look like the following:
+ *
+ * <code>
+ * 'zend-expressive' => [
+ *     'error_handler' => [
+ *         'template_404'   => 'name of 404 template',
+ *         'template_error' => 'name of error template',
+ *     ],
+ * ]
+ * </code>
+ *
+ * If any of the keys are missing, default values will be used.
+ */
+class ErrorHandlerFactory
+{
+    public function __invoke(ContainerInterface $container)
+    {
+        $template = $container->has('Zend\Expressive\Template\TemplateInterface')
+            ? $container->get('Zend\Expressive\Template\TemplateInterface')
+            : null;
+
+        $config = $container->has('Config')
+            ? $container->get('Config')
+            : [];
+
+        $config = isset($config['zend-expressive']['error_handler'])
+            ? $config['zend-expressive']['error_handler']
+            : [];
+
+        return new ErrorHandler(
+            $container->get('Zend\Expressive\Whoops'),
+            $container->get('Zend\Expressive\WhoopsPageHandler'),
+            $template,
+            (isset($config['template_404']) ? $config['template_404'] : 'error/404'),
+            (isset($config['template_error']) ? $config['template_error'] : 'error/error')
+        );
+    }
+}

--- a/src/Container/Exception/ExceptionInterface.php
+++ b/src/Container/Exception/ExceptionInterface.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       http://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Container\Exception;
+
+/**
+ * Marker interface for container exceptions.
+ */
+interface ExceptionInterface
+{
+}

--- a/src/Container/Exception/InvalidServiceException.php
+++ b/src/Container/Exception/InvalidServiceException.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       http://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Container\Exception;
+
+use Interop\Container\Exception\ContainerException;
+use RuntimeException;
+
+/**
+ * Exception indicating a service type is invalid or un-fetchable.
+ */
+class InvalidServiceException extends RuntimeException implements
+    ContainerException,
+    ExceptionInterface
+{
+}

--- a/src/Container/Exception/NotFoundException.php
+++ b/src/Container/Exception/NotFoundException.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       http://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Container\Exception;
+
+use Interop\Container\Exception\NotFoundException as InteropNotFoundException;
+use RuntimeException;
+
+/**
+ * Exception indicating a service was not found in the container.
+ */
+class NotFoundException extends RuntimeException implements
+    ExceptionInterface,
+    InteropNotFoundException
+{
+}

--- a/src/Container/WhoopsFactory.php
+++ b/src/Container/WhoopsFactory.php
@@ -53,6 +53,7 @@ class WhoopsFactory
         $config = isset($config['whoops']) ? $config['whoops'] : [];
 
         $whoops = new Whoops();
+        $whoops->writeToOutput(false);
         $whoops->allowQuit(false);
         $whoops->pushHandler($container->get('Zend\Expressive\WhoopsPageHandler'));
         $this->registerJsonHandler($whoops, $config);

--- a/src/Container/WhoopsFactory.php
+++ b/src/Container/WhoopsFactory.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Container;
+
+use Interop\Container\ContainerInterface;
+use Whoops\Handler\JsonResponseHandler;
+use Whoops\Run as Whoops;
+
+/**
+ * Create and return an instance of the Whoops runner.
+ *
+ * Register this factory as the service `Zend\Expressive\Whoops` in the
+ * container of your choice. This service depends on two others:
+ *
+ * - Config (which should return an array or array-like object with a "whoops"
+ *   key, containing the configuration for whoops).
+ * - Zend\Expressive\WhoopsPageHandler, which should return a
+ *   Whoops\Handler\PrettyPageHandler instance to register on the whoops
+ *   instance.
+ *
+ * The whoops configuration can contain:
+ *
+ * <code>
+ * 'whoops' => [
+ *     'json_exceptions' => [
+ *         'display'    => true,
+ *         'show_trace' => true,
+ *         'ajax_only'  => true,
+ *     ]
+ * ]
+ * </code>
+ *
+ * All values are booleans; ommision of any implies boolean false.
+ */
+class WhoopsFactory
+{
+    /**
+     * Create and return an instance of the Whoops runner.
+     *
+     * @param ContainerInterface $container
+     * @return Whoops
+     */
+    public function __invoke(ContainerInterface $container)
+    {
+        $config = $container->has('Config') ? $container->get('Config') : [];
+        $config = isset($config['whoops']) ? $config['whoops'] : [];
+
+        $whoops = new Whoops();
+        $whoops->allowQuit(false);
+        $whoops->pushHandler($container->get('Zend\Expressive\WhoopsPageHandler'));
+        $this->registerJsonHandler($whoops, $config);
+        $whoops->register();
+        return $whoops;
+    }
+
+    /**
+     * If configuration indicates a JsonResponseHandler, configure and register it.
+     *
+     * @param Whoops $whoops
+     * @param array|\ArrayAccess $config
+     */
+    private function registerJsonHandler(Whoops $whoops, $config)
+    {
+        if (! isset($config['json_exceptions']['display'])
+            || empty($config['json_exceptions']['display'])
+        ) {
+            return;
+        }
+
+        $handler = new JsonResponseHandler();
+
+        if (isset($config['json_exceptions']['show_trace'])) {
+            $handler->addTraceToOutput(true);
+        }
+
+        if (isset($config['json_exceptions']['ajax_only'])) {
+            $handler->onlyForAjaxRequests(true);
+        }
+
+        $whoops->pushHandler($handler);
+    }
+}

--- a/src/Container/WhoopsPageHandlerFactory.php
+++ b/src/Container/WhoopsPageHandlerFactory.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Container;
+
+use Interop\Container\ContainerInterface;
+use Whoops\Handler\PrettyPageHandler;
+
+/**
+ * Create and return an instance of the whoops PrettyPageHandler.
+ *
+ * Register this factory as the service `Zend\Expressive\WhoopsPageHandler` in
+ * the container of your choice.
+ */
+class WhoopsPageHandlerFactory
+{
+    /**
+     * @param ContainerInterface $container
+     * @returns PrettyPageHandler
+     */
+    public function __invoke(ContainerInterface $container)
+    {
+        error_log(sprintf("In %s", __CLASS__));
+        return new PrettyPageHandler();
+    }
+}

--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -236,7 +236,6 @@ class ErrorHandler
 
         $this->prepareWhoopsHandler($request);
 
-        ob_clean();
         $content = $this->whoops->handleException($error);
         $response->getBody()->write($content);
         return $response;

--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -255,7 +255,7 @@ class ErrorHandler
         $uri = $request->getUri();
         $this->whoopsHandler->addDataTable('Expressive Application Request', [
             'HTTP Method'            => $request->getMethod(),
-            'URI'                    => $uri,
+            'URI'                    => (string) $uri,
             'Script'                 => $request->getServerParams()['SCRIPT_NAME'],
             'Headers'                => $request->getHeaders(),
             'Cookies'                => $request->getCookieParams(),

--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -1,0 +1,268 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       http://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive;
+
+use Psr\Http\Message\RequestInterface as Request;
+use Psr\Http\Message\ResponseInterface as Response;
+use Whoops\Handler\PrettyPageHandler;
+use Whoops\Run as Whoops;
+use Zend\Stratigility\Http\Request as StratigilityRequest;
+use Zend\Stratigility\Utils;
+
+class ErrorHandler
+{
+    /**
+     * Body size on the original response; used to compare against received
+     * response in order to determine if changes have been made.
+     *
+     * @var int
+     */
+    private $bodySize;
+
+    /**
+     * Original response against which to compare when determining if the
+     * received response is a different instance, and thus should be directly
+     * returned.
+     *
+     * @var Response
+     */
+    private $originalResponse;
+
+    /**
+     * Template renderer to use when rendering error pages; if not provided,
+     * only the status will be updated.
+     *
+     * @var Template\TemplateInterface
+     */
+    private $template;
+
+    /**
+     * Name of 404 template to use when creating 404 response content with the
+     * template renderer.
+     *
+     * @var string
+     */
+    private $template404;
+
+    /**
+     * Name of error template to use when creating response content for pages
+     * with errors.
+     *
+     * @var string
+     */
+    private $templateError;
+
+    /**
+     * Whoops runner instance to use when returning exception details.
+     *
+     * @var Whoops
+     */
+    private $whoops;
+
+    /**
+     * Whoops PrettyPageHandler; injected to allow runtime configuration with
+     * request information.
+     *
+     * @var PrettyPageHandler
+     */
+    private $whoopsHandler;
+
+    /**
+     * @param Whoops $whoops
+     * @param null|Template\TemplateInterface $template
+     * @param null|string $template404
+     * @param null|string $templateError
+     * @param null|Response $originalResponse
+     */
+    public function __construct(
+        Whoops $whoops,
+        PrettyPageHandler $whoopsHandler,
+        Template\TemplateInterface $template = null,
+        $template404 = 'error/404',
+        $templateError = 'error/error',
+        Response $originalResponse = null
+    ) {
+        $this->whoops        = $whoops;
+        $this->whoopsHandler = $whoopsHandler;
+        $this->template      = $template;
+        $this->template404   = $template404;
+        $this->templateError = $templateError;
+        if ($originalResponse) {
+            $this->setOriginalResponse($originalResponse);
+        }
+    }
+
+    /**
+     * Set the original response for comparisons.
+     *
+     * @param Response $originalResponse
+     */
+    public function setOriginalResponse(Response $response)
+    {
+        $this->bodySize = $response->getBody()->getSize();
+        $this->originalResponse = $response;
+    }
+
+    /**
+     * Final handler for an application.
+     *
+     * @param Request $request
+     * @param Response $response
+     * @param null|mixed $err
+     * @return Response
+     */
+    public function __invoke(Request $request, Response $response, $err = null)
+    {
+        if (! $err) {
+            return $this->handlePotentialSuccess($request, $response);
+        }
+
+        return $this->handleError($err, $request, $response);
+    }
+
+    /**
+     * Handle a non-error condition.
+     *
+     * Non-error conditions mean either all middleware called $next(), and we
+     * have a complete response, or no middleware was able to handle the
+     * request.
+     *
+     * This method determines which occurred, returning the response in the
+     * first instance, and returning a 404 response in the second.
+     *
+     * @param Request $request
+     * @param Response $response
+     * @return Response
+     */
+    private function handlePotentialSuccess(Request $request, Response $response)
+    {
+        if (! $this->originalResponse) {
+            return $this->marshalReceivedResponse($request, $response);
+        }
+
+        if ($this->originalResponse !== $response) {
+            return $response;
+        }
+
+        if ($this->bodySize !== $response->getBody()->getSize()) {
+            return $response;
+        }
+
+        return $this->create404($request, $response);
+    }
+
+    /**
+     * Determine whether to return the given response, or a 404.
+     *
+     * If no original response was present, we check to see if we have a 200
+     * response with empty content; if so, we treat it as a 404.
+     *
+     * Otherwise, we return the response intact.
+     *
+     * @param Request $request
+     * @param Response $response
+     * @return Response
+     */
+    private function marshalReceivedResponse(Request $request, Response $response)
+    {
+        if ($response->getStatusCode() === 200
+            && $response->getBody()->getSize() === 0
+        ) {
+            return $this->create404($request, $response);
+        }
+
+        return $response;
+    }
+
+    /**
+     * Create a 404 response.
+     *
+     * If we have a template renderer composed, renders the 404 template into
+     * the response.
+     *
+     * @param Request $request
+     * @param Response $response
+     * @return Response
+     */
+    private function create404(Request $request, Response $response)
+    {
+        if ($this->template) {
+            $response->getBody()->write(
+                $this->template->render($this->template404, [ 'uri' => $request->getUri() ])
+            );
+        }
+        return $response->withStatus(404);
+    }
+
+    /**
+     * Handle an error.
+     *
+     * Marshals the response status from the error.
+     *
+     * If the error is not an exception, and we have a template renderer,
+     * renders the error template into the response.
+     *
+     * If the error is an exception, uses whoops to create the payload.
+     *
+     * @param mixed $error
+     * @param Request $request
+     * @param Response $response
+     * @return Response
+     */
+    private function handleError($error, Request $request, Response $response)
+    {
+        $response = $response->withStatus(Utils::getStatusCode($error, $response));
+
+        if (! $error instanceof \Exception) {
+            if ($this->template) {
+                $response->getBody()->write(
+                    $this->template->render($this->templateError, [
+                        'uri'    => $request->getUri(),
+                        'error'  => $error,
+                        'status' => $response->getStatusCode(),
+                        'reason' => $response->getReasonPhrase(),
+                    ])
+                );
+            }
+            return $response;
+        }
+
+        $this->prepareWhoopsHandler($request);
+
+        ob_clean();
+        $content = $this->whoops->handleException($error);
+        $response->getBody()->write($content);
+        return $response;
+    }
+
+    /**
+     * Prepare the Whoops page handler with a table displaying request information
+     *
+     * @param Request $request
+     */
+    private function prepareWhoopsHandler(Request $request)
+    {
+        if ($request instanceof StratigilityRequest) {
+            $request = $request->getOriginalRequest();
+        }
+
+        $uri = $request->getUri();
+        $this->whoopsHandler->addDataTable('Expressive Application Request', [
+            'HTTP Method'            => $request->getMethod(),
+            'URI'                    => $uri,
+            'Script'                 => $request->getServerParams()['SCRIPT_NAME'],
+            'Headers'                => $request->getHeaders(),
+            'Cookies'                => $request->getCookieParams(),
+            'Attributes'             => $request->getAttributes(),
+            'Query String Arguments' => $request->getQueryParams(),
+            'Body Params'            => $request->getParsedBody(),
+        ]);
+    }
+}


### PR DESCRIPTION
This patch does the following:

- Adds `filp/whoops` as a dependency.
- Creates a new `Zend\Expressive\ErrorHandler` class, which composes a whoops runtime, `PrettyPageHandler` instance, and optionally a template renderer.
  - When an exception is encountered, it invokes whoops to handle the exception.
  - For other errors or 404 scenarios, if a template is available, it uses the template to present an error page.
- Provides container factories for whoops, the whoops pretty page handler, and the error handler.

TODO
----

- [ ] Unit tests for the error handler
- [ ] Unit tests for each factory
- [ ] Documentation