### PR TITLE
[WIP] ModularApplicationFactory: support ZF2 modules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,8 @@
         "zendframework/zend-view": "^2.5",
         "phpunit/phpunit": "^4.7",
         "squizlabs/php_codesniffer": "^2.3",
+        "zendframework/zend-config": "^2.5",
+        "zendframework/zend-modulemanager": "^2.5",
         "zendframework/zend-mvc": "^2.5",
         "zendframework/zend-psr7bridge": "^0.1.0"
     },
@@ -44,6 +46,8 @@
         "nikic/fast-route": "^0.6.0 to use the FastRoute routing adapter",
         "zendframework/zend-mvc": "^2.5 to use the zend-mvc TreeRouteStack routing adapter",
         "zendframework/zend-psr7bridge": "^0.1.0 to use the zend-mvc TreeRouteStack routing adapter",
+        "zendframework/zend-config": "^2.5 to enable support for ZF2 modules",
+        "zendframework/zend-modulemanager": "^2.5 to enable support for ZF2 modules",
         "twig/twig": "^1.19 to use the Twig template adapter",
         "zendframework/zend-view": "^2.5 to use the Zend View template adapter"
     }

--- a/src/Container/ModularApplicationFactory.php
+++ b/src/Container/ModularApplicationFactory.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Zend\Expressive\Container;
+
+use Zend\Config\Factory as ConfigFactory;
+use Zend\Expressive\Application;
+use Zend\Expressive\Container\ApplicationFactory as ExpressiveApplicationFactory;
+use Zend\ModuleManager\Listener\ConfigListener;
+use Zend\ModuleManager\Listener\ModuleResolverListener;
+use Zend\ModuleManager\ModuleEvent;
+use Zend\ModuleManager\ModuleManager;
+use Zend\ServiceManager\Config;
+use Zend\ServiceManager\ServiceManager;
+use Zend\Stdlib\ArrayUtils;
+
+class ModularApplicationFactory
+{
+    /**
+     * @param $systemConfig
+     * @return array application config
+     */
+    private function initModules($systemConfig)
+    {
+        $modules = is_array($systemConfig['modules'])?$systemConfig['modules']:[];
+        $manager = new ModuleManager($modules);
+        $manager->getEventManager()->attach(ModuleEvent::EVENT_LOAD_MODULE_RESOLVE, new ModuleResolverListener());
+
+        $configListener = new ConfigListener();
+        $manager->getEventManager()->attach($configListener);
+        $manager->loadModules();
+        $moduleConfig = $configListener->getMergedConfig(false);
+
+        if (!isset($systemConfig['config_glob_paths'])) {
+            return $moduleConfig;
+        }
+
+        $additionalConfig = ConfigFactory::fromFiles(
+            glob($systemConfig['config_glob_paths'], GLOB_BRACE)
+        );
+
+        return ArrayUtils::merge($moduleConfig, $additionalConfig);
+    }
+
+    private function initServiceManager($applicationConfig)
+    {
+        $smConfig = new Config(isset($applicationConfig['service_manager'])?$applicationConfig['service_manager']:[]);
+        $serviceManager = new ServiceManager($smConfig);
+        $serviceManager->setService('Config', $applicationConfig);
+        $serviceManager->setAlias('Configuration', 'Config');
+        return $serviceManager;
+    }
+
+    /**
+     * @param array $systemConfig
+     * @return Application
+     */
+    public function create(array $systemConfig)
+    {
+        $applicationConfig = $this->initModules($systemConfig);
+        $serviceManager = $this->initServiceManager($applicationConfig);
+
+        $defaultFactory = new ExpressiveApplicationFactory();
+        return $defaultFactory($serviceManager);
+    }
+}

--- a/src/Container/ModularApplicationFactory.php
+++ b/src/Container/ModularApplicationFactory.php
@@ -30,7 +30,9 @@ class ModularApplicationFactory
         $manager->loadModules();
         $moduleConfig = $configListener->getMergedConfig(false);
 
-        if (!isset($systemConfig['config_glob_paths'])) {
+        if (!isset($systemConfig['module_listener_options'])
+            || !isset($systemConfig['module_listener_options']['config_glob_paths'])
+        ) {
             return $moduleConfig;
         }
 

--- a/src/Container/ModularApplicationFactory.php
+++ b/src/Container/ModularApplicationFactory.php
@@ -37,7 +37,7 @@ class ModularApplicationFactory
         }
 
         $additionalConfig = ConfigFactory::fromFiles(
-            glob($systemConfig['config_glob_paths'], GLOB_BRACE)
+            glob($systemConfig['module_listener_options']['config_glob_paths'], GLOB_BRACE)
         );
 
         return ArrayUtils::merge($moduleConfig, $additionalConfig);


### PR DESCRIPTION
This proof-of-concept PR creates alternative factory for `Application` class, able to load ZF2 modules. 3rd party modules can provide configuration for `Zend\ServiceManager` in order to expose services with no configuration/wiring required. More complex `Expressive` applications can be split into modules as well, to improve maintainability.

Obviously, this powerful feature comes at risk: ZF2 modules often hook to various application events that won't work under `Expressive`. This could create confusion for module devs and consumers.

I can see three options to avoid this confusion:

1. Don't merge this feature at all (sad :) )
2. Create separate module ecosystem for `Expressive`
3. Allow people to tag/indicate if module is built for ZF2, Expressive, or both.

I like option 3, as sooner or later (with arrival of ZF3), we may have to add this feature to modules.zendframework.com anyway.

Let me know if you like this, and (if yes) how would you like me to structure it.

**Usage:**

```php
// index.php

$appFactory = new ModularApplicationFactory();
$app = $appFactory->create(
     // system configuration, similar to ZF2
    [
        'modules' => [
            'Application',
            'AnotherModule'
        ],
        'module_listener_options' => [
            'config_glob_paths' => [
                'config/autoload/{{,*.}global,{,*.}local}.php',
            ],
        ]
    ]
);
$app->run();
```