### PR TITLE
[WIP] Module concept bring to Zend\Expressive

### DIFF
--- a/src/Composer/PostPackage.php
+++ b/src/Composer/PostPackage.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Composer;
+
+use Composer\Installer\PackageEvent;
+
+/**
+ * Events that integrate within Composer workflow, and allow to automatically merge config from middlewares
+ *
+ * Some middlewares (like Zend\Expressive), require the use of global configuration to be merged, so that components
+ * like container can be used.
+ *
+ * In order to use this feature, you need to add those lines into your `composer.json` file:
+ *
+ *   "scripts": {
+ *     "post-package-install": [
+ *       "Zend\\Expressive\\Composer\\PostPackage::install"
+ *     ],
+ *     "post-package-update": [
+ *       "Zend\\Expressive\\Composer\\PostPackage::update"
+ *    ]
+ *  }
+ *
+ * On the other hand, compliant third-party packages must make sure that their "extra" parts in `composer.json`
+ * include the necessary information. Here is the required format:
+ *
+ *   "extra": {
+ *     "middleware_config": [
+ *       {
+ *         "path": "config/general.php"
+ *       },
+ *       {
+ *         "path": "config/view.php",
+ *         "only_if": "zend-expressive-view"
+ *       }
+ *     ]
+ *   }
+ */
+class PostPackage
+{
+    /**
+     * @param PackageEvent $event
+     */
+    public static function install(PackageEvent $event)
+    {
+        static::doInstall($event, true);
+    }
+
+    /**
+     * @param PackageEvent $event
+     */
+    public static function update(PackageEvent $event)
+    {
+        static::doInstall($event, false);
+    }
+
+    private static function doInstall(PackageEvent $event, $overrideConfig)
+    {
+        $applicationExtra = $event->getComposer()->getPackage()->getExtra();
+        $flags            = isset($applicationExtra['zend_expressive_flags'])
+            ? $applicationExtra['zend_expressive_flags']
+            : [];
+
+        /** @var \Composer\Package\CompletePackage $installedPackage */
+        $installedPackage = $event->getOperation()->getPackage();
+        $installedExtra   = $installedPackage->getExtra();
+
+        $middlewareConfig = isset($installedExtra['middleware_config']) ? $installedExtra['middleware_config'] : [];
+
+        foreach ($middlewareConfig as $singleConfig) {
+            // If the config has an "only_if" key, this means the config must only be merged if this option
+            // was passed as part of the consumer
+            if (isset($singleConfig['only_if']) && !in_array($singleConfig['only_if'], $flags, true)) {
+                continue;
+            }
+
+            // Get the path of the file
+
+            $path = // . $singleConfig['path'];
+
+            // Copy the file into consumer application /config path, under a unique key. If overrideConfig is true (which
+            // happens during install), then the file is copy-pasted as it. If it's false (which happens during update),
+            // we merge the existing file, by making sure that the order is correct so that existing keys are not overriden
+        }
+    }
+}

--- a/src/Composer/PostPackage.php
+++ b/src/Composer/PostPackage.php
@@ -32,7 +32,7 @@ use Composer\Installer\PackageEvent;
  * include the necessary information. Here is the required format:
  *
  *   "extra": {
- *     "middleware_config": [
+ *     "container_config": [
  *       {
  *         "path": "config/general.php"
  *       },
@@ -72,9 +72,9 @@ class PostPackage
         $installedPackage = $event->getOperation()->getPackage();
         $installedExtra   = $installedPackage->getExtra();
 
-        $middlewareConfig = isset($installedExtra['middleware_config']) ? $installedExtra['middleware_config'] : [];
+        $containerConfig = isset($installedExtra['container_config']) ? $installedExtra['container_config'] : [];
 
-        foreach ($middlewareConfig as $singleConfig) {
+        foreach ($containerConfig as $singleConfig) {
             // If the config has an "only_if" key, this means the config must only be merged if this option
             // was passed as part of the consumer
             if (isset($singleConfig['only_if']) && !in_array($singleConfig['only_if'], $flags, true)) {

--- a/src/Composer/PostPackage.php
+++ b/src/Composer/PostPackage.php
@@ -64,9 +64,7 @@ class PostPackage
     private static function doInstall(PackageEvent $event, $overrideConfig)
     {
         $applicationExtra = $event->getComposer()->getPackage()->getExtra();
-        $flags            = isset($applicationExtra['zend_expressive_flags'])
-            ? $applicationExtra['zend_expressive_flags']
-            : [];
+        $flags            = isset($applicationExtra['install_flags']) ? $applicationExtra['install_flags'] : [];
 
         /** @var \Composer\Package\CompletePackage $installedPackage */
         $installedPackage = $event->getOperation()->getPackage();


### PR DESCRIPTION
Hi everyone,

During my holidays, I've been thinking of a way for middleware to provide a way to register config into the application, hence emulating a kind of module manager. I've no idea if this is a good idea or not, this must only be considered as a proof of concept (actually, it may be even moved to its own repo?).

## Problem

Currently, Zend\Expressive needs, to work, that the user create a config file, populate it (and make sure that he does not forget any key). Similarily, each external middleware may need its own container key to be registered into the config so that it properly work.

This is in contrast of ZF2 module manager, where you enable modules, and it automatically takes care of retrieving, merging and making available a config file to the whole application, that can be consumed directly.

At the same time, module manager introduces a overhead that is added into each request. Of course, merging can be configured, but the whole event system is triggered. Additionally, it requires manual work from the user that must add the module to the list.

Those two problems prevent us from having each library (like Zend\Filter, Zend\Validator...) to be implemented as a module, as it would cause too much overhead, both from a performance point of view and from usability.

## What we need

Zend\Expressive brings a middleware system, and is meant to be flexible and lightweight. For instance, Zend\Expressive has an optional view layer.

We'd therefore like to be able to create customized installations, with minimal overhead from the user (for instance, just indicate that you would like to install the view layer as well, and boom, additional config would be added).

Additionally, we'd like to have a solution that brings **zero** performance overhead, even if you have 1, 10 or 100 "modules".

## Solution

The solution I've thought about is not yet functional, but it's based on the fact that Zend\Expressive **requires** Composer. I've therefore tried to take advantage of that.

## Middleware/third-party library

In order to be considered as a "module" (from now on, I will call them a "container-aware library", to emphasize the fact that those library are capable of bringing their own config that is automatically injected into the main application).

This can be a middleware, but also a pure PHP library like Zend\Validator.

Those modules simply need to have a specific key into their `composer.json` file, into the `extra` key:

```json
{
  "extra": {
    "container_config": [
    	{
    		"path": "config/container.php"
    	},
    	{
    		"path": "config/view.php",
    		"only_if": "zend-expressive-view"
    	}
    ]
  }
}
```

The required key is `container_config`. It must be an array of array, where each element MUST at least contain a "path" key. The path value is relative to the installed package, and must be a php file.

It can also contains an optional `only_if` value. For now, it only supports one value (but multiple values may be useful in the future). I'll talk about that later, but the idea is that the `config/view.php` file will be only merged IF AND ONLY the `zend-expressive-view` flag has been added to the consumer application (your application).

This is what allows to create custom build.

## Consumer application

The consumer is your application. The user must alter its composer.json file in two ways:

1. You must first add two scripts entries. Those scripts will be run whenever a new package is installed or updated. Those scripts are defined into the Zend\Expressive package, and allow to merge the config file.
2. Optionally, a consumer may add into the `extra` hash a `install_flags` key. Those flags are the one that are compared during the install process.

Here is an example:

```json
"scripts": {
    "post-package-install": [
      "Zend\\Expressive\\Composer\\PostPackage::install"
    ],
    "post-package-update": [
      "Zend\\Expressive\\Composer\\PostPackage::update"
    ]
  },
  "extra": {
    "install_flags": "zend-expressive-view"
  }
```

Because of the `install_flags`, if we take our previous example, the `config/view.php` config would be merged, because the `zend-expressive-view` has been set into the consumer application.

## Workflow

Let's say Zend\Expressive has the following structure:

```yaml
-- config
  -- container.php
  -- view.php
-- src
-- test
-- composer.json  
```

Inside the `composer.json` file:

```json
{
  "extra": {
    "container_config": [
    	{
    		"path": "config/container.php"
    	},
    	{
    		"path": "config/view.php",
    		"only_if": "zend-expressive-view"
    	}
    ]
  }
}
```

If we define, into our consumer application, the flag zend-expressive-view, and run a composer.update, here is what will happen in OUR application:

```yaml
-- config
  -- zend_expressive_container.php
  -- zend_expressive_view.php
```

As you can see, the two files have been copied into our config file, and the package name has been prepended to avoid clashes.

Then, in our `index.php` file, we could have a simple logic to merge those files, and pass it to Zend\Expressive constructor.

## FAQ

### Difference between install and update

Let's say that we add a new package into our composer.json file. The first time `composer update` is run, it will be an install, and hence the config files will be added to our config folder.

Then, we can make some modifications to those files (to alter and override the config). However, on update, we must make sure that the script does not override all the changes we've made. In that case, the configuration file is instead merged, and existing keys are not changed.

### Environment

In ZF2, we had the `global`, `local` mechnasim. I have no idea about how I could do it here.