### PR TITLE
Abstract layout capabilities in zend-view adapter

### DIFF
--- a/doc/book/template/zend-view.md
+++ b/doc/book/template/zend-view.md
@@ -59,24 +59,80 @@ $templates = new ZendView($zendView);
 ## Layouts
 
 Unlike the other supported template engines, zend-view does not support layouts
-out-of-the-box.
+out-of-the-box. Expressive abstracts this fact away, providing two facilities
+for doing so:
 
-Layouts are accomplished in one of two ways:
+- You may pass a layout template name or `Zend\View\Model\ModelInterface`
+  instance representing the layout as the second argument to the constructor.
+- You may pass a "layout" parameter during rendering, with a value of either a
+  layout template name or a `Zend\View\Model\ModelInterface`
+  instance representing the layout. Passing a layout this way will override any
+  layout provided to the constructor.
 
-- Multiple rendering passes:
+In each case, the zend-view implementation will do a depth-first, recursive
+render in order to provide content within the selected layout.
 
-    ```php
-    $content = $templates->render('blog/entry', [ 'entry' => $entry ]);
-    $layout  = $templates->render('layout/layout', [ 'content' => $content ]);
-    ```
+### Layout name passed to constructor
 
-- View models.  To accomplish this, you will compose a view model for the
-  content, and pass it as a value to the layout:
+```php
+use Zend\Expressive\Template\ZendView;
 
-    ```php
-    use Zend\View\Model\ViewModel;
-    
-    $viewModel = new ViewModel(['entry' => $entry]);
-    $viewModel->setTemplate('blog/entry');
-    $layout = $templates->render('layout/layout', [ 'content' => $viewModel ]);
-    ```
+// Create the engine instance with a layout name:
+$zendView = new PhpRenderer(null, 'layout');
+```
+
+### Layout view model passed to constructor
+
+```php
+use Zend\Expressive\Template\ZendView;
+use Zend\View\Model\ViewModel
+
+// Create the layout view model:
+$layout = new ViewModel([
+    'encoding' => 'utf-8',
+    'cssPath'  => '/css/prod/',
+]);
+$layout->setTemplate('layout');
+
+// Create the engine instance with the layout:
+$zendView = new PhpRenderer(null, $layout);
+```
+
+### Provide a layout name when rendering
+
+```php
+$content = $templates->render('blog/entry', [
+    'layout' => 'blog',
+    'entry'  => $entry,
+]);
+```
+
+### Provide a layout view model when rendering
+
+```php
+use Zend\View\Model\ViewModel
+
+// Create the layout view model:
+$layout = new ViewModel([
+    'encoding' => 'utf-8',
+    'cssPath'  => '/css/blog/',
+]);
+$layout->setTemplate('layout');
+
+$content = $templates->render('blog/entry', [
+    'layout' => $layout,
+    'entry'  => $entry,
+]);
+```
+
+## Recommendations
+
+We recommend the following practices when using the zend-view adapter:
+
+- If using a layout, create a factory to return the layout view model as a
+  service; this allows you to inject it into middleware and add variables to it.
+- While we support passing the layout as a rendering parameter, be aware that if
+  you change engines, this may not be supported.
+- While you can use alternate resolvers, not all of them will work with the
+  `addPath()` implementation. As such, we recommend setting up resolvers and
+  paths only during creation of the template adapter.

--- a/src/Exception/RenderingException.php
+++ b/src/Exception/RenderingException.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       http://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Exception;
+
+use DomainException;
+
+class RenderingException extends DomainException implements ExceptionInterface
+{
+}

--- a/src/Template/ZendView.php
+++ b/src/Template/ZendView.php
@@ -45,7 +45,23 @@ class ZendView implements TemplateInterface
     private $resolver;
 
     /**
+     * Constructor
+     *
+     * Allows specifying the renderer to use (any zend-view renderer is
+     * allowed), and optionally also the layout.
+     *
+     * The layout may be:
+     *
+     * - a string layout name
+     * - a ModelInterface instance representing the layout
+     *
+     * If no renderer is provided, a default PhpRenderer instance is created;
+     * omitting the layout indicates no layout should be used by default when
+     * rendering.
+     *
      * @param null|RendererInterface $renderer
+     * @param null|string|ModelInterface $layout
+     * @throws InvalidArgumentException for invalid $layout types
      */
     public function __construct(RendererInterface $renderer = null, $layout = null)
     {
@@ -201,11 +217,11 @@ class ZendView implements TemplateInterface
      * Do a recursive, depth-first rendering of a view model.
      *
      * @param ModelInterface $model
-     * @param PhpRenderer $renderer
+     * @param RendererInterface $renderer
      * @return string
      * @throws Exception\RenderingException if it encounters a terminal child.
      */
-    private function renderModel(ModelInterface $model, PhpRenderer $renderer)
+    private function renderModel(ModelInterface $model, RendererInterface $renderer)
     {
         foreach ($model as $child) {
             if ($child->terminate()) {

--- a/test/Template/TestAsset/zendview-layout.phtml
+++ b/test/Template/TestAsset/zendview-layout.phtml
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Layout Page</title>
+</head>
+<body>
+<?= $this->content ?>
+</body>

--- a/test/Template/TestAsset/zendview-layout2.phtml
+++ b/test/Template/TestAsset/zendview-layout2.phtml
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>ALTERNATE LAYOUT PAGE</title>
+</head>
+<body>
+<?= $this->content ?>
+</body>


### PR DESCRIPTION
This pull request better abstracts layout capabilities for the zend-view adapter. It does so by:

- Allowing passing a layout script name or ViewModel representing the layout as the second argument in the constructor.
- Allowing passing a "layout" parameter during rendering, which may be a layout script name or a ViewModel representing the layout.

In each case, rendering now munges the provided template and parameters into a view model, injecting it as a child of the layout view model if one is discovered (if a layout script name is passed, a layout view model is created to represent it).

This makes usage look more like the other adapters, and brings its capabilities to the same level of completion.