### PR TITLE
Error Handling feature

### DIFF
--- a/doc/book/error-handling.md
+++ b/doc/book/error-handling.md
@@ -1,0 +1,345 @@
+# Error Handling
+
+zend-expressive provides error handling out of the box, via zend-stratigility's [FinalHandler
+implementation](https://github.com/zendframework/zend-stratigility/blob/master/doc/book/api.md#finalhandler).
+This pseudo-middleware is executed in the following conditions:
+
+- If the middleware stack is exhausted, and no middleware has returned a response.
+- If an error has been passed via `$next()`, but not handled by any error middleware.
+
+The `FinalHandler` essentially tries to recover gracefully. In the case that no error was passed, it
+does the following:
+
+- If the response passed to it differs from the response provided at initialization, it will return
+  the response directly; the assumption is that some middleware along the way called `$next()`
+  with a new response.
+- If the response instances are identical, it checks to see if the body size has changed; if it has,
+  the assumption is that a middleware at some point has written to the response body.
+- At this point, it assumes no middleware was able to handle the request, and creates a 404
+  response, indicating "Not Found."
+
+In the event that an error *was* passed, it does the following:
+
+- If `$error` is not an exception, it will use the response status if it already indicates an error
+  (ie., &gt;= 400 status), or will use a 500 status, and return the response directly with the
+  reason phrase.
+- If `$error` *is* an exception, it will use the exception status if it already indicates an error
+  (ie., &gt;= 400 status), or will use a 500 status, and return the response directly with the
+  reason phrase. If the `FinalHandler` was initialized with an option indicating that it is in
+  development mode, it writes the exception stack trace to the response body.
+
+This workflow stays the same throughout zend-expressive. But sometimes, it's just not enough.
+
+## Templated Errors
+
+You'll typically want to provide error messages in your site template. To do so, we provide
+`Zend\Expressive\TemplatedErrorHandler`. This class is similar to the `FinalHandler`, but accepts,
+optionally, a `Zend\Expressive\Template\TemplateInterface` instance, and template names to use for
+404 and general error conditions. This makes it a good choice for use in production.
+
+```php
+use Zend\Expressive\Application;
+use Zend\Expressive\Template\Plates;
+use Zend\Expressive\TemplatedErrorHandler;
+
+$plates = new Plates();
+$plates->addPath(__DIR__ . '/templates/error', 'error');
+$finalHandler = new TemplatedErrorHandler($plates, 'error::404', 'error::500');
+
+$app = new Application($router, $container, $finalHandler);
+```
+
+The above will use the templates `error::404` and `error::500` for 404 and general errors,
+respectively, rendering them using our Plates template adapter.
+
+You can also use the `TemplatedErrorHandler` as a substitute for the `FinalHandler`, without using
+templated capabilities, by omitting the `TemplateInterface` instance when instantiating it. In this
+case, the response message bodies will be empty, though the response status will reflect the error.
+
+### Whoops
+
+[whoops](http://filp.github.io/whoops/) is a library for providing a more usable UI around
+exceptions and PHP errors. We provide integration with this library through
+`Zend\Express\WhoopsErrorHandler`. This error handler derives from the `TemplatedErrorHandler`, and
+uses its features for 404 status and non-exception errors. For exceptions, however, it will return
+the whoops output. As such, it is a good choice for use in development.
+
+To use it, you will need to provide it a whoops runtime instance, as well as a
+`Whoops\Handler\PrettyPageHandler` instance. You can also optionally provide a `TemplateInterface`
+instance and template names, just as you would for a `TemplatedErrorHandler`.
+
+```php
+use Whoops\Handler\PrettyPageHandler;
+use Whoops\Run as Whoops;
+use Zend\Expressive\Application;
+use Zend\Expressive\Template\Plates;
+use Zend\Expressive\WhoopsErrorHandler;
+
+$handler = new PrettyPageHandler();
+
+$whoops = new Whoops;
+$whoops->writeToOutput(false);
+$whoops->allowQuit(false);
+$whoops->pushHandler($handler);
+$whoops->register();
+
+$plates = new Plates();
+$plates->addPath(__DIR__ . '/templates/error', 'error');
+$finalHandler = new WhoopsErrorHandler(
+    $whoops,
+    $handler,
+    $plates,
+    'error::404',
+    'error::500'
+);
+
+$app = new Application($router, $container, $finalHandler);
+```
+
+The calls to `writeToOutput(false)`, `allowQuite(false)`, and `register()` must be made to guarantee
+whoops will interoperate well with zend-expressive.
+
+You can add more handlers if desired.
+
+Internally, when an exception is discovered, zend-expressive adds some data to the whoops output,
+primarily around the request information (URI, HTTP request method, route match attributes, etc.).
+
+## Container Factories and Configuration
+
+The above may feel like a bit much when creating your application. As such, we provide several
+factories that work with [container-interop](https://github.com/container-interop/container-interop)-compatible
+container implementations to simplify setup.
+
+### WhoopsPageHandlerFactory
+
+> - Register this factory as `Zend\Expressive\WhoopsPageHandler`.
+> - This service optionally consumes the service `Config`
+
+`Zend\Expressive\Container\WhoopsPageHandlerFactory` will create and return a
+`Whoops\Handler\PrettyPageHandler` instance. If the `Config` service is also defined, and returns an
+array with the following structure:
+
+```php
+'whoops' => [
+    'editor' => 'editor name, editor service name, or callable',
+]
+```
+
+then the factory will also inject the handler with an editor (this will provide a clickable link in
+the output that will open the editor with the file).
+
+### WhoopsFactory
+
+> - Register this factory as `Zend\Expressive\Whoops`.
+> - This factory requires and consumes a service named `Zend\Expressive\WhoopsPageHandler`, and
+>   optionally the service `Config`.
+
+`Zend\Expressive\Container\WhoopsFactory` will create and return a `Whoops\Run` instance. It will
+inject the `Zend\Expressive\WhoopsPageHandler` as a handler. Additionally, it calls the following
+methods with the specified arguments:
+
+- `writeToOutput(false)`
+- `allowQuit(false)`
+- `register()`
+
+If the `Config` service is defined, and has the following structure:
+
+```php
+'whoops' => [
+    'json_exceptions' => [
+        'display'    => true, // required to enable the JsonResponseHandler
+        'show_trace' => true, // optional
+        'ajax_only'  => true, // optional
+    ]
+]
+```
+
+and the `display` flag is true, it will also inject a `Whoops\Handler\JsonResponseHandler`,
+configured per the settings provided.
+
+### WhoopsErrorHandlerFactory
+
+> - Register this factory as `Zend\Expressive\FinalHandler`.
+> - This factory requires and consumes the services `Zend\Expressive\Whoops` and
+>   `Zend\Expressive\WhoopsPageHandler`, and optionally the services
+>   `Zend\Expressive\Template\TemplateInterface` and `Config`.
+
+`Zend\Expressive\Container\WhoopsErrorHandlerFactory` creates and returns an instance of
+`Zend\Expressive\WhoopsErrorHandler`, injecting it with the services `Zend\Expressive\Whoops` and
+`Zend\Expressive\WhoopsPageHandler`.
+
+If the `Zend\Expressive\Template\TemplateInterface` service is available, that, too, will be
+injected.
+
+If the `Config` service is available, and contains the following structure:
+
+```php
+'zend-expressive' => [
+    'error_handler' => [
+        'template_404'   => 'name of 404 template',
+        'template_error' => 'name of error template',
+    ],
+]
+```
+
+then the factory will inject the values for the given templates.
+
+### TemplatedErrorHandlerFactory
+
+> - Register this factory as `Zend\Expressive\FinalHandler`.
+> - This factory optionally consumes the services `Zend\Expressive\Template\TemplateInterface` and
+>   `Config`.
+
+`Zend\Expressive\Container\TemplatedErrorHandlerFactory` creates and returns an instance of
+`Zend\Expressive\TemplatedErrorHandler`.
+
+If the `Zend\Expressive\Template\TemplateInterface` service is available, it will be injected.
+
+If the `Config` service is available, and contains the following structure:
+
+```php
+'zend-expressive' => [
+    'error_handler' => [
+        'template_404'   => 'name of 404 template',
+        'template_error' => 'name of error template',
+    ],
+]
+```
+
+then the factory will inject the values for the given templates.
+
+### Configuring zend-servicemanager
+
+To use the above with zend-servicemanager, you can either programatically add the factories, or do
+so via configuration.
+
+#### Programmatically
+
+```php
+use Zend\Expressive\Template\Plates;
+
+// For all examples:
+$services->setService('Config', $config);
+$services->setFactory('Zend\Expressive\Template\TemplateInterface', function ($container) {
+    $plates = new Plates();
+    $plates->addPath($container->get('Config')['templates']['error'], 'error');
+});
+$services->setFactory('Zend\Expressive\Application', 'Zend\Expressive\Container\ApplicationFactory');
+
+// For the WhoopsErrorHandler:
+$services->setFactory('Zend\Expressive\WhoopsPageHandler', 'Zend\Expressive\Container\WhoopsPageHandlerFactory');
+$services->setFactory('Zend\Expressive\Whoops', 'Zend\Expressive\Container\WhoopsFactory');
+$services->setFactory('Zend\Expressive\FinalHandler', 'Zend\Expressive\Container\WhoopsErrorHandlerFactory');
+
+// For the TemplatedErrorHandler:
+$services->setFactory('Zend\Expressive\FinalHandler', 'Zend\Expressive\Container\TemplatedErrorHandlerFactory');
+```
+
+From there:
+
+```php
+$app = $services->get('Zend\Expressive\Application');
+$app->run();
+```
+
+#### Via Configuration
+
+First, the configuration:
+
+```php
+use Zend\Expressive\Template\Plates;
+
+return [
+    // Note: you may also be defining your middleware service configuration here.
+    'service_manager' => [
+        'factories' => [
+            'Zend\Expressive\Application' => 'Zend\Expressive\Container\ApplicationFactory',
+            'Zend\Expressive\Template\TemplateInterface' => function ($container) {
+                $plates = new Plates();
+                $plates->addPath($container->get('Config')['templates']['error'], 'error');
+            },
+            'Zend\Expressive\Whoops' => 'Zend\Expressive\Container\WhoopsFactory',
+            'Zend\Expressive\WhoopsPageHandler' => 'Zend\Expressive\Container\WhoopsPageHandlerFactory',
+            'Zend\Expressive\FinalHandler' => 'Zend\Expressive\Container\WhoopsErrorHandlerFactory',
+            /* or:
+            'Zend\Expressive\FinalHandler' => 'Zend\Expressive\Container\TemplatedErrorHandlerFactory',
+            */
+        ],
+    ],
+    'whoops' => [
+        'json_exceptions' => [
+            'display'    => true, // required to enable the JsonResponseHandler
+            'show_trace' => true, // optional
+            'ajax_only'  => true, // optional
+        ],
+    ],
+    'zend-expressive' => [
+        'error_handler' => [
+            'template_404'   => 'name of 404 template',
+            'template_error' => 'name of error template',
+        ],
+    ],
+    // you might also have routes, middleware_pipeline, etc.
+];
+```
+
+Next, the bootstrap:
+
+```php
+use Zend\ServiceManager\Config;
+use Zend\ServiceManager\ServiceManager;
+
+$config    = include 'config/config.php';
+$container = new ServiceManager(new Config($config));
+$container->setService('Config', $config);
+
+$app = $container->get('Zend\Expressive\Application');
+$app->run();
+```
+
+At this point, you're completely configured, with your final handler and any other services you
+might define.
+
+#### Varying services by environment
+
+As noted in the section on each error handler, some error handlers are better suited for production,
+and others for development. How can you manage that?
+
+One trick is to use configuration globbing in order to specify alternate services. In this scenario,
+you might define a global configuration with the production values, and then override that with
+local configuration. zend-config and zend-stdlib provide tools for doing such configuration merging.
+
+> Note: In progrress
+>
+> This section is still in progress, and will be addressed with more information later.
+
+### Using Pimple
+
+Using Pimple is similar to programmatic usage of zend-servicemanager.
+
+```php
+use Interop\Container\Pimple\PimpleInterop;
+use Zend\Expressive\Container;
+use Zend\Expressive\Template\Plates;
+
+$pimple = new Pimple()
+
+$pimple['Config'] = $config;
+$pimple['Zend\Expressive\Application'] = new Container\ApplicationFactory();
+$pimple['Zend\Expressive\Template\TemplateInterface'] = function ($container) {
+    $plates = new Plates();
+    $plates->addPath($container->get('Config')['templates']['error'], 'error');
+};
+$pimple['Zend\Expressive\Whoops'] = new Container\WhoopsFactory();
+$pimple['Zend\Expressive\WhoopsPageHandler'] = new Container\WhoopsPageHandlerFactory();
+$pimple['Zend\Expressive\FinalHandler'] = new Container\WhoopsErrorHandlerFactory();
+// or:
+// $pimple['Zend\Expressive\FinalHandler'] = new Container\FinalErrorHandlerFactory();
+```
+
+Once configured:
+
+```php
+$app = $pimple['Zend\Expressive\Application'];
+$app->run();
+```

--- a/doc/bookdown.json
+++ b/doc/bookdown.json
@@ -7,6 +7,7 @@
     "book/router.aura.md",
     "book/router.fast-route.md",
     "book/router.zf2.md",
+    "book/error-handling.md",
     "book/cookbook.md"
   ],
   "target": "./html"

--- a/src/Application.php
+++ b/src/Application.php
@@ -352,6 +352,13 @@ class Application extends MiddlewarePipe
         if (! $this->finalHandler) {
             $this->finalHandler = new FinalHandler([], $response);
         }
+
+        // Inject the handler with the response, if possible (e.g., the
+        // TemplatedErrorResponse and WhoopsErrorResponse implementations).
+        if (method_exists($this->finalHandler, 'setOriginalResponse')) {
+            $this->finalHandler->setOriginalResponse($response);
+        }
+
         return $this->finalHandler;
     }
 

--- a/src/Container/TemplatedErrorHandlerFactory.php
+++ b/src/Container/TemplatedErrorHandlerFactory.php
@@ -10,10 +10,10 @@
 namespace Zend\Expressive\Container;
 
 use Interop\Container\ContainerInterface;
-use Zend\Expressive\WhoopsErrorHandler;
+use Zend\Expressive\TemplatedErrorHandler;
 
 /**
- * Create and return an instance of the whoops error handler.
+ * Create and return an instance of the templated error handler.
  *
  * Register this factory as the service `Zend\Expressive\FinalHandler` in
  * the container of your choice.
@@ -26,12 +26,6 @@ use Zend\Expressive\WhoopsErrorHandler;
  * - Config (which should return an array or array-like object with a
  *   "zend-expressive" top-level key, and an "error_handler" subkey,
  *   containing the configuration for the error handler).
- *
- * This factory has required dependencies on the following services:
- *
- * - Zend\Expressive\Whoops, which should return a Whoops\Run instance.
- * - Zend\Expressive\WhoopsPageHandler, which should return a
- *   Whoops\Handler\PrettyPageHandler instance.
  *
  * Configuration should look like the following:
  *
@@ -46,7 +40,7 @@ use Zend\Expressive\WhoopsErrorHandler;
  *
  * If any of the keys are missing, default values will be used.
  */
-class WhoopsErrorHandlerFactory
+class TemplatedErrorHandlerFactory
 {
     public function __invoke(ContainerInterface $container)
     {
@@ -62,9 +56,7 @@ class WhoopsErrorHandlerFactory
             ? $config['zend-expressive']['error_handler']
             : [];
 
-        return new WhoopsErrorHandler(
-            $container->get('Zend\Expressive\Whoops'),
-            $container->get('Zend\Expressive\WhoopsPageHandler'),
+        return new TemplatedErrorHandler(
             $template,
             (isset($config['template_404']) ? $config['template_404'] : 'error/404'),
             (isset($config['template_error']) ? $config['template_error'] : 'error/error')

--- a/src/Container/WhoopsErrorHandlerFactory.php
+++ b/src/Container/WhoopsErrorHandlerFactory.php
@@ -10,7 +10,7 @@
 namespace Zend\Expressive\Container;
 
 use Interop\Container\ContainerInterface;
-use Zend\Expressive\ErrorHandler;
+use Zend\Expressive\WhoopsErrorHandler;
 
 /**
  * Create and return an instance of the error handler.
@@ -46,7 +46,7 @@ use Zend\Expressive\ErrorHandler;
  *
  * If any of the keys are missing, default values will be used.
  */
-class ErrorHandlerFactory
+class WhoopsErrorHandlerFactory
 {
     public function __invoke(ContainerInterface $container)
     {
@@ -62,7 +62,7 @@ class ErrorHandlerFactory
             ? $config['zend-expressive']['error_handler']
             : [];
 
-        return new ErrorHandler(
+        return new WhoopsErrorHandler(
             $container->get('Zend\Expressive\Whoops'),
             $container->get('Zend\Expressive\WhoopsPageHandler'),
             $template,

--- a/src/Container/WhoopsPageHandlerFactory.php
+++ b/src/Container/WhoopsPageHandlerFactory.php
@@ -67,7 +67,7 @@ class WhoopsPageHandlerFactory
         $editor = $config['editor'];
 
         if (is_callable($editor)) {
-            $pageHandler->setEditor($editor);
+            $handler->setEditor($editor);
             return;
         }
 
@@ -82,6 +82,6 @@ class WhoopsPageHandlerFactory
             $editor = $container->get($editor);
         }
 
-        $pageHandler->setEditor($editor);
+        $handler->setEditor($editor);
     }
 }

--- a/src/TemplatedErrorHandler.php
+++ b/src/TemplatedErrorHandler.php
@@ -1,0 +1,269 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       http://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive;
+
+use Psr\Http\Message\RequestInterface as Request;
+use Psr\Http\Message\ResponseInterface as Response;
+use Zend\Stratigility\Utils;
+
+/**
+ * Final handler with templated page capabilities.
+ *
+ * Provides the optional ability to render a template for each of 404 and
+ * general error conditions. If no template renderer is provided, returns
+ * empty responses with appropriate status codes.
+ */
+class TemplatedErrorHandler
+{
+    /**
+     * Body size on the original response; used to compare against received
+     * response in order to determine if changes have been made.
+     *
+     * @var int
+     */
+    private $bodySize;
+
+    /**
+     * Original response against which to compare when determining if the
+     * received response is a different instance, and thus should be directly
+     * returned.
+     *
+     * @var Response
+     */
+    private $originalResponse;
+
+    /**
+     * Template renderer to use when rendering error pages; if not provided,
+     * only the status will be updated.
+     *
+     * @var Template\TemplateInterface
+     */
+    private $template;
+
+    /**
+     * Name of 404 template to use when creating 404 response content with the
+     * template renderer.
+     *
+     * @var string
+     */
+    private $template404;
+
+    /**
+     * Name of error template to use when creating response content for pages
+     * with errors.
+     *
+     * @var string
+     */
+    private $templateError;
+
+    /**
+     * @param null|Template\TemplateInterface $template Template renderer.
+     * @param null|string $template404 Template to use for 404 responses.
+     * @param null|string $templateError Template to use for general errors.
+     * @param null|Response $originalResponse Original response (used to
+     *     calculate if the response has changed during middleware
+     *     execution).
+     */
+    public function __construct(
+        Template\TemplateInterface $template = null,
+        $template404 = 'error/404',
+        $templateError = 'error/error',
+        Response $originalResponse = null
+    ) {
+        $this->template      = $template;
+        $this->template404   = $template404;
+        $this->templateError = $templateError;
+        if ($originalResponse) {
+            $this->setOriginalResponse($originalResponse);
+        }
+    }
+
+    /**
+     * Set the original response for comparisons.
+     *
+     * @param Response $originalResponse
+     */
+    public function setOriginalResponse(Response $response)
+    {
+        $this->bodySize = $response->getBody()->getSize();
+        $this->originalResponse = $response;
+    }
+
+    /**
+     * Final handler for an application.
+     *
+     * @param Request $request
+     * @param Response $response
+     * @param null|mixed $err
+     * @return Response
+     */
+    public function __invoke(Request $request, Response $response, $err = null)
+    {
+        if (! $err) {
+            return $this->handlePotentialSuccess($request, $response);
+        }
+
+        return $this->handleErrorResponse($err, $request, $response);
+    }
+
+    /**
+     * Handle a non-exception error.
+     *
+     * If a template renderer is present, passes the following to the template
+     * specified in the $templateError property:
+     *
+     * - error (the error itsel)
+     * - uri
+     * - status (response status)
+     * - reason (reason associated with response status)
+     * - request (full PSR-7 request instance)
+     * - response (full PSR-7 response instance)
+     *
+     * The results of rendering are then written to the response body.
+     *
+     * This method may be used as an extension point.
+     *
+     * @param mixed $error
+     * @param Request $request
+     * @param Response $response
+     * @return Response
+     */
+    protected function handleError($error, Request $request, Response $response)
+    {
+        if ($this->template) {
+            $response->getBody()->write(
+                $this->template->render($this->templateError, [
+                    'uri'      => $request->getUri(),
+                    'error'    => $error,
+                    'status'   => $response->getStatusCode(),
+                    'reason'   => $response->getReasonPhrase(),
+                    'request'  => $request,
+                    'response' => $response,
+                ])
+            );
+        }
+
+        return $response;
+    }
+
+    /**
+     * Prepare the exception for display.
+     *
+     * Proxies to `handleError()`; exists primarily to as an extension point
+     * for other handlers.
+     *
+     * @param \Exception $exception
+     * @param Request $request
+     * @param Response $response
+     */
+    protected function handleException(\Exception $exception, Request $request, Response $response)
+    {
+        return $this->handleError($exception, $request, $response);
+    }
+
+    /**
+     * Handle a non-error condition.
+     *
+     * Non-error conditions mean either all middleware called $next(), and we
+     * have a complete response, or no middleware was able to handle the
+     * request.
+     *
+     * This method determines which occurred, returning the response in the
+     * first instance, and returning a 404 response in the second.
+     *
+     * @param Request $request
+     * @param Response $response
+     * @return Response
+     */
+    private function handlePotentialSuccess(Request $request, Response $response)
+    {
+        if (! $this->originalResponse) {
+            return $this->marshalReceivedResponse($request, $response);
+        }
+
+        if ($this->originalResponse !== $response) {
+            return $response;
+        }
+
+        if ($this->bodySize !== $response->getBody()->getSize()) {
+            return $response;
+        }
+
+        return $this->create404($request, $response);
+    }
+
+    /**
+     * Determine whether to return the given response, or a 404.
+     *
+     * If no original response was present, we check to see if we have a 200
+     * response with empty content; if so, we treat it as a 404.
+     *
+     * Otherwise, we return the response intact.
+     *
+     * @param Request $request
+     * @param Response $response
+     * @return Response
+     */
+    private function marshalReceivedResponse(Request $request, Response $response)
+    {
+        if ($response->getStatusCode() === 200
+            && $response->getBody()->getSize() === 0
+        ) {
+            return $this->create404($request, $response);
+        }
+
+        return $response;
+    }
+
+    /**
+     * Create a 404 response.
+     *
+     * If we have a template renderer composed, renders the 404 template into
+     * the response.
+     *
+     * @param Request $request
+     * @param Response $response
+     * @return Response
+     */
+    private function create404(Request $request, Response $response)
+    {
+        if ($this->template) {
+            $response->getBody()->write(
+                $this->template->render($this->template404, [ 'uri' => $request->getUri() ])
+            );
+        }
+        return $response->withStatus(404);
+    }
+
+    /**
+     * Handle an error response.
+     *
+     * Marshals the response status from the error.
+     *
+     * If the error is not an exception, it then proxies to handleError();
+     * otherwise, it proxies to handleException().
+     *
+     * @param mixed $error
+     * @param Request $request
+     * @param Response $response
+     * @return Response
+     */
+    private function handleErrorResponse($error, Request $request, Response $response)
+    {
+        $response = $response->withStatus(Utils::getStatusCode($error, $response));
+
+        if (! $error instanceof \Exception) {
+            return $this->handleError($error, $request, $response);
+        }
+
+
+        return $this->handleException($error, $request, $response);
+    }
+}

--- a/src/WhoopsErrorHandler.php
+++ b/src/WhoopsErrorHandler.php
@@ -16,7 +16,7 @@ use Whoops\Run as Whoops;
 use Zend\Stratigility\Http\Request as StratigilityRequest;
 use Zend\Stratigility\Utils;
 
-class ErrorHandler
+class WhoopsErrorHandler
 {
     /**
      * Body size on the original response; used to compare against received

--- a/test/Container/TemplatedErrorHandlerFactoryTest.php
+++ b/test/Container/TemplatedErrorHandlerFactoryTest.php
@@ -10,34 +10,26 @@
 namespace ZendTest\Expressive\Container;
 
 use PHPUnit_Framework_TestCase as TestCase;
-use Whoops\Handler\JsonResponseHandler;
-use Whoops\Handler\PrettyPageHandler;
-use Whoops\Run as Whoops;
-use Zend\Expressive\Container\WhoopsErrorHandlerFactory;
+use Zend\Expressive\Container\TemplatedErrorHandlerFactory;
 use Zend\Expressive\Template\TemplateInterface;
-use Zend\Expressive\WhoopsErrorHandler;
+use Zend\Expressive\TemplatedErrorHandler;
 
-class WhoopsErrorHandlerFactoryTest extends TestCase
+class TemplatedErrorHandlerFactoryTest extends TestCase
 {
     public function setUp()
     {
-        $whoops      = $this->prophesize(Whoops::class);
-        $pageHandler = $this->prophesize(PrettyPageHandler::class);
         $this->container = $this->prophesize('Interop\Container\ContainerInterface');
-        $this->container->get('Zend\Expressive\WhoopsPageHandler')->willReturn($pageHandler->reveal());
-        $this->container->get('Zend\Expressive\Whoops')->willReturn($whoops->reveal());
-
-        $this->factory   = new WhoopsErrorHandlerFactory();
+        $this->factory   = new TemplatedErrorHandlerFactory();
     }
 
-    public function testReturnsAWhoopsErrorHandler()
+    public function testReturnsATemplatedErrorHandler()
     {
         $this->container->has(TemplateInterface::class)->willReturn(false);
         $this->container->has('Config')->willReturn(false);
 
         $factory = $this->factory;
         $result  = $factory($this->container->reveal());
-        $this->assertInstanceOf(WhoopsErrorHandler::class, $result);
+        $this->assertInstanceOf(TemplatedErrorHandler::class, $result);
     }
 
     public function testWillInjectTemplateIntoErrorHandlerWhenServiceIsPresent()
@@ -49,7 +41,7 @@ class WhoopsErrorHandlerFactoryTest extends TestCase
 
         $factory = $this->factory;
         $result  = $factory($this->container->reveal());
-        $this->assertInstanceOf(WhoopsErrorHandler::class, $result);
+        $this->assertInstanceOf(TemplatedErrorHandler::class, $result);
         $this->assertAttributeInstanceOf(TemplateInterface::class, 'template', $result);
     }
 
@@ -65,7 +57,7 @@ class WhoopsErrorHandlerFactoryTest extends TestCase
 
         $factory = $this->factory;
         $result  = $factory($this->container->reveal());
-        $this->assertInstanceOf(WhoopsErrorHandler::class, $result);
+        $this->assertInstanceOf(TemplatedErrorHandler::class, $result);
         $this->assertAttributeEquals('error::404', 'template404', $result);
         $this->assertAttributeEquals('error::500', 'templateError', $result);
     }

--- a/test/Container/WhoopsErrorHandlerFactoryTest.php
+++ b/test/Container/WhoopsErrorHandlerFactoryTest.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive\Container;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use ReflectionFunction;
+use ReflectionProperty;
+use Whoops\Handler\JsonResponseHandler;
+use Whoops\Handler\PrettyPageHandler;
+use Whoops\Run as Whoops;
+use Zend\Expressive\Container\WhoopsErrorHandlerFactory;
+use Zend\Expressive\Template\TemplateInterface;
+use Zend\Expressive\WhoopsErrorHandler;
+
+class WhoopsErrorHandlerFactoryTest extends TestCase
+{
+    public function setUp()
+    {
+        $whoops      = $this->prophesize(Whoops::class);
+        $pageHandler = $this->prophesize(PrettyPageHandler::class);
+        $this->container = $this->prophesize('Interop\Container\ContainerInterface');
+        $this->container->get('Zend\Expressive\WhoopsPageHandler')->willReturn($pageHandler->reveal());
+        $this->container->get('Zend\Expressive\Whoops')->willReturn($whoops->reveal());
+
+        $this->factory   = new WhoopsErrorHandlerFactory();
+    }
+
+    public function testReturnsAWhoopsErrorHandler()
+    {
+        $this->container->has(TemplateInterface::class)->willReturn(false);
+        $this->container->has('Config')->willReturn(false);
+
+        $factory = $this->factory;
+        $result  = $factory($this->container->reveal());
+        $this->assertInstanceOf(WhoopsErrorHandler::class, $result);
+    }
+
+    public function testWillInjectTemplateIntoErrorHandlerWhenServiceIsPresent()
+    {
+        $template = $this->prophesize(TemplateInterface::class);
+        $this->container->has(TemplateInterface::class)->willReturn(true);
+        $this->container->get(TemplateInterface::class)->willReturn($template->reveal());
+        $this->container->has('Config')->willReturn(false);
+
+        $factory = $this->factory;
+        $result  = $factory($this->container->reveal());
+        $this->assertInstanceOf(WhoopsErrorHandler::class, $result);
+        $this->assertAttributeInstanceOf(TemplateInterface::class, 'template', $result);
+    }
+
+    public function testWillInjectTemplateNamesFromConfigurationWhenPresent()
+    {
+        $config = ['zend-expressive' => ['error_handler' => [
+            'template_404'   => 'error::404',
+            'template_error' => 'error::500',
+        ]]];
+        $this->container->has(TemplateInterface::class)->willReturn(false);
+        $this->container->has('Config')->willReturn(true);
+        $this->container->get('Config')->willReturn($config);
+
+        $factory = $this->factory;
+        $result  = $factory($this->container->reveal());
+        $this->assertInstanceOf(WhoopsErrorHandler::class, $result);
+        $this->assertAttributeEquals('error::404', 'template404', $result);
+        $this->assertAttributeEquals('error::500', 'templateError', $result);
+    }
+}

--- a/test/Container/WhoopsFactoryTest.php
+++ b/test/Container/WhoopsFactoryTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive\Container;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use ReflectionFunction;
+use ReflectionProperty;
+use Whoops\Handler\JsonResponseHandler;
+use Whoops\Handler\PrettyPageHandler;
+use Whoops\Run as Whoops;
+use Zend\Expressive\Container\WhoopsFactory;
+
+class WhoopsFactoryTest extends TestCase
+{
+    public function setUp()
+    {
+        $pageHandler = $this->prophesize(PrettyPageHandler::class);
+        $this->container = $this->prophesize('Interop\Container\ContainerInterface');
+        $this->container->get('Zend\Expressive\WhoopsPageHandler')->willReturn($pageHandler->reveal());
+
+        $this->factory   = new WhoopsFactory();
+    }
+
+    public function assertWhoopsContainsHandler($type, Whoops $whoops, $message = null)
+    {
+        $message = $message ?: sprintf("Failed to assert whoops runtime composed handler of type %s", $type);
+        $r = new ReflectionProperty($whoops, 'handlerStack');
+        $r->setAccessible(true);
+        $stack = $r->getValue($whoops);
+
+        $found = false;
+        foreach ($stack as $handler) {
+            if ($handler instanceof $type) {
+                $found = true;
+                break;
+            }
+        }
+
+        $this->assertTrue($found, $message);
+    }
+
+    public function testReturnsAWhoopsRuntimeWithPageHandlerComposed()
+    {
+        $this->container->has('Config')->willReturn(false);
+        $factory = $this->factory;
+        $result  = $factory($this->container->reveal());
+        $this->assertInstanceOf(Whoops::class, $result);
+        $this->assertWhoopsContainsHandler(PrettyPageHandler::class, $result);
+    }
+
+    public function testWillInjectJsonResponseHandlerIfConfigurationExpectsIt()
+    {
+        $config = ['whoops' => ['json_exceptions' => ['display' => true]]];
+        $this->container->has('Config')->willReturn(true);
+        $this->container->get('Config')->willReturn($config);
+
+        $factory = $this->factory;
+        $result  = $factory($this->container->reveal());
+        $this->assertInstanceOf(Whoops::class, $result);
+        $this->assertWhoopsContainsHandler(PrettyPageHandler::class, $result);
+        $this->assertWhoopsContainsHandler(JsonResponseHandler::class, $result);
+    }
+
+    /**
+     * @depends testWillInjectJsonResponseHandlerIfConfigurationExpectsIt
+     */
+    public function testJsonResponseHandlerCanBeConfigured()
+    {
+        $config = ['whoops' => ['json_exceptions' => [
+            'display'    => true,
+            'show_trace' => true,
+            'ajax_only'  => true,
+        ]]];
+        $this->container->has('Config')->willReturn(true);
+        $this->container->get('Config')->willReturn($config);
+
+        $factory = $this->factory;
+        $whoops  = $factory($this->container->reveal());
+
+        $jsonHandler = $whoops->popHandler();
+        $this->assertInstanceOf(JsonResponseHandler::class, $jsonHandler);
+        $this->assertAttributeSame(true, 'returnFrames', $jsonHandler);
+        $this->assertAttributeSame(true, 'onlyForAjaxRequests', $jsonHandler);
+    }
+}

--- a/test/Container/WhoopsPageHandlerFactoryTest.php
+++ b/test/Container/WhoopsPageHandlerFactoryTest.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive\Container;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use ReflectionFunction;
+use ReflectionProperty;
+use Whoops\Handler\PrettyPageHandler;
+use Zend\Expressive\Container\WhoopsPageHandlerFactory;
+use Zend\Expressive\Container\Exception\InvalidServiceException;
+
+class WhoopsPageHandlerFactoryTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->container = $this->prophesize('Interop\Container\ContainerInterface');
+        $this->factory   = new WhoopsPageHandlerFactory();
+    }
+
+    public function testReturnsAPrettyPageHandler()
+    {
+        $this->container->has('Config')->willReturn(false);
+        $factory = $this->factory;
+
+        $result = $factory($this->container->reveal());
+        $this->assertInstanceOf(PrettyPageHandler::class, $result);
+    }
+
+    public function testWillInjectStringEditor()
+    {
+        $config = ['whoops' => ['editor' => 'emacs']];
+        $this->container->has('Config')->willReturn(true);
+        $this->container->get('Config')->willReturn($config);
+        $this->container->has('emacs')->willReturn(false);
+
+        $factory = $this->factory;
+        $result = $factory($this->container->reveal());
+        $this->assertInstanceOf(PrettyPageHandler::class, $result);
+        $this->assertAttributeEquals($config['whoops']['editor'], 'editor', $result);
+    }
+
+    public function testWillInjectCallableEditor()
+    {
+        $config = ['whoops' => ['editor' => function () {
+        }]];
+        $this->container->has('Config')->willReturn(true);
+        $this->container->get('Config')->willReturn($config);
+        $factory = $this->factory;
+
+        $result = $factory($this->container->reveal());
+        $this->assertInstanceOf(PrettyPageHandler::class, $result);
+        $this->assertAttributeSame($config['whoops']['editor'], 'editor', $result);
+    }
+
+    public function testWillInjectEditorAsAService()
+    {
+        $config = ['whoops' => ['editor' => 'custom']];
+        $editor = function () {
+        };
+        $this->container->has('Config')->willReturn(true);
+        $this->container->get('Config')->willReturn($config);
+        $this->container->has('custom')->willReturn(true);
+        $this->container->get('custom')->willReturn($editor);
+
+        $factory = $this->factory;
+        $result = $factory($this->container->reveal());
+        $this->assertInstanceOf(PrettyPageHandler::class, $result);
+        $this->assertAttributeSame($editor, 'editor', $result);
+    }
+
+    public function invalidEditors()
+    {
+        return [
+            'true'       => [true],
+            'false'      => [false],
+            'zero'       => [0],
+            'int'        => [1],
+            'zero-float' => [0.0],
+            'float'      => [1.1],
+            'array'      => [['emacs']],
+            'object'     => [(object) ['editor' => 'emacs']],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidEditors
+     */
+    public function testInvalidEditorWillRaiseException($editor)
+    {
+        $config = ['whoops' => ['editor' => $editor]];
+        $this->container->has('Config')->willReturn(true);
+        $this->container->get('Config')->willReturn($config);
+
+        $factory = $this->factory;
+
+        $this->setExpectedException(InvalidServiceException::class);
+        $factory($this->container->reveal());
+    }
+}

--- a/test/TemplatedErrorHandlerTest.php
+++ b/test/TemplatedErrorHandlerTest.php
@@ -1,0 +1,414 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       http://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive;
+
+use Exception;
+use PHPUnit_Framework_TestCase as TestCase;
+use Prophecy\Argument;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+use Zend\Expressive\TemplatedErrorHandler;
+use Zend\Expressive\Template\TemplateInterface;
+
+class TemplatedErrorHandlerTest extends TestCase
+{
+    public function getTemplateImplementation()
+    {
+        return $this->prophesize(TemplateInterface::class);
+    }
+
+    public function getRequest($stream)
+    {
+        $request = $this->prophesize(RequestInterface::class);
+        $request->getBody()->will(function () use ($stream) {
+            return $stream->reveal();
+        });
+        return $request;
+    }
+
+    public function getResponse($stream)
+    {
+        $response = $this->prophesize(ResponseInterface::class);
+        $response->getBody()->will(function () use ($stream) {
+            return $stream->reveal();
+        });
+        return $response;
+    }
+
+    public function getStream()
+    {
+        return $this->prophesize(StreamInterface::class);
+    }
+
+    public function testCanBeInstantiatedWithNoArguments()
+    {
+        $handler = new TemplatedErrorHandler();
+        $this->assertAttributeSame(null, 'template', $handler);
+    }
+
+    public function testCanBeInstantiatedWithTemplateImplementation()
+    {
+        $template = $this->getTemplateImplementation()->reveal();
+        $handler = new TemplatedErrorHandler($template);
+        $this->assertAttributeSame($template, 'template', $handler);
+    }
+
+    public function testOriginalResponseIsNullByDefault()
+    {
+        $handler = new TemplatedErrorHandler();
+        $this->assertAttributeSame(null, 'originalResponse', $handler);
+    }
+
+    public function testOriginalResponseCanBeInjectedAtInstantiation()
+    {
+        $stream = $this->getStream();
+        $stream->getSize()->willReturn(100);
+        $response = $this->getResponse($stream);
+
+        $handler = new TemplatedErrorHandler(null, '', '', $response->reveal());
+        $this->assertAttributeSame($response->reveal(), 'originalResponse', $handler);
+        $this->assertAttributeEquals(100, 'bodySize', $handler);
+    }
+
+    /* Tests covering handlePotentialSuccess() paths; NO TEMPLATE */
+
+    public function testInvocationWithoutErrorAndPositiveStreamSizeReturnsResponse()
+    {
+        $handler = new TemplatedErrorHandler();
+
+        $stream   = $this->getStream();
+        $stream->getSize()->willReturn(100);
+        $response = $this->getResponse($stream);
+        $response->getStatusCode()->willReturn(200);
+        $request = $this->getRequest($this->getStream());
+
+        $result = $handler($request->reveal(), $response->reveal());
+        $this->assertSame($response->reveal(), $result);
+    }
+
+    public function testInvocationWithoutErrorAndEmptyResponseReturns404Response()
+    {
+        $handler = new TemplatedErrorHandler();
+
+        $expected = $this->getResponse($this->getStream());
+
+        $stream   = $this->getStream();
+        $stream->getSize()->willReturn(0);
+        $response = $this->getResponse($stream);
+        $response->getStatusCode()->willReturn(200);
+        $response->withStatus(404)->willReturn($expected->reveal());
+
+        $request = $this->getRequest($this->getStream());
+
+        $result = $handler($request->reveal(), $response->reveal());
+        $this->assertSame($expected->reveal(), $result);
+    }
+
+    public function testInvocationWithoutErrorAndResponseSameAsOriginalReturns404Response()
+    {
+        $handler = new TemplatedErrorHandler();
+
+        $expected = $this->getResponse($this->getStream());
+
+        $stream   = $this->getStream();
+        $stream->getSize()->willReturn(100);
+        $response = $this->getResponse($stream);
+        $response->getStatusCode()->willReturn(200);
+        $response->withStatus(404)->willReturn($expected->reveal());
+
+        $handler->setOriginalResponse($response->reveal());
+
+        $request = $this->getRequest($this->getStream());
+
+        $result = $handler($request->reveal(), $response->reveal());
+        $this->assertSame($expected->reveal(), $result);
+    }
+
+    public function testInvocationWithoutErrorAndResponseSameAsOriginalWithNewBodyContentsReturnsResponse()
+    {
+        $handler = new TemplatedErrorHandler();
+
+        $count    = 0;
+        $stream   = $this->getStream();
+        $stream->getSize()->will(function () use (&$count) {
+            ++$count;
+            return 100 * $count;
+        });
+        $response = $this->getResponse($stream);
+        $response->getStatusCode()->willReturn(200);
+
+        $handler->setOriginalResponse($response->reveal());
+
+        $request = $this->getRequest($this->getStream());
+
+        $result = $handler($request->reveal(), $response->reveal());
+        $this->assertSame($response->reveal(), $result);
+    }
+
+    public function testInvocationWithoutErrorAndResponseDifferentThanOriginalReturnsResponse()
+    {
+        $handler = new TemplatedErrorHandler();
+
+        $originalStream = $this->getStream();
+        $originalStream->getSize()->willReturn(0);
+        $expected = $this->getResponse($originalStream);
+        $handler->setOriginalResponse($expected->reveal());
+
+        $response = $this->getResponse($this->getStream());
+        $request  = $this->getRequest($this->getStream());
+
+        $result = $handler($request->reveal(), $response->reveal());
+        $this->assertSame($response->reveal(), $result);
+    }
+
+    /* Tests covering handlePotentialSuccess() paths; WITH TEMPLATE */
+
+    /**
+     * @group templated
+     */
+    public function testInvocationWithoutErrorAndEmptyResponseCanReturnTemplated404Response()
+    {
+        $template = $this->getTemplateImplementation();
+        $template
+            ->render(
+                'error::404',
+                Argument::type('array')
+            )
+            ->willReturn('Templated contents');
+
+        $handler = new TemplatedErrorHandler(
+            $template->reveal(),
+            'error::404',
+            'error::500'
+        );
+
+        $expected = $this->getResponse($this->getStream());
+
+        $stream   = $this->getStream();
+        $stream->getSize()->willReturn(0);
+        $stream->write('Templated contents')->shouldBeCalled();
+
+        $response = $this->getResponse($stream);
+        $response->getStatusCode()->willReturn(200);
+        $response->withStatus(404)->willReturn($expected->reveal());
+
+        $request = $this->getRequest($this->getStream());
+        $request->getUri()->shouldBeCalled();
+
+        $result = $handler($request->reveal(), $response->reveal());
+        $this->assertSame($expected->reveal(), $result);
+    }
+
+    /**
+     * @group templated
+     */
+    public function testInvocationWithoutErrorAndResponseSameAsOriginalCanReturnTemplated404Response()
+    {
+        $template = $this->getTemplateImplementation();
+        $template
+            ->render(
+                'error::404',
+                Argument::type('array')
+            )
+            ->willReturn('Templated contents');
+
+        $handler = new TemplatedErrorHandler(
+            $template->reveal(),
+            'error::404',
+            'error::500'
+        );
+
+        $expected = $this->getResponse($this->getStream());
+
+        $stream   = $this->getStream();
+        $stream->getSize()->willReturn(100);
+        $stream->write('Templated contents')->shouldBeCalled();
+
+        $response = $this->getResponse($stream);
+        $response->getStatusCode()->willReturn(200);
+        $response->withStatus(404)->willReturn($expected->reveal());
+
+        $handler->setOriginalResponse($response->reveal());
+
+        $request = $this->getRequest($this->getStream());
+        $request->getUri()->shouldBeCalled();
+
+        $result = $handler($request->reveal(), $response->reveal());
+        $this->assertSame($expected->reveal(), $result);
+    }
+
+    /* Tests covering handleErrorResponse() paths; NO TEMPLATE */
+
+    public function testNonExceptionErrorReturnsResponseWith500StatusWhenNoTemplatingInjected()
+    {
+        $handler = new TemplatedErrorHandler();
+
+        $response = $this->getResponse($this->getStream());
+        $response->getStatusCode()->willReturn(200);
+        $response->withStatus(500)->will(function () use ($response) {
+            return $response->reveal();
+        });
+
+        $request = $this->getRequest($this->getStream());
+
+        $result = $handler($request->reveal(), $response->reveal(), 'error');
+        $this->assertSame($response->reveal(), $result);
+    }
+
+    public function testExceptionErrorReturnsResponseWith500StatusWhenNoTemplatingInjected()
+    {
+        $handler = new TemplatedErrorHandler();
+
+        $response = $this->getResponse($this->getStream());
+        $response->getStatusCode()->willReturn(200);
+        $response->withStatus(500)->will(function () use ($response) {
+            return $response->reveal();
+        });
+
+        $request   = $this->getRequest($this->getStream());
+        $exception = new Exception();
+
+        $result = $handler($request->reveal(), $response->reveal(), $exception);
+        $this->assertSame($response->reveal(), $result);
+    }
+
+    public function validHttpErrorStatusCodes()
+    {
+        for ($i = 400; $i < 600; $i += 1) {
+            yield [$i];
+        }
+    }
+
+    /**
+     * @dataProvider validHttpErrorStatusCodes
+     */
+    public function testExceptionErrorUsesExceptionCodeAsStatusIfValidHTTPErrorStatus($code)
+    {
+        $handler = new TemplatedErrorHandler();
+
+        $response = $this->getResponse($this->getStream());
+        $response->getStatusCode()->willReturn(200);
+        $response->withStatus($code)->will(function () use ($response) {
+            return $response->reveal();
+        });
+
+        $request   = $this->getRequest($this->getStream());
+        $exception = new Exception('Message', $code);
+        $handler($request->reveal(), $response->reveal(), $exception);
+    }
+
+    public function invalidHttpErrorStatusCodes()
+    {
+        for ($i = 0; $i < 400; $i += 1) {
+            yield [$i];
+        }
+
+        for ($i = 600; $i < 700; $i += 1) {
+            yield [$i];
+        }
+    }
+
+    /**
+     * @dataProvider invalidHttpErrorStatusCodes
+     */
+    public function testInvalidExceptionErrorCodeDefaultsToHTTP500Status($code)
+    {
+        $handler = new TemplatedErrorHandler();
+
+        $response = $this->getResponse($this->getStream());
+        $response->getStatusCode()->willReturn(200);
+        $response->withStatus(500)->will(function () use ($response) {
+            return $response->reveal();
+        });
+
+        $request   = $this->getRequest($this->getStream());
+        $exception = new Exception('Message', $code);
+        $handler($request->reveal(), $response->reveal(), $exception);
+    }
+
+    /* Tests covering handleErrorResponse() paths; WITH TEMPLATE */
+
+    /**
+     * @group templated
+     */
+    public function testNonExceptionErrorReturnsResponseWith500StatusAndTemplateResultsWhenTemplatingInjected()
+    {
+        $template = $this->getTemplateImplementation();
+        $template
+            ->render(
+                'error::500',
+                Argument::type('array')
+            )
+            ->willReturn('Templated contents');
+
+        $handler = new TemplatedErrorHandler(
+            $template->reveal(),
+            'error::404',
+            'error::500'
+        );
+
+        $stream   = $this->getStream();
+        $stream->getSize()->willReturn(0);
+        $stream->write('Templated contents')->shouldBeCalled();
+
+        $expected = $this->getResponse($stream);
+        $expected->getStatusCode()->willReturn(500)->shouldBeCalled();
+        $expected->getReasonPhrase()->shouldBeCalled();
+
+        $response = $this->getResponse($stream);
+        $response->getStatusCode()->willReturn(200);
+        $response->withStatus(500)->willReturn($expected->reveal());
+
+        $request = $this->getRequest($this->getStream());
+        $request->getUri()->shouldBeCalled();
+
+        $result = $handler($request->reveal(), $response->reveal(), 'error');
+        $this->assertSame($expected->reveal(), $result);
+    }
+
+    /**
+     * @group templated
+     */
+    public function testExceptionErrorReturnsResponseWith500StatusAndTemplateResultsWhenTemplatingInjected()
+    {
+        $template = $this->getTemplateImplementation();
+        $template
+            ->render(
+                'error::500',
+                Argument::type('array')
+            )
+            ->willReturn('Templated contents');
+
+        $handler = new TemplatedErrorHandler(
+            $template->reveal(),
+            'error::404',
+            'error::500'
+        );
+
+        $stream   = $this->getStream();
+        $stream->getSize()->willReturn(0);
+        $stream->write('Templated contents')->shouldBeCalled();
+
+        $expected = $this->getResponse($stream);
+        $expected->getStatusCode()->willReturn(500)->shouldBeCalled();
+        $expected->getReasonPhrase()->shouldBeCalled();
+
+        $response = $this->getResponse($stream);
+        $response->getStatusCode()->willReturn(200);
+        $response->withStatus(500)->willReturn($expected->reveal());
+
+        $request = $this->getRequest($this->getStream());
+        $request->getUri()->shouldBeCalled();
+
+        $result = $handler($request->reveal(), $response->reveal(), new Exception());
+        $this->assertSame($expected->reveal(), $result);
+    }
+}

--- a/test/WhoopsErrorHandlerTest.php
+++ b/test/WhoopsErrorHandlerTest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       http://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive;
+
+use Exception;
+use PHPUnit_Framework_TestCase as TestCase;
+use Prophecy\Argument;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+use Whoops\Handler\PrettyPageHandler;
+use Whoops\Run as Whoops;
+use Zend\Expressive\WhoopsErrorHandler;
+
+class WhoopsErrorHandlerTest extends TestCase
+{
+    public function getWhoops()
+    {
+        return $this->prophesize(Whoops::class);
+    }
+
+    public function getPrettyPageHandler()
+    {
+        return $this->prophesize(PrettyPageHandler::class);
+    }
+
+    public function testInstantiationRequiresWhoopsAndPageHandler()
+    {
+        $whoops = $this->getWhoops();
+        $pageHandler = $this->getPrettyPageHandler();
+
+        $handler = new WhoopsErrorHandler($whoops->reveal(), $pageHandler->reveal());
+        $this->assertAttributeSame($whoops->reveal(), 'whoops', $handler);
+        $this->assertAttributeSame($pageHandler->reveal(), 'whoopsHandler', $handler);
+    }
+
+    public function testExceptionErrorPreparesPageHandlerAndInvokesWhoops()
+    {
+        $exception = new Exception('Boom!');
+
+        $whoops = $this->getWhoops();
+        $whoops->handleException($exception)->willReturn('Whoops content');
+
+        $pageHandler = $this->getPrettyPageHandler();
+        $pageHandler->addDataTable('Expressive Application Request', Argument::type('array'))->shouldBeCalled();
+
+        $handler = new WhoopsErrorHandler($whoops->reveal(), $pageHandler->reveal());
+
+        $stream    = $this->prophesize(StreamInterface::class);
+        $stream->write('Whoops content')->shouldBeCalled();
+
+        $expected  = $this->prophesize(ResponseInterface::class);
+        $expected->getBody()->will(function () use ($stream) {
+            return $stream->reveal();
+        });
+
+        $response  = $this->prophesize(ResponseInterface::class);
+        $response->getStatusCode()->willReturn(200);
+        $response->withStatus(500)->will(function () use ($expected) {
+            return $expected->reveal();
+        });
+
+        $request   = $this->prophesize(ServerRequestInterface::class);
+        $request->getUri()->willReturn('http://example.com');
+        $request->getMethod()->shouldBeCalled();
+        $request->getServerParams()->willReturn(['SCRIPT_NAME' => __FILE__])->shouldBeCalled();
+        $request->getHeaders()->shouldBeCalled();
+        $request->getCookieParams()->shouldBeCalled();
+        $request->getAttributes()->shouldBeCalled();
+        $request->getQueryParams()->shouldBeCalled();
+        $request->getParsedBody()->shouldBeCalled();
+
+        $result = $handler($request->reveal(), $response->reveal(), $exception);
+        $this->assertSame($expected->reveal(), $result);
+    }
+}


### PR DESCRIPTION
This builds off of #60 (which was inadvertantly merged). It adds a `TemplatedErrorHandler`, and renames `ErrorHandler` to `WhoopsErrorHandler`, having it extend the `TemplatedErrorHandler` in order to provide common functionality between the two implementations.

TODO
----

- [X] Alternate, templated-only production error handler.
- [x] Unit tests for each error handler.
- [x] Unit tests for each factory.
- [x] Documentation.