### PR TITLE
Aura\Router error with no get('/') registered

### DIFF
--- a/src/Router/Aura.php
+++ b/src/Router/Aura.php
@@ -152,6 +152,12 @@ class Aura implements RouterInterface
     private function marshalFailedRoute(Request $request)
     {
         $failedRoute = $this->router->getFailedRoute();
+
+        // Evidently, getFailedRoute() can sometimes return null; these are 404 conditions.
+        if (null === $failedRoute) {
+            return RouteResult::fromRouteFailure();
+        }
+
         if ($failedRoute->failedMethod()) {
             return RouteResult::fromRouteFailure($failedRoute->method);
         }


### PR DESCRIPTION
```Fatal error: Call to a member function failedMethod() on null in vendor\zendframework\zend-expressive\src\Router\Aura.php on line 156```