### PR TITLE
added cookbook for set up custom 404 page

### DIFF
--- a/doc/book/cookbook.md
+++ b/doc/book/cookbook.md
@@ -253,16 +253,8 @@ class NotFound
 }
 ```
 
-After it, we need to register the middleware into `invokables` type in our service config:
+> We can register the `Application\NotFound` instance as a service in [service container](https://github.com/zendframework/zend-expressive/blob/master/doc/book/container/intro.md).
 
-```php
-//... config/services.php
-    'invokables' => [
-        // ...
-        'Application\NotFound' => 'Application\NotFound',
-    ],
-//...
-```
 Now, we can configure the `middleware_pipeline` under `post_routing`:
 
 ```php

--- a/doc/book/cookbook.md
+++ b/doc/book/cookbook.md
@@ -48,6 +48,7 @@ The above works, because every `Application` instance is itself middleware, and,
 an instance of [Stratigility's `MiddlewarePipe`](https://github.com/zendframework/zend-stratigility/blob/master/doc/book/middleware.md),
 which provides the ability to compose middleware.
 
+<<<<<<< HEAD
 ## How can I specify a route-specific middleware pipeline?
 
 Sometimes you may want to use a middleware pipeline only if a particular route
@@ -234,8 +235,11 @@ return [
 ```
 
 ## How can I set 404 page?
+=======
+## How can I set custom 404 page handling?
+>>>>>>> wording current 404 for custom
 
-We can set 404 page with create new Middleware that set 404 status from response object.
+We can set custom 404 page handling with create new Middleware that set 404 status from response object, or do logging.
 
 Let's create a `NotFound` middleware:
 
@@ -248,6 +252,7 @@ class NotFound
 {
     public function __invoke($req, $res, $next)
     {
+        // other things can be done here, for eg: logging
         return $next($req, $res->withStatus(404), 'Page Not Found');
     }
 }

--- a/doc/book/cookbook.md
+++ b/doc/book/cookbook.md
@@ -48,7 +48,6 @@ The above works, because every `Application` instance is itself middleware, and,
 an instance of [Stratigility's `MiddlewarePipe`](https://github.com/zendframework/zend-stratigility/blob/master/doc/book/middleware.md),
 which provides the ability to compose middleware.
 
-<<<<<<< HEAD
 ## How can I specify a route-specific middleware pipeline?
 
 Sometimes you may want to use a middleware pipeline only if a particular route
@@ -234,10 +233,7 @@ return [
 ];
 ```
 
-## How can I set 404 page?
-=======
 ## How can I set custom 404 page handling?
->>>>>>> wording current 404 for custom
 
 We can set custom 404 page handling instead of [using the final handler](http://zend-expressive.readthedocs.org/en/latest/error-handling/) for logging or other purpose with create new middleware that we want to intercept if no other middleware has executed, and is indicate a "not found" situation.
 

--- a/doc/book/cookbook.md
+++ b/doc/book/cookbook.md
@@ -239,7 +239,7 @@ return [
 ## How can I set custom 404 page handling?
 >>>>>>> wording current 404 for custom
 
-We can set custom 404 page handling with create new Middleware that set 404 status from response object, or do logging.
+We can set custom 404 page handling instead of [using the final handler](http://zend-expressive.readthedocs.org/en/latest/error-handling/) for logging or other purpose with create new middleware that we want to intercept if no other middleware has executed, and is indicate a "not found" situation.
 
 Let's create a `NotFound` middleware:
 

--- a/doc/book/cookbook.md
+++ b/doc/book/cookbook.md
@@ -228,7 +228,62 @@ return [
                     'ValidationMiddleware',
                 ],
             ],
-        ], 
+        ],
     ],
 ];
+```
+
+## How can I set 404 page?
+
+We can set 404 page with create new Middleware that set 404 status from response object.
+
+Let's create a `NotFound` middleware:
+
+```php
+namespace Application;
+
+use Zend\Expressive\Template\TemplateInterface;
+
+class NotFound
+{
+    public function __invoke($req, $res, $next)
+    {
+        return $next($req, $res->withStatus(404), 'Page Not Found');
+    }
+}
+```
+
+After it, we need to register the middleware into `invokables` type in our service config:
+
+```php
+//... config/services.php
+    'invokables' => [
+        // ...
+        'Application\NotFound' => 'Application\NotFound',
+    ],
+//...
+```
+Now, we can configure the `middleware_pipeline` under `post_routing`:
+
+```php
+'middleware_pipeline' => [
+    'pre_routing' => [
+        [
+            //...
+        ],
+
+    ],
+    'post_routing' => [
+        [
+            'middleware' => 'Application\NotFound',
+        ],
+    ],
+],
+```
+
+The other thing that we can do is programmatically pipe in `public/index.php`:
+
+```php
+$app->pipe($services->get('Application\NotFound'));
+$app->run();
 ```


### PR DESCRIPTION
@weierophinney this is what I can get from your site: https://github.com/weierophinney/mwop.net/blob/master/config/autoload/global.php . Still not sure about using 404 page with `WhoopsErrorHandler` or `TemplatedErrorHandler`. 

Note:
defining `'error' => true` in `middleware_pipeline` config make it not working. Please let me know if I missed something. Thanks.