### PR TITLE
Move router and service to require-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,15 @@ to provide a minimalist PSR-7 middleware framework for PHP, with the following
 features:
 
 - Routing. Choose your own router; we support:
-  - [Aura.Router](https://github.com/auraphp/Aura.Router)
-  - [FastRoute](https://github.com/nikic/FastRoute)
-  - [ZF2's MVC router](https://github.com/zendframework/zend-mvc)
+    - [Aura.Router](https://github.com/auraphp/Aura.Router)
+    - [FastRoute](https://github.com/nikic/FastRoute)
+    - [ZF2's MVC router](https://github.com/zendframework/zend-mvc)
 - DI Containers, via [container-interop](https://github.com/container-interop/container-interop).
   Middleware matched via routing is retrieved from the composed container.
 - Optionally, templating. We support:
-  - [Plates](http://platesphp.com/)
-  - [Twig](http://twig.sensiolabs.org/)
-  - [ZF2's PhpRenderer](https://github.com/zendframework/zend-view)
+    - [Plates](http://platesphp.com/)
+    - [Twig](http://twig.sensiolabs.org/)
+    - [ZF2's PhpRenderer](https://github.com/zendframework/zend-view)
 
 ## Installation
 
@@ -28,6 +28,21 @@ Install this library using composer:
 ```bash
 $ composer require zendframework/zend-expressive:*@dev
 ```
+
+You will also need a router. We currently support:
+
+- [Aura.Router](https://github.com/auraphp/Aura.Router): `composer require aura/router`
+- [FastRoute](https://github.com/nikic/FastRoute): `composer require nikic/fast-route`
+- [ZF2 MVC Router](https://github.com/zendframework/zend-mvc): `composer require zendframework/zend-mvc`
+
+We recommend using a dependency injection container, and typehint against
+[container-interop](https://github.com/container-interop/container-interop). We
+can recommend the following implementations:
+
+- [zend-servicemanager](https://github.com/zendframework/zend-servicemanager):
+  `composer require zendframework/zend-servicemanager`
+- [pimple-interop](https://github.com/moufmouf/pimple-interop):
+  `composer require mouf/pimple-interop`
 
 ## Documentation
 

--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,13 @@
     "require": {
         "php": ">=5.5",
         "container-interop/container-interop": "^1.1",
-        "filp/whoops": "^1.1",
         "psr/http-message": "^1.0",
         "zendframework/zend-diactoros": "^1.1",
         "zendframework/zend-stratigility": "^1.1"
     },
     "require-dev": {
         "aura/router": "^2.3",
+        "filp/whoops": "^1.1",
         "league/plates": "^3.1",
         "nikic/fast-route": "^0.6.0",
         "phpunit/phpunit": "^4.7",
@@ -41,6 +41,7 @@
     },
     "suggest": {
         "aura/router": "^2.3 to use the Aura.Router routing adapter",
+        "filp/whoops": "^1.1 to use the Whoops error handler",
         "league/plates": "^3.1 to use the Plates template adapter",
         "mouf/pimple-interop": "^1.0 to use Pimple for dependency injection",
         "nikic/fast-route": "^0.6.0 to use the FastRoute routing adapter",

--- a/composer.json
+++ b/composer.json
@@ -11,23 +11,23 @@
     ],
     "require": {
         "php": ">=5.5",
-        "aura/router": "^2.3",
         "container-interop/container-interop": "^1.1",
+        "filp/whoops": "^1.1",
         "psr/http-message": "^1.0",
         "zendframework/zend-diactoros": "^1.1",
-        "zendframework/zend-servicemanager": "^2.6",
-        "zendframework/zend-stratigility": "^1.1",
-        "filp/whoops": "^1.1"
+        "zendframework/zend-stratigility": "^1.1"
     },
     "require-dev": {
+        "aura/router": "^2.3",
         "league/plates": "^3.1",
         "nikic/fast-route": "^0.6.0",
-        "twig/twig": "^1.19",
-        "zendframework/zend-view": "^2.5",
         "phpunit/phpunit": "^4.7",
         "squizlabs/php_codesniffer": "^2.3",
+        "twig/twig": "^1.19",
         "zendframework/zend-mvc": "^2.5",
-        "zendframework/zend-psr7bridge": "^0.1.0"
+        "zendframework/zend-psr7bridge": "^0.1.0",
+        "zendframework/zend-servicemanager": "^2.6",
+        "zendframework/zend-view": "^2.5"
     },
     "autoload": {
       "psr-4": {
@@ -40,11 +40,14 @@
       }
     },
     "suggest": {
+        "aura/router": "^2.3 to use the Aura.Router routing adapter",
         "league/plates": "^3.1 to use the Plates template adapter",
+        "mouf/pimple-interop": "^1.0 to use Pimple for dependency injection",
         "nikic/fast-route": "^0.6.0 to use the FastRoute routing adapter",
         "zendframework/zend-mvc": "^2.5 to use the zend-mvc TreeRouteStack routing adapter",
         "zendframework/zend-psr7bridge": "^0.1.0 to use the zend-mvc TreeRouteStack routing adapter",
         "twig/twig": "^1.19 to use the Twig template adapter",
-        "zendframework/zend-view": "^2.5 to use the Zend View template adapter"
+        "zendframework/zend-servicemanager": "^2.5 to use zend-servicemanager for dependency injection",
+        "zendframework/zend-view": "^2.5 to use the zend-view template adapter"
     }
 }

--- a/doc/book/container/intro.md
+++ b/doc/book/container/intro.md
@@ -21,8 +21,10 @@ examples.
 
 At this time, we document support for the following specific containers:
 
-- [zend-servicemanager](zend-servicemanager.md)
-- [Pimple](pimple.md)
+- [zend-servicemanager](https://github.com/zendframework/zend-servicemanager):
+  `composer require zendframework/zend-servicemanager`
+- [pimple-interop](https://github.com/moufmouf/pimple-interop):
+  `composer require mouf/pimple-interop`
 
 > ## Service Names
 >

--- a/doc/book/error-handling.md
+++ b/doc/book/error-handling.md
@@ -37,6 +37,13 @@ You'll typically want to provide error messages in your site template. To do so,
 optionally, a `Zend\Expressive\Template\TemplateInterface` instance, and template names to use for
 404 and general error conditions. This makes it a good choice for use in production.
 
+First, of course, you'll need to select a templating system and ensure you have
+the appropriate dependencies installed; see the [templating documentation](../template/intro.md)
+for information on what we support and how to install supported systems.
+
+Once you have selected your templating system, you can setup the templated error
+handler.
+
 ```php
 use Zend\Expressive\Application;
 use Zend\Expressive\Template\Plates;
@@ -64,7 +71,13 @@ exceptions and PHP errors. We provide integration with this library through
 uses its features for 404 status and non-exception errors. For exceptions, however, it will return
 the whoops output. As such, it is a good choice for use in development.
 
-To use it, you will need to provide it a whoops runtime instance, as well as a
+To use it, you must first install whoops:
+
+```bash
+$ composer require filp/whoops
+```
+
+Then you will need to provide the error handler a whoops runtime instance, as well as a
 `Whoops\Handler\PrettyPageHandler` instance. You can also optionally provide a `TemplateInterface`
 instance and template names, just as you would for a `TemplatedErrorHandler`.
 

--- a/doc/book/quick-start.md
+++ b/doc/book/quick-start.md
@@ -19,8 +19,14 @@ If you haven't already, [install Composer](https://getcomposer.org). Once you
 have, we can install Expressive:
 
 ```bash
-$ composer require zendframework/zend-expressive
+$ composer require zendframework/zend-expressive aura/router
 ```
+
+> ### Routers
+>
+> Expressive needs a routing implementation in order to create routed
+> middleware. We suggest Aura.Router in the quick start, but you can also
+> currently choose from FastRoute and the ZF2 MVC router.
 
 ## 3. Create a web root directory
 

--- a/doc/book/template/intro.md
+++ b/doc/book/template/intro.md
@@ -9,3 +9,9 @@ We do, however, provide abstraction for templating via the interface
 middleware that is engine-agnostic. In this documentation, we'll detail the
 features of this interface, the various implementations we provide, and how you
 can configure, inject, and consume templating in your middleware.
+
+We currently support:
+
+- [Plates](plates.md): `composer require league/plates`
+- [Twig](twig.md): `composer require twig/twig`
+- [zend-view](zend-view.md): `composer require zendframework/zend-view`


### PR DESCRIPTION
Hi, 

As the router and container can be moved what about moving those to require-dev and have a project/skelton repo which comes with service and router by default ?

Else the problem is we install the extra components and will not be using those.

Thank you.