### PR TITLE
Implement middleware lazy-loading

### DIFF
--- a/doc/book/application.md
+++ b/doc/book/application.md
@@ -135,14 +135,37 @@ applications by subpath.
 The signature of `pipe()` is:
 
 ```php
-public function pipe($pathOrMiddleware, callable $middleware = null)
+public function pipe($pathOrMiddleware, $middleware = null)
 ```
 
 where:
 
-- `$pathOrMiddleware` is either a string URI path (for path segregation), or a
-  callable middleware.
-- `$middleware` is required if `$pathOrMiddleware` is a string URI path.
+- `$pathOrMiddleware` is either a string URI path (for path segregation), a
+  callable middleware, or the service name for a middleware to fetch from the
+  composed container.
+- `$middleware` is required if `$pathOrMiddleware` is a string URI path. It can
+  be either a callable, or the service name for a middleware to fetch from the
+  composed container.
+
+Unlike `Zend\Stratigility\MiddlewarePipe`, `Application::pipe()` *allows
+fetching middleware by service name*. This facility allows lazy-loading of
+middleware only when it is invoked. Internally, it wraps the call to fetch and
+dispatch the middleware inside a closure.
+
+Additionally, we define a new method, `pipeErrorHandler()`, with the following
+signature:
+
+```php
+public function pipeErrorHandler($pathOrMiddleware, $middleware = null)
+```
+
+It acts just like `pipe()` except when the middleware specified is a service
+name; in that particular case, when it wraps the middleware in a closure, it
+uses the error handler signature:
+
+```php
+function ($error, ServerRequestInterface $request, ResponseInterface $response, callable $next);
+```
 
 Read the section on [piping vs routing](router/piping.md) for more information.
 

--- a/doc/book/router/piping.md
+++ b/doc/book/router/piping.md
@@ -31,6 +31,10 @@ This path segregation, however, is limited: it will only match literal paths.
 This is done purposefully, to provide excellent baseline performance, and to
 prevent feature creep in the library.
 
+zend-expressive uses and exposes piping to users, with one addition: middleware
+may be specified by service name, and zend-expressive will lazy-load the service
+only when the middleware is invoked.
+
 ## Routing
 
 Routing is the process of discovering values from the incoming request based on

--- a/src/Application.php
+++ b/src/Application.php
@@ -159,10 +159,29 @@ class Application extends MiddlewarePipe
     /**
      * Overload pipe() operation.
      *
-     * Allows specifying service names for middleware, instead of requiring a
-     * callable.
+     * Middleware piped may be either callables or service names. Middleware
+     * specified as services will be wrapped in a closure similar to the
+     * following:
      *
-     * Ensures that the route middleware is only ever registered once.
+     * <code>
+     * function ($request, $response, $next = null) use ($container, $middleware) {
+     *     $invokable = $container->get($middleware);
+     *     if (! is_callable($invokable)) {
+     *         throw new Exception\InvalidMiddlewareException(sprintf(
+     *             'Lazy-loaded middleware "%s" is not invokable',
+     *             $middleware
+     *         ));
+     *     }
+     *     return $invokable($request, $response, $next);
+     * };
+     * </code>
+     *
+     * This is done to delay fetching the middleware until it is actually used;
+     * the upshot is that you will not be notified if the service is invalid to
+     * use as middleware until runtime.
+     *
+     * Additionally, ensures that the route middleware is only ever registered
+     * once.
      *
      * @param string|callable $path Either a URI path prefix, or middleware.
      * @param null|string|callable $middleware Middleware
@@ -198,8 +217,29 @@ class Application extends MiddlewarePipe
     /**
      * Pipe an error handler.
      *
-     * Proxies to pipe(), after first determining if the middleware represents
-     * a service to lazy-load via the container.
+     * Middleware piped may be either callables or service names. Middleware
+     * specified as services will be wrapped in a closure similar to the
+     * following:
+     *
+     * <code>
+     * function ($error, $request, $response, $next) use ($container, $middleware) {
+     *     $invokable = $container->get($middleware);
+     *     if (! is_callable($invokable)) {
+     *         throw new Exception\InvalidMiddlewareException(sprintf(
+     *             'Lazy-loaded middleware "%s" is not invokable',
+     *             $middleware
+     *         ));
+     *     }
+     *     return $invokable($error, $request, $response, $next);
+     * };
+     * </code>
+     *
+     * This is done to delay fetching the middleware until it is actually used;
+     * the upshot is that you will not be notified if the service is invalid to
+     * use as middleware until runtime.
+     *
+     * Once middleware detection and wrapping (if necessary) is complete,
+     * proxies to pipe().
      *
      * @param string|callable $path Either a URI path prefix, or middleware.
      * @param null|string|callable $middleware Middleware

--- a/test/Container/ApplicationFactoryTest.php
+++ b/test/Container/ApplicationFactoryTest.php
@@ -494,6 +494,7 @@ class ApplicationFactoryTest extends TestCase
     }
 
     /**
+     * @group fail
      * @group piping
      * @dataProvider uncallableMiddleware
      */
@@ -546,7 +547,11 @@ class ApplicationFactoryTest extends TestCase
             ->get('config')
             ->willReturn($config);
 
-        $this->setExpectedException('Zend\Expressive\Exception\InvalidMiddlewareException');
+        $this->container
+            ->has('/')
+            ->willReturn(false);
+
+        $this->setExpectedException('InvalidArgumentException');
         $app = $this->factory->__invoke($this->container->reveal());
     }
 
@@ -606,7 +611,7 @@ class ApplicationFactoryTest extends TestCase
             ->has('Middleware')
             ->willReturn(false);
 
-        $this->setExpectedException('Zend\Expressive\Exception\InvalidMiddlewareException');
+        $this->setExpectedException('InvalidArgumentException');
         $app = $this->factory->__invoke($this->container->reveal());
     }
 


### PR DESCRIPTION
Prior to this patch, the ApplicationFactory implemented lazy loading of pipeline middleware. The feature is very useful, as it delays fetching of middleware until execution by wrapping the call to fetch and invoke it in a closure.

This patch pushes that feature into `Application` itself:

- `pipe()` now allows specifying middleware by service name.
- A new method, `pipeErrorHandler()`, proxies to `pipe()`, but wraps lazy-middleware in a wrapper that uses the error middleware signature.

`ApplicationFactory` has been updated to use these facilities, and removes its own. Documentation has been updated to indicate the lazy-middleware features.