### PR TITLE
Support route assembly

### DIFF
--- a/src/Router/Aura.php
+++ b/src/Router/Aura.php
@@ -134,6 +134,14 @@ class Aura implements RouterInterface
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function generateUri($name, array $substitutions = [])
+    {
+        return $this->router->generate($name, $substitutions);
+    }
+
+    /**
      * Marshal a RouteResult representing a route failure.
      *
      * If the route failure is due to the HTTP method, passes the allowed

--- a/src/Router/RouterInterface.php
+++ b/src/Router/RouterInterface.php
@@ -10,6 +10,7 @@
 namespace Zend\Expressive\Router;
 
 use Psr\Http\Message\ServerRequestInterface as Request;
+use Zend\Expressive\Exception;
 
 /**
  * Interface defining required router capabilities.
@@ -26,4 +27,19 @@ interface RouterInterface
      * @return RouteResult
      */
     public function match(Request $request);
+
+    /**
+     * Generate a URI from the named route.
+     *
+     * Takes the named route and any substitutions, and attempts to generate a
+     * URI from it.
+     *
+     * @see https://github.com/auraphp/Aura.Router#generating-a-route-path
+     * @see http://framework.zend.com/manual/current/en/modules/zend.mvc.routing.html
+     * @param string $name
+     * @param array $substitutions
+     * @return string
+     * @throws Exception\RuntimeException if unable to generate the given URI.
+     */
+    public function generateUri($name, array $substitutions = []);
 }

--- a/test/Router/AuraRouteTest.php
+++ b/test/Router/AuraRouteTest.php
@@ -154,4 +154,26 @@ class AuraRouteTest extends TestCase
         $this->assertFalse($result->isMethodFailure());
         $this->assertSame([], $result->getAllowedMethods());
     }
+
+    /**
+     * @group 53
+     */
+    public function testCanGenerateUriFromRoutes()
+    {
+        $router = new AuraRouter();
+        $route1 = new Route('/foo', 'foo', ['POST'], 'foo-create');
+        $route2 = new Route('/foo', 'foo', ['GET'], 'foo-list');
+        $route3 = new Route('/foo/{id}', 'foo', ['GET'], 'foo');
+        $route4 = new Route('/bar/{baz}', 'bar', Route::HTTP_METHOD_ANY, 'bar');
+
+        $router->addRoute($route1);
+        $router->addRoute($route2);
+        $router->addRoute($route3);
+        $router->addRoute($route4);
+
+        $this->assertEquals('/foo', $router->generateUri('foo-create'));
+        $this->assertEquals('/foo', $router->generateUri('foo-list'));
+        $this->assertEquals('/foo/bar', $router->generateUri('foo', ['id' => 'bar']));
+        $this->assertEquals('/bar/BAZ', $router->generateUri('bar', ['baz' => 'BAZ']));
+    }
 }

--- a/test/Router/FastRouteTest.php
+++ b/test/Router/FastRouteTest.php
@@ -163,4 +163,26 @@ class FastRouteTest extends TestCase
         $this->assertFalse($result->isMethodFailure());
         $this->assertSame([], $result->getAllowedMethods());
     }
+
+    /**
+     * @group 53
+     */
+    public function testCanGenerateUriFromRoutes()
+    {
+        $router = new FastRoute();
+        $route1 = new Route('/foo', 'foo', ['POST'], 'foo-create');
+        $route2 = new Route('/foo', 'foo', ['GET'], 'foo-list');
+        $route3 = new Route('/foo/{id:\d+}', 'foo', ['GET'], 'foo');
+        $route4 = new Route('/bar/{baz}', 'bar', Route::HTTP_METHOD_ANY, 'bar');
+
+        $router->addRoute($route1);
+        $router->addRoute($route2);
+        $router->addRoute($route3);
+        $router->addRoute($route4);
+
+        $this->assertEquals('/foo', $router->generateUri('foo-create'));
+        $this->assertEquals('/foo', $router->generateUri('foo-list'));
+        $this->assertEquals('/foo/42', $router->generateUri('foo', ['id' => 42]));
+        $this->assertEquals('/bar/BAZ', $router->generateUri('bar', ['baz' => 'BAZ']));
+    }
 }


### PR DESCRIPTION
Allow generating URIs based on a given route specification.

- [x] Add `generateUri($name, array $substitutes = [])` to `RouterInterface`
- [x] Implement `generateUri()` for Aura router
- [x] Implement `generateUri()` for ZF2 router
- [x] Implement `generateUri()` for FastRoute router. Since this routing implementation does not include URI generation by default, this will require writing such functionality.