### PR TITLE
404 is never called from FinalHandler

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -18,7 +18,6 @@ use Zend\Diactoros\Response;
 use Zend\Diactoros\Response\EmitterInterface;
 use Zend\Diactoros\Response\SapiEmitter;
 use Zend\Diactoros\ServerRequestFactory;
-use Zend\Stratigility\FinalHandler;
 use Zend\Stratigility\MiddlewarePipe;
 
 /**
@@ -436,18 +435,15 @@ class Application extends MiddlewarePipe
     /**
      * Return the final handler to use during `run()` if the stack is exhausted.
      *
-     * Creates an instance of Zend\Stratigility\FinalHandler if no handler is
-     * already registered.
-     *
      * @param null|ResponseInterface $response Response instance with which to seed the
      *     FinalHandler; used to determine if the response passed to the handler
      *     represents the original or final response state.
-     * @return callable
+     * @return callable|null
      */
     public function getFinalHandler(ResponseInterface $response = null)
     {
         if (! $this->finalHandler) {
-            $this->finalHandler = new FinalHandler([], $response);
+            return null;
         }
 
         // Inject the handler with the response, if possible (e.g., the

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -232,13 +232,6 @@ class ApplicationTest extends TestCase
         $this->assertSame($routeMiddleware, $test);
     }
 
-    public function testComposesStratigilityFinalHandlerByDefault()
-    {
-        $app   = $this->getApp();
-        $final = $app->getFinalHandler();
-        $this->assertInstanceOf('Zend\Stratigility\FinalHandler', $final);
-    }
-
     public function testCanInjectFinalHandlerViaConstructor()
     {
         $finalHandler = function ($req, $res, $err = null) {
@@ -265,35 +258,6 @@ class ApplicationTest extends TestCase
 
         $test = $app($request, $response->reveal());
         $this->assertSame($finalResponse, $test);
-    }
-
-    public function testFinalHandlerCreatedAtInvocationIsProvidedResponseInstance()
-    {
-        $routeResult = RouteResult::fromRouteFailure();
-        $this->router->match()->willReturn($routeResult);
-
-        $app = new Application($this->router->reveal());
-
-        $finalResponse = $this->prophesize('Psr\Http\Message\ResponseInterface');
-        $app->pipe(function ($req, $res, $next) use ($finalResponse) {
-            return $finalResponse->reveal();
-        });
-
-        $responseStream = $this->prophesize('Psr\Http\Message\StreamInterface');
-        $responseStream->getSize()->willReturn(0);
-
-        $request  = new Request([], [], 'http://example.com/');
-        $response = $this->prophesize('Psr\Http\Message\ResponseInterface');
-        $response->getBody()->willReturn($responseStream->reveal());
-
-        $test = $app($request, $response->reveal());
-
-        $finalHandler = $app->getFinalHandler();
-        $this->assertInstanceOf('Zend\Stratigility\FinalHandler', $finalHandler);
-        $r = new ReflectionProperty($finalHandler, 'response');
-        $r->setAccessible(true);
-        $handlerResponse = $r->getValue($finalHandler);
-        $this->assertSame($response->reveal(), $handlerResponse);
     }
 
     public function testComposesSapiEmitterByDefault()

--- a/test/Container/ApplicationFactoryTest.php
+++ b/test/Container/ApplicationFactoryTest.php
@@ -208,7 +208,7 @@ class ApplicationFactoryTest extends TestCase
         $this->assertInstanceOf('Zend\Expressive\Emitter\EmitterStack', $app->getEmitter());
         $this->assertCount(1, $app->getEmitter());
         $this->assertInstanceOf('Zend\Diactoros\Response\SapiEmitter', $app->getEmitter()->pop());
-        $this->assertInstanceOf('Zend\Stratigility\FinalHandler', $app->getFinalHandler());
+        $this->assertNull($app->getFinalHandler());
     }
 
     /**

--- a/test/IntegrationTest.php
+++ b/test/IntegrationTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Prophecy\Argument;
+use Psr\Http\Message\ResponseInterface;
+use Zend\Diactoros\ServerRequest;
+use Zend\Diactoros\Response;
+use Zend\Diactoros\Response\EmitterInterface;
+use Zend\Expressive\Application;
+use Zend\Expressive\Router\Aura as AuraRouter;
+use Zend\Expressive\TemplatedErrorHandler;
+
+class IntegrationTest extends TestCase
+{
+    public $response;
+
+    public function setUp()
+    {
+        $this->response = null;
+    }
+
+    public function getEmitter()
+    {
+        $self    = $this;
+        $emitter = $this->prophesize(EmitterInterface::class);
+        $emitter
+            ->emit(Argument::type(ResponseInterface::class))
+            ->will(function ($args) use ($self) {
+                $response = array_shift($args);
+                $self->response = $response;
+                return null;
+            })
+            ->shouldBeCalled();
+        return $emitter->reveal();
+    }
+
+    public function testDefaultFinalHandlerCanEmitA404WhenNoMiddlewareMatches()
+    {
+        $app      = new Application(new AuraRouter(), null, null, $this->getEmitter());
+        $request  = new ServerRequest([], [], 'https://example.com/foo', 'GET');
+        $response = new Response();
+
+        $app->run($request, $response);
+        $this->assertInstanceOf(ResponseInterface::class, $this->response);
+        $this->assertEquals(404, $this->response->getStatusCode());
+    }
+
+    public function testInjectedFinalHandlerCanEmitA404WhenNoMiddlewareMatches()
+    {
+        $finalHandler = new TemplatedErrorHandler();
+        $app          = new Application(new AuraRouter(), null, $finalHandler, $this->getEmitter());
+        $request      = new ServerRequest([], [], 'https://example.com/foo', 'GET');
+        $response     = new Response();
+
+        $app->run($request, $response);
+        $this->assertInstanceOf(ResponseInterface::class, $this->response);
+        $this->assertEquals(404, $this->response->getStatusCode());
+    }
+}


### PR DESCRIPTION
The Stratigility FinalHandler never calls `create404` because of [this line](https://github.com/zendframework/zend-stratigility/blob/716c647fb76303c76c0c254bb4c5bc628aefa7e1/src/FinalHandler.php#L83). In [getFinalHandler()](https://github.com/zendframework/zend-expressive/blob/23c48d8f770fd73a062b903682bbf6d4aff6918c/src/Application.php#L371) of Expressive the $response will be a Diactoros Response (or other PSR-7), which gets passed to the Final Handler, and then decorated by Stratigility.  The result is the FinalHandler response will **never** equal the invoked response so the $response is returned by the FinalHandler and the 404 is never shown.