### PR TITLE
Inconsistent service name for config

### DIFF
--- a/doc/book/error-handling.md
+++ b/doc/book/error-handling.md
@@ -113,10 +113,10 @@ container implementations to simplify setup.
 ### WhoopsPageHandlerFactory
 
 > - Register this factory as `Zend\Expressive\WhoopsPageHandler`.
-> - This service optionally consumes the service `Config`
+> - This service optionally consumes the service `config`
 
 `Zend\Expressive\Container\WhoopsPageHandlerFactory` will create and return a
-`Whoops\Handler\PrettyPageHandler` instance. If the `Config` service is also defined, and returns an
+`Whoops\Handler\PrettyPageHandler` instance. If the `config` service is also defined, and returns an
 array with the following structure:
 
 ```php
@@ -132,7 +132,7 @@ the output that will open the editor with the file).
 
 > - Register this factory as `Zend\Expressive\Whoops`.
 > - This factory requires and consumes a service named `Zend\Expressive\WhoopsPageHandler`, and
->   optionally the service `Config`.
+>   optionally the service `config`.
 
 `Zend\Expressive\Container\WhoopsFactory` will create and return a `Whoops\Run` instance. It will
 inject the `Zend\Expressive\WhoopsPageHandler` as a handler. Additionally, it calls the following
@@ -142,7 +142,7 @@ methods with the specified arguments:
 - `allowQuit(false)`
 - `register()`
 
-If the `Config` service is defined, and has the following structure:
+If the `config` service is defined, and has the following structure:
 
 ```php
 'whoops' => [
@@ -162,7 +162,7 @@ configured per the settings provided.
 > - Register this factory as `Zend\Expressive\FinalHandler`.
 > - This factory requires and consumes the services `Zend\Expressive\Whoops` and
 >   `Zend\Expressive\WhoopsPageHandler`, and optionally the services
->   `Zend\Expressive\Template\TemplateInterface` and `Config`.
+>   `Zend\Expressive\Template\TemplateInterface` and `config`.
 
 `Zend\Expressive\Container\WhoopsErrorHandlerFactory` creates and returns an instance of
 `Zend\Expressive\WhoopsErrorHandler`, injecting it with the services `Zend\Expressive\Whoops` and
@@ -171,7 +171,7 @@ configured per the settings provided.
 If the `Zend\Expressive\Template\TemplateInterface` service is available, that, too, will be
 injected.
 
-If the `Config` service is available, and contains the following structure:
+If the `config` service is available, and contains the following structure:
 
 ```php
 'zend-expressive' => [
@@ -188,14 +188,14 @@ then the factory will inject the values for the given templates.
 
 > - Register this factory as `Zend\Expressive\FinalHandler`.
 > - This factory optionally consumes the services `Zend\Expressive\Template\TemplateInterface` and
->   `Config`.
+>   `config`.
 
 `Zend\Expressive\Container\TemplatedErrorHandlerFactory` creates and returns an instance of
 `Zend\Expressive\TemplatedErrorHandler`.
 
 If the `Zend\Expressive\Template\TemplateInterface` service is available, it will be injected.
 
-If the `Config` service is available, and contains the following structure:
+If the `config` service is available, and contains the following structure:
 
 ```php
 'zend-expressive' => [
@@ -219,10 +219,10 @@ so via configuration.
 use Zend\Expressive\Template\Plates;
 
 // For all examples:
-$services->setService('Config', $config);
+$services->setService('config', $config);
 $services->setFactory('Zend\Expressive\Template\TemplateInterface', function ($container) {
     $plates = new Plates();
-    $plates->addPath($container->get('Config')['templates']['error'], 'error');
+    $plates->addPath($container->get('config')['templates']['error'], 'error');
     
     return $plates;
 });
@@ -258,7 +258,7 @@ return [
             'Zend\Expressive\Application' => 'Zend\Expressive\Container\ApplicationFactory',
             'Zend\Expressive\Template\TemplateInterface' => function ($container) {
                 $plates = new Plates();
-                $plates->addPath($container->get('Config')['templates']['error'], 'error');
+                $plates->addPath($container->get('config')['templates']['error'], 'error');
                 
                 return $plates;
             },
@@ -295,7 +295,7 @@ use Zend\ServiceManager\ServiceManager;
 
 $config    = include 'config/config.php';
 $container = new ServiceManager(new Config($config));
-$container->setService('Config', $config);
+$container->setService('config', $config);
 
 $app = $container->get('Zend\Expressive\Application');
 $app->run();
@@ -328,11 +328,11 @@ use Zend\Expressive\Template\Plates;
 
 $pimple = new Pimple()
 
-$pimple['Config'] = $config;
+$pimple['config'] = $config;
 $pimple['Zend\Expressive\Application'] = new Container\ApplicationFactory();
 $pimple['Zend\Expressive\Template\TemplateInterface'] = function ($container) {
     $plates = new Plates();
-    $plates->addPath($container->get('Config')['templates']['error'], 'error');
+    $plates->addPath($container->get('config')['templates']['error'], 'error');
     
     return $plates;
 };

--- a/src/Container/ApplicationFactory.php
+++ b/src/Container/ApplicationFactory.php
@@ -24,17 +24,17 @@ use Zend\Expressive\Router\RouterInterface;
  *
  * This factory uses the following services, if available:
  *
- * - Zend\Expressive\Router\RouterInterface. If missing, an Aura router bridge
+ * - 'Zend\Expressive\Router\RouterInterface'. If missing, an Aura router bridge
  *   will be instantiated and used.
- * - Zend\Expressive\FinalHandler. The service should be a callable to use as
+ * - 'Zend\Expressive\FinalHandler'. The service should be a callable to use as
  *   the final handler when the middleware pipeline is exhausted.
- * - Zend\Diactoros\Response\EmitterInterface. If missing, an EmitterStack is
+ * - 'Zend\Diactoros\Response\EmitterInterface'. If missing, an EmitterStack is
  *   created, adding a SapiEmitter to the bottom of the stack.
- * - Config (an array or ArrayAccess object). If present, and it contains route
+ * - 'config' (an array or ArrayAccess object). If present, and it contains route
  *   definitions, these will be used to seed routes in the Application instance
  *   before returning it.
  *
- * When introspecting the `Config` service, the following structure can be used
+ * When introspecting the `config` service, the following structure can be used
  * to define routes:
  *
  * <code>
@@ -185,7 +185,7 @@ class ApplicationFactory
      */
     private function injectRoutes(Application $app, ContainerInterface $container)
     {
-        $config = $container->has('Config') ? $container->get('Config') : [];
+        $config = $container->has('config') ? $container->get('config') : [];
         if (! isset($config['routes'])) {
             $app->pipeRoutingMiddleware();
             return;
@@ -318,7 +318,7 @@ class ApplicationFactory
      */
     private function injectPreMiddleware(Application $app, ContainerInterface $container)
     {
-        $config = $container->has('Config') ? $container->get('Config') : [];
+        $config = $container->has('config') ? $container->get('config') : [];
         if (! isset($config['middleware_pipeline']['pre_routing']) ||
             ! is_array($config['middleware_pipeline']['pre_routing'])
         ) {
@@ -339,7 +339,7 @@ class ApplicationFactory
      */
     private function injectPostMiddleware(Application $app, ContainerInterface $container)
     {
-        $config = $container->has('Config') ? $container->get('Config') : [];
+        $config = $container->has('config') ? $container->get('config') : [];
         if (! isset($config['middleware_pipeline']['post_routing']) ||
             ! is_array($config['middleware_pipeline']['post_routing'])
         ) {

--- a/src/Container/TemplatedErrorHandlerFactory.php
+++ b/src/Container/TemplatedErrorHandlerFactory.php
@@ -20,10 +20,10 @@ use Zend\Expressive\TemplatedErrorHandler;
  *
  * This factory has optional dependencies on the following services:
  *
- * - Zend\Expressive\Template\TemplateInterface, which should return an
+ * - 'Zend\Expressive\Template\TemplateInterface', which should return an
  *   implementation of that interface. If not present, the error handler
  *   will not create templated responses.
- * - Config (which should return an array or array-like object with a
+ * - 'config' (which should return an array or array-like object with a
  *   "zend-expressive" top-level key, and an "error_handler" subkey,
  *   containing the configuration for the error handler).
  *
@@ -48,8 +48,8 @@ class TemplatedErrorHandlerFactory
             ? $container->get('Zend\Expressive\Template\TemplateInterface')
             : null;
 
-        $config = $container->has('Config')
-            ? $container->get('Config')
+        $config = $container->has('config')
+            ? $container->get('config')
             : [];
 
         $config = isset($config['zend-expressive']['error_handler'])

--- a/src/Container/WhoopsErrorHandlerFactory.php
+++ b/src/Container/WhoopsErrorHandlerFactory.php
@@ -20,10 +20,10 @@ use Zend\Expressive\WhoopsErrorHandler;
  *
  * This factory has optional dependencies on the following services:
  *
- * - Zend\Expressive\Template\TemplateInterface, which should return an
+ * - 'Zend\Expressive\Template\TemplateInterface', which should return an
  *   implementation of that interface. If not present, the error handler
  *   will not create templated responses.
- * - Config (which should return an array or array-like object with a
+ * - 'config' (which should return an array or array-like object with a
  *   "zend-expressive" top-level key, and an "error_handler" subkey,
  *   containing the configuration for the error handler).
  *
@@ -54,8 +54,8 @@ class WhoopsErrorHandlerFactory
             ? $container->get('Zend\Expressive\Template\TemplateInterface')
             : null;
 
-        $config = $container->has('Config')
-            ? $container->get('Config')
+        $config = $container->has('config')
+            ? $container->get('config')
             : [];
 
         $config = isset($config['zend-expressive']['error_handler'])

--- a/src/Container/WhoopsFactory.php
+++ b/src/Container/WhoopsFactory.php
@@ -19,9 +19,9 @@ use Whoops\Run as Whoops;
  * Register this factory as the service `Zend\Expressive\Whoops` in the
  * container of your choice. This service depends on two others:
  *
- * - Config (which should return an array or array-like object with a "whoops"
+ * - 'config' (which should return an array or array-like object with a "whoops"
  *   key, containing the configuration for whoops).
- * - Zend\Expressive\WhoopsPageHandler, which should return a
+ * - 'Zend\Expressive\WhoopsPageHandler', which should return a
  *   Whoops\Handler\PrettyPageHandler instance to register on the whoops
  *   instance.
  *
@@ -49,7 +49,7 @@ class WhoopsFactory
      */
     public function __invoke(ContainerInterface $container)
     {
-        $config = $container->has('Config') ? $container->get('Config') : [];
+        $config = $container->has('config') ? $container->get('config') : [];
         $config = isset($config['whoops']) ? $config['whoops'] : [];
 
         $whoops = new Whoops();

--- a/src/Container/WhoopsPageHandlerFactory.php
+++ b/src/Container/WhoopsPageHandlerFactory.php
@@ -18,7 +18,7 @@ use Whoops\Handler\PrettyPageHandler;
  * Register this factory as the service `Zend\Expressive\WhoopsPageHandler` in
  * the container of your choice.
  *
- * This service has an optional dependency on the "Config" service, which should
+ * This service has an optional dependency on the "config" service, which should
  * return an array or ArrayAccess instance. If found, it looks for the following
  * structure:
  *
@@ -39,7 +39,7 @@ class WhoopsPageHandlerFactory
      */
     public function __invoke(ContainerInterface $container)
     {
-        $config = $container->has('Config') ? $container->get('Config') : [];
+        $config = $container->has('config') ? $container->get('config') : [];
         $config = isset($config['whoops']) ? $config['whoops'] : [];
 
         $pageHandler = new PrettyPageHandler();

--- a/test/Container/ApplicationFactoryTest.php
+++ b/test/Container/ApplicationFactoryTest.php
@@ -95,7 +95,7 @@ class ApplicationFactoryTest extends TestCase
             ->willReturn($finalHandler);
 
         $this->container
-            ->has('Config')
+            ->has('config')
             ->willReturn(false);
 
         $app = $this->factory->__invoke($this->container->reveal());
@@ -155,11 +155,11 @@ class ApplicationFactoryTest extends TestCase
             ->willReturn($finalHandler);
 
         $this->container
-            ->has('Config')
+            ->has('config')
             ->willReturn(true);
 
         $this->container
-            ->get('Config')
+            ->get('config')
             ->willReturn($config);
 
         $app = $this->factory->__invoke($this->container->reveal());
@@ -197,7 +197,7 @@ class ApplicationFactoryTest extends TestCase
             ->shouldNotBeCalled();
 
         $this->container
-            ->has('Config')
+            ->has('config')
             ->willReturn(false);
 
         $app = $this->factory->__invoke($this->container->reveal());
@@ -267,11 +267,11 @@ class ApplicationFactoryTest extends TestCase
             ->willReturn($finalHandler);
 
         $this->container
-            ->has('Config')
+            ->has('config')
             ->willReturn(true);
 
         $this->container
-            ->get('Config')
+            ->get('config')
             ->willReturn($config);
 
         $app = $this->factory->__invoke($this->container->reveal());
@@ -355,11 +355,11 @@ class ApplicationFactoryTest extends TestCase
             ->willReturn($finalHandler);
 
         $this->container
-            ->has('Config')
+            ->has('config')
             ->willReturn(true);
 
         $this->container
-            ->get('Config')
+            ->get('config')
             ->willReturn($config);
 
         $app = $this->factory->__invoke($this->container->reveal());
@@ -437,11 +437,11 @@ class ApplicationFactoryTest extends TestCase
             ->willReturn($finalHandler);
 
         $this->container
-            ->has('Config')
+            ->has('config')
             ->willReturn(true);
 
         $this->container
-            ->get('Config')
+            ->get('config')
             ->willReturn($config);
 
         $this->container
@@ -539,11 +539,11 @@ class ApplicationFactoryTest extends TestCase
             ->willReturn($finalHandler);
 
         $this->container
-            ->has('Config')
+            ->has('config')
             ->willReturn(true);
 
         $this->container
-            ->get('Config')
+            ->get('config')
             ->willReturn($config);
 
         $this->setExpectedException('Zend\Expressive\Exception\InvalidMiddlewareException');
@@ -595,11 +595,11 @@ class ApplicationFactoryTest extends TestCase
             ->willReturn($finalHandler);
 
         $this->container
-            ->has('Config')
+            ->has('config')
             ->willReturn(true);
 
         $this->container
-            ->get('Config')
+            ->get('config')
             ->willReturn($config);
 
         $this->container
@@ -657,11 +657,11 @@ class ApplicationFactoryTest extends TestCase
             ->willReturn($finalHandler);
 
         $this->container
-            ->has('Config')
+            ->has('config')
             ->willReturn(true);
 
         $this->container
-            ->get('Config')
+            ->get('config')
             ->willReturn($config);
 
         $this->container
@@ -748,11 +748,11 @@ class ApplicationFactoryTest extends TestCase
             ->willReturn($finalHandler);
 
         $this->container
-            ->has('Config')
+            ->has('config')
             ->willReturn(true);
 
         $this->container
-            ->get('Config')
+            ->get('config')
             ->willReturn($config);
 
         $app = $this->factory->__invoke($this->container->reveal());
@@ -814,11 +814,11 @@ class ApplicationFactoryTest extends TestCase
             ->willReturn($finalHandler);
 
         $this->container
-            ->has('Config')
+            ->has('config')
             ->willReturn(true);
 
         $this->container
-            ->get('Config')
+            ->get('config')
             ->willReturn($config);
 
         $this->container
@@ -901,11 +901,11 @@ class ApplicationFactoryTest extends TestCase
             ->willReturn($finalHandler);
 
         $this->container
-            ->has('Config')
+            ->has('config')
             ->willReturn(true);
 
         $this->container
-            ->get('Config')
+            ->get('config')
             ->willReturn($config);
 
         $app = $this->factory->__invoke($this->container->reveal());

--- a/test/Container/TemplatedErrorHandlerFactoryTest.php
+++ b/test/Container/TemplatedErrorHandlerFactoryTest.php
@@ -25,7 +25,7 @@ class TemplatedErrorHandlerFactoryTest extends TestCase
     public function testReturnsATemplatedErrorHandler()
     {
         $this->container->has(TemplateInterface::class)->willReturn(false);
-        $this->container->has('Config')->willReturn(false);
+        $this->container->has('config')->willReturn(false);
 
         $factory = $this->factory;
         $result  = $factory($this->container->reveal());
@@ -37,7 +37,7 @@ class TemplatedErrorHandlerFactoryTest extends TestCase
         $template = $this->prophesize(TemplateInterface::class);
         $this->container->has(TemplateInterface::class)->willReturn(true);
         $this->container->get(TemplateInterface::class)->willReturn($template->reveal());
-        $this->container->has('Config')->willReturn(false);
+        $this->container->has('config')->willReturn(false);
 
         $factory = $this->factory;
         $result  = $factory($this->container->reveal());
@@ -52,8 +52,8 @@ class TemplatedErrorHandlerFactoryTest extends TestCase
             'template_error' => 'error::500',
         ]]];
         $this->container->has(TemplateInterface::class)->willReturn(false);
-        $this->container->has('Config')->willReturn(true);
-        $this->container->get('Config')->willReturn($config);
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn($config);
 
         $factory = $this->factory;
         $result  = $factory($this->container->reveal());

--- a/test/Container/WhoopsErrorHandlerFactoryTest.php
+++ b/test/Container/WhoopsErrorHandlerFactoryTest.php
@@ -33,7 +33,7 @@ class WhoopsErrorHandlerFactoryTest extends TestCase
     public function testReturnsAWhoopsErrorHandler()
     {
         $this->container->has(TemplateInterface::class)->willReturn(false);
-        $this->container->has('Config')->willReturn(false);
+        $this->container->has('config')->willReturn(false);
 
         $factory = $this->factory;
         $result  = $factory($this->container->reveal());
@@ -45,7 +45,7 @@ class WhoopsErrorHandlerFactoryTest extends TestCase
         $template = $this->prophesize(TemplateInterface::class);
         $this->container->has(TemplateInterface::class)->willReturn(true);
         $this->container->get(TemplateInterface::class)->willReturn($template->reveal());
-        $this->container->has('Config')->willReturn(false);
+        $this->container->has('config')->willReturn(false);
 
         $factory = $this->factory;
         $result  = $factory($this->container->reveal());
@@ -60,8 +60,8 @@ class WhoopsErrorHandlerFactoryTest extends TestCase
             'template_error' => 'error::500',
         ]]];
         $this->container->has(TemplateInterface::class)->willReturn(false);
-        $this->container->has('Config')->willReturn(true);
-        $this->container->get('Config')->willReturn($config);
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn($config);
 
         $factory = $this->factory;
         $result  = $factory($this->container->reveal());

--- a/test/Container/WhoopsFactoryTest.php
+++ b/test/Container/WhoopsFactoryTest.php
@@ -48,7 +48,7 @@ class WhoopsFactoryTest extends TestCase
 
     public function testReturnsAWhoopsRuntimeWithPageHandlerComposed()
     {
-        $this->container->has('Config')->willReturn(false);
+        $this->container->has('config')->willReturn(false);
         $factory = $this->factory;
         $result  = $factory($this->container->reveal());
         $this->assertInstanceOf(Whoops::class, $result);
@@ -58,8 +58,8 @@ class WhoopsFactoryTest extends TestCase
     public function testWillInjectJsonResponseHandlerIfConfigurationExpectsIt()
     {
         $config = ['whoops' => ['json_exceptions' => ['display' => true]]];
-        $this->container->has('Config')->willReturn(true);
-        $this->container->get('Config')->willReturn($config);
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn($config);
 
         $factory = $this->factory;
         $result  = $factory($this->container->reveal());
@@ -78,8 +78,8 @@ class WhoopsFactoryTest extends TestCase
             'show_trace' => true,
             'ajax_only'  => true,
         ]]];
-        $this->container->has('Config')->willReturn(true);
-        $this->container->get('Config')->willReturn($config);
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn($config);
 
         $factory = $this->factory;
         $whoops  = $factory($this->container->reveal());

--- a/test/Container/WhoopsPageHandlerFactoryTest.php
+++ b/test/Container/WhoopsPageHandlerFactoryTest.php
@@ -26,7 +26,7 @@ class WhoopsPageHandlerFactoryTest extends TestCase
 
     public function testReturnsAPrettyPageHandler()
     {
-        $this->container->has('Config')->willReturn(false);
+        $this->container->has('config')->willReturn(false);
         $factory = $this->factory;
 
         $result = $factory($this->container->reveal());
@@ -36,8 +36,8 @@ class WhoopsPageHandlerFactoryTest extends TestCase
     public function testWillInjectStringEditor()
     {
         $config = ['whoops' => ['editor' => 'emacs']];
-        $this->container->has('Config')->willReturn(true);
-        $this->container->get('Config')->willReturn($config);
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn($config);
         $this->container->has('emacs')->willReturn(false);
 
         $factory = $this->factory;
@@ -50,8 +50,8 @@ class WhoopsPageHandlerFactoryTest extends TestCase
     {
         $config = ['whoops' => ['editor' => function () {
         }]];
-        $this->container->has('Config')->willReturn(true);
-        $this->container->get('Config')->willReturn($config);
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn($config);
         $factory = $this->factory;
 
         $result = $factory($this->container->reveal());
@@ -64,8 +64,8 @@ class WhoopsPageHandlerFactoryTest extends TestCase
         $config = ['whoops' => ['editor' => 'custom']];
         $editor = function () {
         };
-        $this->container->has('Config')->willReturn(true);
-        $this->container->get('Config')->willReturn($config);
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn($config);
         $this->container->has('custom')->willReturn(true);
         $this->container->get('custom')->willReturn($editor);
 
@@ -95,8 +95,8 @@ class WhoopsPageHandlerFactoryTest extends TestCase
     public function testInvalidEditorWillRaiseException($editor)
     {
         $config = ['whoops' => ['editor' => $editor]];
-        $this->container->has('Config')->willReturn(true);
-        $this->container->get('Config')->willReturn($config);
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn($config);
 
         $factory = $this->factory;
 


### PR DESCRIPTION
Today we tried to find out what is the most common name to register the application configuration in the container. In ZF2 you find three versions: `Config`, `config` and `configuration`.
The first two equal to the same service name because zend-servicemanager normalizes it. The latter is an alias for `Config`.
Looking at zend-expressive we recognized that it again uses the normalization "feature": 
https://github.com/zendframework/zend-expressive/blob/master/src/Container/ApplicationFactory.php#L188

Note that `Config` is used but the docs give an example with `config` as service name:
https://github.com/zendframework/zend-expressive/blob/master/doc/book/usage-examples.md#hello-world-using-a-configuration-driven-container

So docs + ApplicationFactory will only work as long as you use zend-servicemanager as container.
Otherwise, it will fail silently.
We should change that. But which version do you prefer?


