### PR TITLE
add null| to docblock to $namespace property

### DIFF
--- a/src/Template/TemplatePath.php
+++ b/src/Template/TemplatePath.php
@@ -17,7 +17,7 @@ class TemplatePath
     protected $path;
 
     /**
-     * @var string
+     * @var null|string
      */
     protected $namespace;
 


### PR DESCRIPTION
as `getNamespace()` may be return null.