### PR TITLE
App does not route by default

### DIFF
--- a/doc/book/router.aura.md
+++ b/doc/book/router.aura.md
@@ -61,6 +61,30 @@ $router = new AuraBridge($auraRouter);
 $app = AppFactory::create(null, $router);
 ```
 
+> ### Piping the route middleware
+>
+> If you programmatically configure the router and add routes without using
+> `Application::route()`, you may run into issues with the order in which piped
+> middleware (middleware added to the application via the `pipe()` method) is
+> executed.
+>
+> To ensure that everything executes in the correct order, you can call
+> `Application::pipeRouteMiddleware()` at any time to pipe it to the
+> application. As an example, after you have created your application
+> instance:
+>
+> ```php
+> $app->pipe($middlewareToExecuteFirst);
+> $app->pipeRouteMiddleware();
+> $app->pipe($errorMiddleware);
+> ```
+>
+> If you fail to add any routes via `Application::route()` or to call
+> `Application::pipeRouteMiddleware()`, the routing middleware will be called
+> when executing the application. **This means that it will be last in the
+> middleware pipeline,** which means that if you registered any error
+> middleware, it can never be invoked.
+
 ## Factory-Driven Creation
 
 We recommend using an Inversion of Control container for your applications;

--- a/doc/book/router.fast-route.md
+++ b/doc/book/router.fast-route.md
@@ -60,6 +60,30 @@ $router = new FastRouteBridge($fastRoute, $getDispatcher);
 $app = AppFactory::create(null, $router);
 ```
 
+> ### Piping the route middleware
+>
+> If you programmatically configure the router and add routes without using
+> `Application::route()`, you may run into issues with the order in which piped
+> middleware (middleware added to the application via the `pipe()` method) is
+> executed.
+>
+> To ensure that everything executes in the correct order, you can call
+> `Application::pipeRouteMiddleware()` at any time to pipe it to the
+> application. As an example, after you have created your application
+> instance:
+>
+> ```php
+> $app->pipe($middlewareToExecuteFirst);
+> $app->pipeRouteMiddleware();
+> $app->pipe($errorMiddleware);
+> ```
+>
+> If you fail to add any routes via `Application::route()` or to call
+> `Application::pipeRouteMiddleware()`, the routing middleware will be called
+> when executing the application. **This means that it will be last in the
+> middleware pipeline,** which means that if you registered any error
+> middleware, it can never be invoked.
+
 ## Factory-Driven Creation
 
 We recommend using an Inversion of Control container for your applications;

--- a/doc/book/router.zf2.md
+++ b/doc/book/router.zf2.md
@@ -73,6 +73,30 @@ $router = new Zf2Bridge($zf2Router);
 $app = AppFactory::create(null, $router);
 ```
 
+> ### Piping the route middleware
+>
+> If you programmatically configure the router and add routes without using
+> `Application::route()`, you may run into issues with the order in which piped
+> middleware (middleware added to the application via the `pipe()` method) is
+> executed.
+>
+> To ensure that everything executes in the correct order, you can call
+> `Application::pipeRouteMiddleware()` at any time to pipe it to the
+> application. As an example, after you have created your application
+> instance:
+>
+> ```php
+> $app->pipe($middlewareToExecuteFirst);
+> $app->pipeRouteMiddleware();
+> $app->pipe($errorMiddleware);
+> ```
+>
+> If you fail to add any routes via `Application::route()` or to call
+> `Application::pipeRouteMiddleware()`, the routing middleware will be called
+> when executing the application. **This means that it will be last in the
+> middleware pipeline,** which means that if you registered any error
+> middleware, it can never be invoked.
+
 ## Factory-Driven Creation
 
 We recommend using an Inversion of Control container for your applications;

--- a/src/Application.php
+++ b/src/Application.php
@@ -114,6 +114,7 @@ class Application extends MiddlewarePipe
      */
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $out = null)
     {
+        $this->pipeRoutingMiddleware();
         $out = $out ?: $this->getFinalHandler($response);
         return parent::__invoke($request, $response, $out);
     }
@@ -182,6 +183,17 @@ class Application extends MiddlewarePipe
         }
 
         return $this;
+    }
+
+    /**
+     * Register the routing middleware in the middleware pipeline.
+     */
+    public function pipeRoutingMiddleware()
+    {
+        if ($this->routeMiddlewareIsRegistered) {
+            return;
+        }
+        $this->pipe([$this, 'routeMiddleware']);
     }
 
     /**
@@ -297,10 +309,7 @@ class Application extends MiddlewarePipe
 
         $this->routes[] = $route;
         $this->router->addRoute($route);
-
-        if (! $this->routeMiddlewareIsRegistered) {
-            $this->pipe([$this, 'routeMiddleware']);
-        }
+        $this->pipeRoutingMiddleware();
 
         return $route;
     }

--- a/src/Container/ApplicationFactory.php
+++ b/src/Container/ApplicationFactory.php
@@ -187,6 +187,7 @@ class ApplicationFactory
     {
         $config = $container->has('Config') ? $container->get('Config') : [];
         if (! isset($config['routes'])) {
+            $app->pipeRoutingMiddleware();
             return;
         }
 


### PR DESCRIPTION
Hi,

I had trouble with figuring out how to set up a separate `/api` middleware pipe.
My system set up:

1. A `root` middleware pipe (Zend\Expressive\Application) with a `home` route `/` serving the layout + assets for a SPA.
2. A `API` middleware pipe (also Zend\Expressive\Application) with a programmatic created router following the [docs](https://github.com/zendframework/zend-expressive/blob/master/doc/book/router.aura.md#programmatic-creation)

This is how my `index.php` initializes the pipes:

```php
$services = new \Zend\ServiceManager\ServiceManager(new \Zend\ServiceManager\Config(require 'config/services.php'));

$app = $services->get('Zend\Expressive\Application');

$cargoBackend = $services->get('cargo.backend');

$app->pipe('/api', $cargoBackend);

$app->run();
```

And this is the factory responsible for the `cargo.backend` middleware pipe:

```php
    public function __invoke(ContainerInterface $container)
    {
        $router = $container->get('cargo.backend.router');

        $app = AppFactory::create($container, $router);

        //This is the problem a want to address with the issue!!!
        $app->pipe("/", [$app, 'routeMiddleware']);

        return $app;
    }
```

I was not aware that I have to pipe the router manually when using the `AppFactory`. When passing a router to it I expect that the router gets activated automatically by the factory.
I would like to submit a PR that fixes the problem, but want to ask first if this would have side effects 
and if such a change is wanted/needed? Otherwise we should document it. The cookbook would be a good place.

I have a second problem but currently don't know what causes it:
Before I added the line `$app->pipe("/", [$app, 'routeMiddleware'])` to the factory my route was not invoked (`/api/locations`) but I got an empty response with a `200 ok status code` instead of a `404 not found`. Maybe this happens because the `api app` is set up with its own `emitter` and `final handler` by default, so the `final handler` of the `root app` is not invoked?

