### PR TITLE
Changed the route name instead of path for ZF2 routes

### DIFF
--- a/test/RouteMiddlewareTest.php
+++ b/test/RouteMiddlewareTest.php
@@ -363,6 +363,7 @@ class RouteMiddlewareTest extends TestCase
         $this->assertEquals('Middleware POST', (string) $result->getBody());
     }
 
+
     /**
      * @see https://github.com/zendframework/zend-expressive/issues/40
      * @group 40

--- a/test/Router/Zf2Test.php
+++ b/test/Router/Zf2Test.php
@@ -70,6 +70,16 @@ class Zf2Test extends TestCase
                             'middleware' => 'foo',
                         ]
                     ]
+                ],
+                Zf2Router::METHOD_NOT_ALLOWED_ROUTE => [
+                    'type'     => 'segment',
+                    'priority' => -1,
+                    'options'  => [
+                        'route'    => '[/]',
+                        'defaults' => [
+                            Zf2Router::METHOD_NOT_ALLOWED_ROUTE => '/foo',
+                        ],
+                    ]
                 ]
             ]
         ])->shouldBeCalled();
@@ -110,6 +120,16 @@ class Zf2Test extends TestCase
                         'defaults' => [
                             'middleware' => 'foo',
                         ]
+                    ]
+                ],
+                Zf2Router::METHOD_NOT_ALLOWED_ROUTE => [
+                    'type'     => 'segment',
+                    'priority' => -1,
+                    'options'  => [
+                        'route'    => '[/]',
+                        'defaults' => [
+                            Zf2Router::METHOD_NOT_ALLOWED_ROUTE => '/foo/:id',
+                        ],
                     ]
                 ]
             ]
@@ -200,10 +220,25 @@ class Zf2Test extends TestCase
      */
     public function testMatchFailureDueToHttpMethodReturnsRouteResultWithAllowedMethods()
     {
-
         $router = new Zf2Router();
         $router->addRoute(new Route('/foo', 'bar', ['POST', 'DELETE']));
         $request = new ServerRequest([ 'REQUEST_METHOD' => 'GET' ], [], '/foo', 'GET');
+        $result = $router->match($request);
+
+        $this->assertInstanceOf('Zend\Expressive\Router\RouteResult', $result);
+        $this->assertTrue($result->isFailure());
+        $this->assertTrue($result->isMethodFailure());
+        $this->assertEquals(['POST', 'DELETE'], $result->getAllowedMethods());
+    }
+
+    /**
+     * @group match
+     */
+    public function testMatchFailureDueToMethodNotAllowedWithParamsInTheRoute()
+    {
+        $router = new Zf2Router();
+        $router->addRoute(new Route('/foo[/:id]', 'foo', ['POST', 'DELETE']));
+        $request = new ServerRequest([ 'REQUEST_METHOD' => 'GET' ], [], '/foo/1', 'GET');
         $result = $router->match($request);
 
         $this->assertInstanceOf('Zend\Expressive\Router\RouteResult', $result);

--- a/test/Router/Zf2Test.php
+++ b/test/Router/Zf2Test.php
@@ -37,8 +37,12 @@ class Zf2Test extends TestCase
     {
         $request = $this->prophesize('Psr\Http\Message\ServerRequestInterface');
 
+        $uri = $this->prophesize('Psr\Http\Message\UriInterface');
+        $uri->getPath()->willReturn('/foo');
+        $uri->__toString()->willReturn('http://www.example.com/foo');
+
         $request->getMethod()->willReturn('GET');
-        $request->getUri()->willReturn('https://example.com/foo');
+        $request->getUri()->willReturn($uri);
         $request->getHeaders()->willReturn([]);
         $request->getCookieParams()->willReturn([]);
         $request->getQueryParams()->willReturn([]);
@@ -51,7 +55,7 @@ class Zf2Test extends TestCase
     {
         $route = new Route('/foo', 'foo', ['GET']);
 
-        $this->zf2Router->addRoute('/foo', [
+        $this->zf2Router->addRoute('/foo^GET', [
             'type' => 'segment',
             'options' => [
                 'route' => '/foo',
@@ -64,16 +68,6 @@ class Zf2Test extends TestCase
                         'verb' => 'GET',
                         'defaults' => [
                             'middleware' => 'foo',
-                        ]
-                    ]
-                ],
-                Zf2Router::METHOD_NOT_ALLOWED_ROUTE => [
-                    'type' => 'segment',
-                    'priority' => -1,
-                    'options' => [
-                        'route' => '[/]',
-                        'defaults' => [
-                            'middleware' => null
                         ]
                     ]
                 ]
@@ -96,7 +90,7 @@ class Zf2Test extends TestCase
             ],
         ]);
 
-        $this->zf2Router->addRoute('/foo/:id', [
+        $this->zf2Router->addRoute('/foo/:id^GET', [
             'type' => 'segment',
             'options' => [
                 'route' => '/foo/:id',
@@ -115,16 +109,6 @@ class Zf2Test extends TestCase
                         'verb' => 'GET',
                         'defaults' => [
                             'middleware' => 'foo',
-                        ]
-                    ]
-                ],
-                Zf2Router::METHOD_NOT_ALLOWED_ROUTE => [
-                    'type' => 'segment',
-                    'priority' => -1,
-                    'options' => [
-                        'route' => '[/]',
-                        'defaults' => [
-                            'middleware' => null
                         ]
                     ]
                 ]
@@ -164,7 +148,7 @@ class Zf2Test extends TestCase
 
         $result = $zf2Router->match($request);
         $this->assertInstanceOf('Zend\Expressive\Router\RouteResult', $result);
-        $this->assertEquals('/foo/GET', $result->getMatchedRouteName());
+        $this->assertEquals('/foo^GET/GET', $result->getMatchedRouteName());
         $this->assertEquals($middleware, $result->getMatchedMiddleware());
     }
 


### PR DESCRIPTION
This PR changes the ZF2 routes definition using the route name instead of path. This can simplify the implementation of https://github.com/zendframework/zend-expressive/pull/53.
