### PR TITLE
Allow providing route names via configuration

### DIFF
--- a/src/Container/ApplicationFactory.php
+++ b/src/Container/ApplicationFactory.php
@@ -199,7 +199,8 @@ class ApplicationFactory
             $methods = (isset($spec['allowed_methods']) && is_array($spec['allowed_methods']))
                 ? $spec['allowed_methods']
                 : null;
-            $route = $app->route($spec['path'], $spec['middleware'], $methods);
+            $name    = isset($spec['name']) ? $spec['name'] : null;
+            $route   = $app->route($spec['path'], $spec['middleware'], $methods, $name);
 
             if (isset($spec['options']) && is_array($spec['options'])) {
                 $route->setOptions($spec['options']);


### PR DESCRIPTION
New config key in a route definition: "name"; if present, it will be used to set the route name.