### PR TITLE
404 doesn't work

### DIFF
--- a/test/RouteMiddlewareTest.php
+++ b/test/RouteMiddlewareTest.php
@@ -520,14 +520,13 @@ class RouteMiddlewareTest extends TestCase
         }, ['GET']);
 
         $next = function ($req, $res) {
-            return $res->withStatus(404);
+            return $res;
         };
 
         $request  = new ServerRequest([ 'REQUEST_METHOD' => 'GET' ], [], '/foo', 'GET');
         $response = new Response();
         $result   = $app->routeMiddleware($request, $response, $next);
         $this->assertInstanceOf(Response::class, $result);
-        $this->assertNotSame($response, $result);
-        $this->assertEquals(404, $result->getStatusCode());
+        $this->assertNotEquals(405, $result->getStatusCode());
     }
 }

--- a/test/RouteMiddlewareTest.php
+++ b/test/RouteMiddlewareTest.php
@@ -505,4 +505,29 @@ class RouteMiddlewareTest extends TestCase
         $result   = $app->routeMiddleware($request, $response, $next);
         $this->assertEquals('Middleware', (string) $result->getBody());
     }
+
+    /**
+     * @dataProvider routerAdapters
+     * @group 74
+     */
+    public function testWithOnlyRootPathRouteDefinedRoutingToSubPathsShouldReturn404($adapter)
+    {
+        $app = new Application(new $adapter);
+
+        $app->route('/', function ($req, $res, $next) {
+            $res->getBody()->write('Middleware');
+            return $res;
+        }, ['GET']);
+
+        $next = function ($req, $res) {
+            return $res->withStatus(404);
+        };
+
+        $request  = new ServerRequest([ 'REQUEST_METHOD' => 'GET' ], [], '/foo', 'GET');
+        $response = new Response();
+        $result   = $app->routeMiddleware($request, $response, $next);
+        $this->assertInstanceOf(Response::class, $result);
+        $this->assertNotSame($response, $result);
+        $this->assertEquals(404, $result->getStatusCode());
+    }
 }


### PR DESCRIPTION
For example, I have routes:
```
    'routes' => [
        [
            'path' => '/',
            'middleware' => 'Application\HelloWorld',
            'allowed_methods' => [ 'GET' ],
        ],
   ],

```
and it means, that / is accessible. but when I access /foo, I got 405 method not allowed. I am using default `Application` implementation, that should be Aura route.