### PR TITLE
Fixed issue #40 + minor fixes

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -132,17 +132,23 @@ class Application extends MiddlewarePipe
         if (! in_array(strtoupper($method), $this->httpRouteMethods, true)) {
             throw new BadMethodCallException('Unsupported method');
         }
-
-        if (count($args) !== 2) {
+        $numArgs = count($args);
+        if ($numArgs < 2) {
             throw new BadMethodCallException(sprintf(
-                '%s::%s requires exactly 2 arguments; received %d',
+                '%s::%s requires at least 2 arguments; received %d',
                 __CLASS__,
                 $method,
                 count($args)
             ));
         }
 
-        $args[] = [$method];
+        if ($numArgs === 3) {
+            $name    = $args[2];
+            $args[2] = [$method];
+            $args[]  = $name;
+        } else {
+            $args[] = [$method];
+        }
 
         // @TODO: we can use variadic parameters when dependency is raised to PHP 5.6
         return call_user_func_array([$this, 'route'], $args);
@@ -261,10 +267,11 @@ class Application extends MiddlewarePipe
      * @param string|Router\Route $path
      * @param callable|string $middleware Middleware (or middleware service name) to associate with route.
      * @param null|array $methods HTTP method to accept; null indicates any.
+     * @param null|string $name the name of the route
      * @return Router\Route
      * @throws Exception\InvalidArgumentException if $path is not a Router\Route AND middleware is null.
      */
-    public function route($path, $middleware = null, array $methods = null)
+    public function route($path, $middleware = null, array $methods = null, $name = null)
     {
         if (! $path instanceof Router\Route && null === $middleware) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -277,13 +284,14 @@ class Application extends MiddlewarePipe
             $route   = $path;
             $path    = $route->getPath();
             $methods = $route->getAllowedMethods();
+            $name    = $route->getName();
         }
 
         $this->checkForDuplicateRoute($path, $methods);
 
         if (! isset($route)) {
             $methods = (null === $methods) ? Router\Route::HTTP_METHOD_ANY : $methods;
-            $route   = new Router\Route($path, $middleware, $methods);
+            $route   = new Router\Route($path, $middleware, $methods, $name);
         }
 
         $this->routes[] = $route;
@@ -381,7 +389,7 @@ class Application extends MiddlewarePipe
     /**
      * Determine if the route is duplicated in the current list.
      *
-     * Checks if a route with the same path exists already in the list;
+     * Checks if a route with the same name or path exists already in the list;
      * if so, and it responds to any of the $methods indicated, raises
      * a DomainException indicating a duplicate route.
      *
@@ -411,7 +419,7 @@ class Application extends MiddlewarePipe
 
         if (count($matches) > 0) {
             throw new DomainException(
-                'Duplicate route detected; same path, and one or more HTTP methods intersect'
+                'Duplicate route detected; same name or path, and one or more HTTP methods intersect'
             );
         }
     }

--- a/src/Router/Aura.php
+++ b/src/Router/Aura.php
@@ -29,6 +29,13 @@ class Aura implements RouterInterface
     private $router;
 
     /**
+     * Store the path and the HTTP methods allowed
+     *
+     * @var array
+     */
+    private $routes = [];
+
+    /**
      * Constructor
      *
      * If no Aura.Router instance is provided, the constructor will lazy-load
@@ -75,18 +82,17 @@ class Aura implements RouterInterface
      */
     public function addRoute(Route $route)
     {
+        $path      = $route->getPath();
         $auraRoute = $this->router->add(
-            $route->getPath(),
-            $route->getPath(),
+            $route->getName(),
+            $path,
             $route->getMiddleware()
         );
 
-        $httpMethods = $route->getAllowedMethods();
-        if (is_array($httpMethods)) {
-            $auraRoute->setServer([
-                'REQUEST_METHOD' => implode('|', $httpMethods),
-            ]);
-        }
+        $allowedMethods = (array) $route->getAllowedMethods();
+        $auraRoute->setServer([
+            'REQUEST_METHOD' => implode('|', $allowedMethods)
+        ]);
 
         foreach ($route->getOptions() as $key => $value) {
             switch ($key) {
@@ -98,12 +104,17 @@ class Aura implements RouterInterface
                     break;
             }
         }
+
+        if (array_key_exists($path, $this->routes)) {
+            $allowedMethods = array_merge($this->routes[$path], $allowedMethods);
+        }
+        $this->routes[$path] = $allowedMethods;
     }
 
     /**
      * @param  string $patch
      * @param  array $params
-     * @return boolean
+     * @return RouteResult
      */
     public function match(Request $request)
     {
@@ -129,11 +140,14 @@ class Aura implements RouterInterface
     private function marshalFailedRoute()
     {
         $failedRoute = $this->router->getFailedRoute();
-        if (! $failedRoute->failedMethod()) {
-            return RouteResult::fromRouteFailure();
+        if ($failedRoute->failedMethod()) {
+            return RouteResult::fromRouteFailure($failedRoute->method);
         }
-
-        return RouteResult::fromRouteFailure($failedRoute->method);
+        list($path) = explode('^', $failedRoute->name);
+        if (array_key_exists($path, $this->routes)) {
+            return RouteResult::fromRouteFailure($this->routes[$path]);
+        }
+        return RouteResult::fromRouteFailure();
     }
 
     /**

--- a/src/Router/Aura.php
+++ b/src/Router/Aura.php
@@ -89,11 +89,6 @@ class Aura implements RouterInterface
             $route->getMiddleware()
         );
 
-        $allowedMethods = (array) $route->getAllowedMethods();
-        $auraRoute->setServer([
-            'REQUEST_METHOD' => implode('|', $allowedMethods)
-        ]);
-
         foreach ($route->getOptions() as $key => $value) {
             switch ($key) {
                 case 'tokens':
@@ -104,6 +99,15 @@ class Aura implements RouterInterface
                     break;
             }
         }
+
+        $allowedMethods = (array) $route->getAllowedMethods();
+        if ([ Route::HTTP_METHOD_ANY ] === $allowedMethods) {
+            return;
+        }
+
+        $auraRoute->setServer([
+            'REQUEST_METHOD' => implode('|', $allowedMethods)
+        ]);
 
         if (array_key_exists($path, $this->routes)) {
             $allowedMethods = array_merge($this->routes[$path], $allowedMethods);

--- a/src/Router/FastRoute.php
+++ b/src/Router/FastRoute.php
@@ -93,7 +93,7 @@ class FastRoute implements RouterInterface
 
     /**
      * @param  Request $request
-     * @return boolean
+     * @return RouteResult
      */
     public function match(Request $request)
     {

--- a/src/Router/Route.php
+++ b/src/Router/Route.php
@@ -29,6 +29,7 @@ use Zend\Expressive\Exception;
 class Route
 {
     const HTTP_METHOD_ANY = 0xff;
+    const HTTP_METHOD_SEPARATOR = ':';
 
     /**
      * @var int|string[] HTTP methods allowed with this route.
@@ -84,7 +85,9 @@ class Route
         $this->path       = $path;
         $this->middleware = $middleware;
         $this->methods    = is_array($methods) ? $this->validateHttpMethods($methods) : $methods;
-        $this->name       = empty($name) ? $path . '^' . implode('_', (array) $this->methods) : $name;
+        $this->name       = empty($name) ?
+                            $path . '^' . implode(self::HTTP_METHOD_SEPARATOR, (array) $this->methods) :
+                            $name;
     }
 
     /**

--- a/src/Router/Route.php
+++ b/src/Router/Route.php
@@ -51,14 +51,20 @@ class Route
     private $path;
 
     /**
+     * @var string
+     */
+    private $name;
+
+    /**
      * @param string $path Path to match.
      * @param string|callable $middleware Middleware to use when this route is matched.
      * @param int|array Allowed HTTP methods; defaults to HTTP_METHOD_ANY.
+     * @param string|null $name the route name
      * @throws Exception\InvalidArgumentException for invalid path type.
      * @throws Exception\InvalidArgumentException for invalid middleware type.
      * @throws Exception\InvalidArgumentException for any invalid HTTP method names.
      */
-    public function __construct($path, $middleware, $methods = self::HTTP_METHOD_ANY)
+    public function __construct($path, $middleware, $methods = self::HTTP_METHOD_ANY, $name = null)
     {
         if (! is_string($path)) {
             throw new Exception\InvalidArgumentException('Invalid path; must be a string');
@@ -78,6 +84,7 @@ class Route
         $this->path       = $path;
         $this->middleware = $middleware;
         $this->methods    = is_array($methods) ? $this->validateHttpMethods($methods) : $methods;
+        $this->name       = empty($name) ? $path . '^' . implode('_', (array) $this->methods) : $name;
     }
 
     /**
@@ -86,6 +93,14 @@ class Route
     public function getPath()
     {
         return $this->path;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
     }
 
     /**
@@ -130,6 +145,14 @@ class Route
     public function setOptions(array $options)
     {
         $this->options = $options;
+    }
+
+    /**
+     * @param string $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
     }
 
     /**

--- a/src/Router/Zf2.php
+++ b/src/Router/Zf2.php
@@ -19,22 +19,26 @@ use Zend\Psr7Bridge\Psr7ServerRequest;
  *
  * This router implementation consumes zend-mvc's TreeRouteStack, (the default
  * router implementation in a ZF2 application). The addRoute() method injects
- * segment routes into the TreeRouteStack, and manages an internal route stack
- * in order to do HTTP method negotiation after a successful match (as the ZF2
- * "Method" router implementation will return a result indistinguishable from a
- * 404 otherwise).
+ * segment routes into the TreeRouteStack, and create a fail route for HTTP
+ * method negotiation (as the ZF2 "Method" router implementation will return
+ * a result indistinguishable from a 404 otherwise).
  */
 class Zf2 implements RouterInterface
 {
-    /**
-     * @var Route[] Registered routes
-     */
-    private $routes = [];
+    // Name of the route fail
+    const ROUTE_FAIL = 'fail';
 
     /**
      * @var TreeRouteStack
      */
     private $zf2Router;
+
+    /**
+     * Store the path and the HTTP methods allowed
+     *
+     * @var array
+     */
+    private $routes = [];
 
     /**
      * @param null|TreeRouteStack $router
@@ -44,7 +48,6 @@ class Zf2 implements RouterInterface
         if (null === $router) {
             $router = $this->createRouter();
         }
-
         $this->zf2Router = $router;
     }
 
@@ -54,21 +57,69 @@ class Zf2 implements RouterInterface
     public function addRoute(Route $route)
     {
         $path    = $route->getPath();
-        $options = $route->getOptions() ?: [];
+        $options = $route->getOptions();
         $options = array_replace_recursive($options, [
-            'route'   => $route->getPath(),
-            'defaults' => [
-                'middleware' => $route->getMiddleware(),
-            ],
+            'route' => $path
         ]);
-
+        $childRouteName = implode('-', $route->getAllowedMethods());
+        $childRoutes    = $this->getMethodRouteConfig($route);
         $spec = [
-            'type'    => 'segment',
-            'options' => $options,
+            'type'          => 'segment',
+            'options'       => $options,
+            'may_terminate' => false,
+            'child_routes'  => [ $childRouteName => $childRoutes ]
         ];
+        $routeFail = $path . '/' . self::ROUTE_FAIL;
+        if (array_key_exists($routeFail, $this->routes)) {
+            $this->zf2Router->getRoute($path)->addRoute($childRouteName, $childRoutes);
+        } else {
+            $spec['child_routes'][self::ROUTE_FAIL] = $this->getFailRouteConfig();
+            $this->zf2Router->addRoute($path, $spec);
+        }
 
-        $this->zf2Router->addRoute($path, $spec);
-        $this->routes[$path] = $route;
+        $allowedMethods = (array) $route->getAllowedMethods();
+        if (array_key_exists($routeFail, $this->routes)) {
+            $allowedMethods = array_merge($this->routes[$routeFail], $allowedMethods);
+        }
+        $this->routes[$routeFail] = $allowedMethods;
+    }
+
+    /**
+     * Get the method route configuration
+     *
+     * @param Route $route
+     * @return array
+     */
+    private function getMethodRouteConfig($route)
+    {
+        return [
+            'type'    => 'method',
+            'options' => [
+                'verb'     => implode(',', (array) $route->getAllowedMethods()),
+                'defaults' => [
+                    'middleware' => $route->getMiddleware()
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * Get the configuration for the fail route
+     *
+     * @return array
+     */
+    private function getFailRouteConfig()
+    {
+        return [
+            'type'     => 'segment',
+            'priority' => -1,
+            'options'  => [
+                'route'    => '[/]',
+                'defaults' => [
+                    'middleware' => null
+                ]
+            ]
+        ];
     }
 
     /**
@@ -83,11 +134,6 @@ class Zf2 implements RouterInterface
 
         if (null === $match) {
             return RouteResult::fromRouteFailure();
-        }
-
-        $allowedMethods = $this->getAllowedMethods($match->getMatchedRouteName());
-        if (! $this->methodIsAllowed($request->getMethod(), $allowedMethods)) {
-            return RouteResult::fromRouteFailure($allowedMethods);
         }
 
         return $this->marshalSuccessResultFromRouteMatch($match);
@@ -109,63 +155,17 @@ class Zf2 implements RouterInterface
      */
     private function marshalSuccessResultFromRouteMatch(RouteMatch $match)
     {
-        $params = $match->getParams();
-        $middleware = isset($params['middleware'])
-            ? $params['middleware']
-            : $this->getMiddlewareFromRoute($match->getMatchedRouteName());
+        $params    = $match->getParams();
+        $routeName = $match->getMatchedRouteName();
+
+        if (null === $params['middleware']) {
+            return RouteResult::fromRouteFailure($this->routes[$routeName]);
+        }
 
         return RouteResult::fromRouteMatch(
-            $match->getMatchedRouteName(),
-            $middleware,
+            $routeName,
+            $params['middleware'],
             $params
         );
-    }
-
-    /**
-     * Given a route name (the path), retrieve the middleware associated with it.
-     *
-     * @param string $name
-     * @return null|string|callable
-     */
-    private function getMiddlewareFromRoute($name)
-    {
-        if (! array_key_exists($name, $this->routes)) {
-            return null;
-        }
-
-        $route = $this->routes[$name];
-        return $route->getMiddleware();
-    }
-
-    /**
-     * Get list of allowed methods for this route.
-     *
-     * @param name $string
-     * @return int|string[]
-     */
-    private function getAllowedMethods($name)
-    {
-        if (! array_key_exists($name, $this->routes)) {
-            return Route::HTTP_METHOD_ANY;
-        }
-
-        $route = $this->routes[$name];
-        return $route->getAllowedMethods();
-    }
-
-    /**
-     * Is the provided method in the list of allowed methods?
-     *
-     * @param string $method
-     * @param int|string[] $allowedMethods
-     * @return bool
-     */
-    private function methodIsAllowed($method, $allowedMethods)
-    {
-        if ($allowedMethods === Route::HTTP_METHOD_ANY) {
-            return true;
-        }
-
-        return in_array(strtoupper($method), array_map('strtoupper', $allowedMethods), true);
     }
 }

--- a/test/RouteMiddlewareTest.php
+++ b/test/RouteMiddlewareTest.php
@@ -14,6 +14,7 @@ use Zend\Diactoros\ServerRequest;
 use Zend\Diactoros\Response;
 use Zend\Expressive\Application;
 use Zend\Expressive\Router\RouteResult;
+use Zend\Expressive\Router\RouterInterface;
 
 class RouteMiddlewareTest extends TestCase
 {
@@ -256,5 +257,221 @@ class RouteMiddlewareTest extends TestCase
 
         $this->setExpectedException('Zend\Expressive\Exception\InvalidMiddlewareException', 'retrieve');
         $app->routeMiddleware($request, $response, $next);
+    }
+
+    /**
+     * Get the router adapters installed
+     */
+    public function getRouterAdapters()
+    {
+        $adapters = [];
+        if (class_exists('Aura\Router\Router')) {
+            $adapters[] = [ 'Zend\Expressive\Router\Aura' ];
+        }
+        if (class_exists('FastRoute\RouteCollector')) {
+            $adapters[] = [ 'Zend\Expressive\Router\FastRoute' ];
+        }
+        if (class_exists('Zend\Mvc\Router\RouteMatch')) {
+            $adapters[] = [ 'Zend\Expressive\Router\Zf2' ];
+        }
+        return $adapters;
+    }
+
+    /**
+     * Create an Application object with 2 routes, a GET and a POST
+     * using Application::get() and Application::post()
+     *
+     * @param string $adapter
+     * @param string $getName
+     * @param string $postName
+     * @return Application
+     */
+    private function getApplicationWithGetPost($adapter, $getName = null, $postName = null)
+    {
+        $app = new Application(new $adapter);
+        $app->get('/foo', function ($req, $res, $next) {
+            $res->getBody()->write('Middleware GET');
+            return $res;
+        }, $getName);
+        $app->post('/foo', function ($req, $res, $next) {
+            $res->getBody()->write('Middleware POST');
+            return $res;
+        }, $postName);
+
+        return $app;
+    }
+
+    /**
+     * Create an Application object with 2 routes, a GET and a POST
+     * using Application::route()
+     *
+     * @param string $adapter
+     * @param string $getName
+     * @param string $postName
+     * @return Application
+     */
+    private function getApplicationWithRouteGetPost($adapter, $getName = null, $postName = null)
+    {
+        $app = new Application(new $adapter);
+        $app->route('/foo', function ($req, $res, $next) {
+            $res->getBody()->write('Middleware GET');
+            return $res;
+        }, ['GET'], $getName);
+        $app->route('/foo', function ($req, $res, $next) {
+            $res->getBody()->write('Middleware POST');
+            return $res;
+        }, ['POST'], $postName);
+
+        return $app;
+    }
+
+    /**
+     * @dataProvider getRouterAdapters
+     */
+    public function testRoutingNoMatch($adapter)
+    {
+        $app  = $this->getApplicationWithGetPost($adapter);
+        $next = function ($req, $res) {
+            return $res;
+        };
+
+        $request  = new ServerRequest([ 'REQUEST_METHOD' => 'DELETE' ], [], '/foo', 'DELETE');
+        $response = new Response();
+        $result   = $app->routeMiddleware($request, $response, $next);
+        $this->assertSame(405, $result->getStatusCode());
+        $headers = $result->getHeaders();
+        $this->assertSame([ 'GET,POST' ], $headers['Allow']);
+    }
+
+
+    /**
+     * @see https://github.com/zendframework/zend-expressive/issues/40
+     * @dataProvider getRouterAdapters
+     */
+    public function testRoutingWithSamePathWithoutName($adapter)
+    {
+        $app  = $this->getApplicationWithGetPost($adapter);
+        $next = function ($req, $res) {
+            return $res;
+        };
+
+        $request  = new ServerRequest([ 'REQUEST_METHOD' => 'GET' ], [], '/foo', 'GET');
+        $response = new Response();
+        $result   = $app->routeMiddleware($request, $response, $next);
+
+        $this->assertEquals('Middleware GET', (string) $result->getBody());
+
+        $request  = new ServerRequest([ 'REQUEST_METHOD' => 'POST' ], [], '/foo', 'POST');
+        $response = new Response();
+        $result   = $app->routeMiddleware($request, $response, $next);
+
+        $this->assertEquals('Middleware POST', (string) $result->getBody());
+    }
+
+    /**
+     * @see https://github.com/zendframework/zend-expressive/issues/40
+     * @dataProvider getRouterAdapters
+     */
+    public function testRoutingWithSamePathWithName($adapter)
+    {
+        $app  = $this->getApplicationWithGetPost($adapter, 'foo-get', 'foo-post');
+        $next = function ($req, $res) {
+            return $res;
+        };
+
+        $request  = new ServerRequest([ 'REQUEST_METHOD' => 'GET' ], [], '/foo', 'GET');
+        $response = new Response();
+        $result   = $app->routeMiddleware($request, $response, $next);
+
+        $this->assertEquals('Middleware GET', (string) $result->getBody());
+
+        $request  = new ServerRequest([ 'REQUEST_METHOD' => 'POST' ], [], '/foo', 'POST');
+        $response = new Response();
+        $result   = $app->routeMiddleware($request, $response, $next);
+
+        $this->assertEquals('Middleware POST', (string) $result->getBody());
+    }
+
+    /**
+     * @see https://github.com/zendframework/zend-expressive/issues/40
+     * @dataProvider getRouterAdapters
+     */
+    public function testRoutingWithSamePathWithRouteWithoutName($adapter)
+    {
+        $app  = $this->getApplicationWithRouteGetPost($adapter);
+        $next = function ($req, $res) {
+            return $res;
+        };
+
+        $request  = new ServerRequest([ 'REQUEST_METHOD' => 'GET' ], [], '/foo', 'GET');
+        $response = new Response();
+        $result   = $app->routeMiddleware($request, $response, $next);
+
+        $this->assertEquals('Middleware GET', (string) $result->getBody());
+
+        $request  = new ServerRequest([ 'REQUEST_METHOD' => 'POST' ], [], '/foo', 'POST');
+        $response = new Response();
+        $result   = $app->routeMiddleware($request, $response, $next);
+
+        $this->assertEquals('Middleware POST', (string) $result->getBody());
+    }
+
+    /**
+     * @see https://github.com/zendframework/zend-expressive/issues/40
+     * @dataProvider getRouterAdapters
+     */
+    public function testRoutingWithSamePathWithRouteWithName($adapter)
+    {
+        $app  = $this->getApplicationWithRouteGetPost($adapter, 'foo-get', 'foo-post');
+        $next = function ($req, $res) {
+            return $res;
+        };
+
+        $request  = new ServerRequest([ 'REQUEST_METHOD' => 'GET' ], [], '/foo', 'GET');
+        $response = new Response();
+        $result   = $app->routeMiddleware($request, $response, $next);
+
+        $this->assertEquals('Middleware GET', (string) $result->getBody());
+
+        $request  = new ServerRequest([ 'REQUEST_METHOD' => 'POST' ], [], '/foo', 'POST');
+        $response = new Response();
+        $result   = $app->routeMiddleware($request, $response, $next);
+
+        $this->assertEquals('Middleware POST', (string) $result->getBody());
+    }
+
+    /**
+     * @see https://github.com/zendframework/zend-expressive/issues/40
+     * @dataProvider getRouterAdapters
+     */
+    public function testRoutingWithSamePathWithRouteWithMultipleMethods($adapter)
+    {
+        $app = new Application(new $adapter);
+        $app->route('/foo', function ($req, $res, $next) {
+            $res->getBody()->write('Middleware GET, POST');
+            return $res;
+        }, [ 'GET', 'POST' ]);
+        $app->route('/foo', function ($req, $res, $next) {
+            $res->getBody()->write('Middleware DELETE');
+            return $res;
+        }, [ 'DELETE' ]);
+        $next = function ($req, $res) {
+            return $res;
+        };
+
+        $request  = new ServerRequest([ 'REQUEST_METHOD' => 'GET' ], [], '/foo', 'GET');
+        $response = new Response();
+        $result   = $app->routeMiddleware($request, $response, $next);
+        $this->assertEquals('Middleware GET, POST', (string) $result->getBody());
+
+        $request  = new ServerRequest([ 'REQUEST_METHOD' => 'POST' ], [], '/foo', 'POST');
+        $response = new Response();
+        $result   = $app->routeMiddleware($request, $response, $next);
+        $this->assertEquals('Middleware GET, POST', (string) $result->getBody());
+
+        $request  = new ServerRequest([ 'REQUEST_METHOD' => 'DELETE' ], [], '/foo', 'DELETE');
+        $response = new Response();
+        $result   = $app->routeMiddleware($request, $response, $next);
+        $this->assertEquals('Middleware DELETE', (string) $result->getBody());
     }
 }

--- a/test/RouteMiddlewareTest.php
+++ b/test/RouteMiddlewareTest.php
@@ -468,4 +468,32 @@ class RouteMiddlewareTest extends TestCase
         $result   = $app->routeMiddleware($request, $response, $next);
         $this->assertEquals('Middleware DELETE', (string) $result->getBody());
     }
+
+    private function getAllHttpMethods()
+    {
+        return [ 'GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS' ];
+    }
+
+    /**
+     * @dataProvider getRouterAdapters
+     */
+    public function testMatchWithAllHttpMethods($adapter)
+    {
+        $app = new Application(new $adapter);
+        // Add a route with Zend\Expressive\Router\Route::HTTP_METHOD_ANY
+        $app->route('/foo', function ($req, $res, $next) {
+            $res->getBody()->write('Middleware');
+            return $res;
+        });
+        $next = function ($req, $res) {
+            return $res;
+        };
+
+        foreach ($this->getAllHttpMethods() as $method) {
+            $request  = new ServerRequest([ 'REQUEST_METHOD' => $method ], [], '/foo', $method);
+            $response = new Response();
+            $result   = $app->routeMiddleware($request, $response, $next);
+            $this->assertEquals('Middleware', (string) $result->getBody());
+        }
+    }
 }

--- a/test/RouteMiddlewareTest.php
+++ b/test/RouteMiddlewareTest.php
@@ -260,21 +260,15 @@ class RouteMiddlewareTest extends TestCase
     }
 
     /**
-     * Get the router adapters installed
+     * Get the router adapters to test
      */
     public function getRouterAdapters()
     {
-        $adapters = [];
-        if (class_exists('Aura\Router\Router')) {
-            $adapters[] = [ 'Zend\Expressive\Router\Aura' ];
-        }
-        if (class_exists('FastRoute\RouteCollector')) {
-            $adapters[] = [ 'Zend\Expressive\Router\FastRoute' ];
-        }
-        if (class_exists('Zend\Mvc\Router\RouteMatch')) {
-            $adapters[] = [ 'Zend\Expressive\Router\Zf2' ];
-        }
-        return $adapters;
+        return [
+          [ 'Zend\Expressive\Router\Aura' ],
+          [ 'Zend\Expressive\Router\FastRoute' ],
+          [ 'Zend\Expressive\Router\Zf2' ]
+        ];
     }
 
     /**

--- a/test/Router/AuraRouteTest.php
+++ b/test/Router/AuraRouteTest.php
@@ -33,7 +33,7 @@ class AuraRouteTest extends TestCase
         $this->auraRoute->setServer([
             'REQUEST_METHOD' => 'GET',
         ])->shouldBeCalled();
-        $this->auraRouter->add('/foo', '/foo', 'foo')->willReturn($this->auraRoute->reveal());
+        $this->auraRouter->add('/foo^GET', '/foo', 'foo')->willReturn($this->auraRoute->reveal());
 
         $router = $this->getRouter();
         $router->addRoute($route);
@@ -49,7 +49,7 @@ class AuraRouteTest extends TestCase
         ])->shouldBeCalled();
         $this->auraRoute->addTokens($route->getOptions()['tokens'])->shouldBeCalled();
 
-        $this->auraRouter->add('/foo', '/foo', 'foo')->willReturn($this->auraRoute->reveal());
+        $this->auraRouter->add('/foo^GET', '/foo', 'foo')->willReturn($this->auraRoute->reveal());
 
         $router = $this->getRouter();
         $router->addRoute($route);
@@ -65,7 +65,7 @@ class AuraRouteTest extends TestCase
         ])->shouldBeCalled();
         $this->auraRoute->addValues($route->getOptions()['values'])->shouldBeCalled();
 
-        $this->auraRouter->add('/foo', '/foo', 'foo')->willReturn($this->auraRoute->reveal());
+        $this->auraRouter->add('/foo^GET', '/foo', 'foo')->willReturn($this->auraRoute->reveal());
 
         $router = $this->getRouter();
         $router->addRoute($route);
@@ -127,7 +127,6 @@ class AuraRouteTest extends TestCase
         $result = $router->match($request->reveal());
         $this->assertInstanceOf('Zend\Expressive\Router\RouteResult', $result);
         $this->assertTrue($result->isFailure());
-        $this->assertTrue($result->isMethodFailure());
         $this->assertSame(['POST'], $result->getAllowedMethods());
     }
 

--- a/test/Router/RouteTest.php
+++ b/test/Router/RouteTest.php
@@ -115,6 +115,6 @@ class RouteTest extends TestCase
     public function testRouteNameWithGetAndPost()
     {
         $route = new Route('/test', $this->noopMiddleware, [ 'GET', 'POST' ]);
-        $this->assertSame('/test^GET_POST', $route->getName());
+        $this->assertSame('/test^GET' . Route::HTTP_METHOD_SEPARATOR . 'POST', $route->getName());
     }
 }

--- a/test/Router/RouteTest.php
+++ b/test/Router/RouteTest.php
@@ -86,4 +86,35 @@ class RouteTest extends TestCase
         $route = new Route('/foo', $this->noopMiddleware);
         $this->assertSame([], $route->getOptions());
     }
+
+    public function testRouteSetName()
+    {
+        $route = new Route('/test', $this->noopMiddleware);
+        $route->setName('test');
+        $this->assertSame('test', $route->getName());
+    }
+
+    public function testRouteName()
+    {
+        $route = new Route('/test', $this->noopMiddleware);
+        $this->assertSame('/test^' . Route::HTTP_METHOD_ANY, $route->getName());
+    }
+
+    public function testRouteNameWithConstructor()
+    {
+        $route = new Route('/test', $this->noopMiddleware, [], 'test');
+        $this->assertSame('test', $route->getName());
+    }
+
+    public function testRouteNameWithGET()
+    {
+        $route = new Route('/test', $this->noopMiddleware, [ 'GET' ]);
+        $this->assertSame('/test^GET', $route->getName());
+    }
+
+    public function testRouteNameWithGetAndPost()
+    {
+        $route = new Route('/test', $this->noopMiddleware, [ 'GET', 'POST' ]);
+        $this->assertSame('/test^GET_POST', $route->getName());
+    }
 }

--- a/test/Router/Zf2Test.php
+++ b/test/Router/Zf2Test.php
@@ -13,6 +13,7 @@ use PHPUnit_Framework_TestCase as TestCase;
 use Prophecy\Argument;
 use Zend\Expressive\Router\Zf2 as Zf2Router;
 use Zend\Expressive\Router\Route;
+use Zend\Diactoros\ServerRequest;
 
 class Zf2Test extends TestCase
 {
@@ -54,10 +55,29 @@ class Zf2Test extends TestCase
             'type' => 'segment',
             'options' => [
                 'route' => '/foo',
-                'defaults' => [
-                    'middleware' => 'foo',
-                ],
             ],
+            'may_terminate' => false,
+            'child_routes' => [
+                'GET' => [
+                    'type' => 'method',
+                    'options' => [
+                        'verb' => 'GET',
+                        'defaults' => [
+                            'middleware' => 'foo',
+                        ]
+                    ]
+                ],
+                'fail' => [
+                    'type' => 'segment',
+                    'priority' => -1,
+                    'options' => [
+                        'route' => '[/]',
+                        'defaults' => [
+                            'middleware' => null
+                        ]
+                    ]
+                ]
+            ]
         ])->shouldBeCalled();
 
         $router = $this->getRouter();
@@ -84,10 +104,31 @@ class Zf2Test extends TestCase
                     'id' => '\d+',
                 ],
                 'defaults' => [
-                    'bar' => 'baz',
-                    'middleware' => 'foo',
+                    'bar' => 'baz'
                 ],
             ],
+            'may_terminate' => false,
+            'child_routes' => [
+                'GET' => [
+                    'type' => 'method',
+                    'options' => [
+                        'verb' => 'GET',
+                        'defaults' => [
+                            'middleware' => 'foo',
+                        ]
+                    ]
+                ],
+                'fail' => [
+                    'type' => 'segment',
+                    'priority' => -1,
+                    'options' => [
+                        'route' => '[/]',
+                        'defaults' => [
+                            'middleware' => null
+                        ]
+                    ]
+                ]
+            ]
         ])->shouldBeCalled();
 
         $router = $this->getRouter();
@@ -107,6 +148,24 @@ class Zf2Test extends TestCase
                 RouteResult::fromRouteFailure(),
             ],
         ];
+    }
+
+    public function testMatch()
+    {
+        $middleware = function ($req, $res, $next) {
+            return $res;
+        };
+
+        $route = new Route('/foo', $middleware, ['GET']);
+        $zf2Router = new Zf2Router();
+        $zf2Router->addRoute($route);
+
+        $request = new ServerRequest([ 'REQUEST_METHOD' => 'GET' ], [], '/foo', 'GET');
+
+        $result = $zf2Router->match($request);
+        $this->assertInstanceOf('Zend\Expressive\Router\RouteResult', $result);
+        $this->assertEquals('/foo/GET', $result->getMatchedRouteName());
+        $this->assertEquals($middleware, $result->getMatchedMiddleware());
     }
 
     /**
@@ -157,31 +216,11 @@ class Zf2Test extends TestCase
      */
     public function testMatchFailureDueToHttpMethodReturnsRouteResultWithAllowedMethods()
     {
-        $routeMatch = $this->prophesize('Zend\Mvc\Router\RouteMatch');
-        $routeMatch->getMatchedRouteName()->willReturn('/foo');
-        $routeMatch->getParams()->willReturn([
-            'middleware' => 'bar',
-        ]);
 
-        $this->zf2Router->addRoute('/foo', [
-            'type' => 'segment',
-            'options' => [
-                'route' => '/foo',
-                'defaults' => [
-                    'middleware' => 'bar',
-                ],
-            ],
-        ])->shouldBeCalled();
-        $this->zf2Router
-            ->match(Argument::type('Zend\Http\PhpEnvironment\Request'))
-            ->willReturn($routeMatch->reveal());
-
-
-        $router = $this->getRouter();
+        $router = new Zf2Router();
         $router->addRoute(new Route('/foo', 'bar', ['POST', 'DELETE']));
-
-        $request = $this->createRequestProphecy();
-        $result = $router->match($request->reveal());
+        $request = new ServerRequest([ 'REQUEST_METHOD' => 'GET' ], [], '/foo', 'GET');
+        $result = $router->match($request);
 
         $this->assertInstanceOf('Zend\Expressive\Router\RouteResult', $result);
         $this->assertTrue($result->isFailure());

--- a/test/Router/Zf2Test.php
+++ b/test/Router/Zf2Test.php
@@ -67,7 +67,7 @@ class Zf2Test extends TestCase
                         ]
                     ]
                 ],
-                'fail' => [
+                Zf2Router::METHOD_NOT_ALLOWED_ROUTE => [
                     'type' => 'segment',
                     'priority' => -1,
                     'options' => [
@@ -118,7 +118,7 @@ class Zf2Test extends TestCase
                         ]
                     ]
                 ],
-                'fail' => [
+                Zf2Router::METHOD_NOT_ALLOWED_ROUTE => [
                     'type' => 'segment',
                     'priority' => -1,
                     'options' => [


### PR DESCRIPTION
**NOTE:** this PR needs the merge of https://github.com/zendframework/zend-psr7bridge/pull/2.

This PR fixes issue #40. I added the name of the route in Router/Route. You can specify the name as the last optional parameter in the constructor. If the name is not specified I create a new one based on the path and the HTTP methods:
```php
$this->name = empty($name) ? $path . '^' . implode('_', (array) $this->methods) : $name;
```
I also added the naming support in Application::route(). You can add a name as last parameter, for instance adding the `'foo'` name:
```php
$app->route('/foo', $middleware, [ 'GET' ], 'foo');
\\ also using direct http methods
$app->get('/foo', $middleware, 'foo');
```
We cannot have a syntax like that: 
```php
$app->get('/foo', $middleware)->setName('foo');
```
Because the `route()` method, called by `get()`, add the route to the router adapter.

For the ZF2 route adapter I used the HTTP method route and a special `'fail'` route injected in each route to manage the 405 error (Method not allowed).

I also added some tests to cover more route scenarios with or without route name.

