### PR TITLE
Update quickstart documentation to install default container

### DIFF
--- a/doc/book/quick-start.md
+++ b/doc/book/quick-start.md
@@ -16,10 +16,10 @@ $ cd expressive
 ## 2. Install Expressive
 
 If you haven't already, [install Composer](https://getcomposer.org). Once you
-have, we can install Expressive:
+have, we can install Expressive, along with a router and a container:
 
 ```bash
-$ composer require zendframework/zend-expressive aura/router
+$ composer require zendframework/zend-expressive aura/router zendframework/zend-servicemanager
 ```
 
 > ### Routers


### PR DESCRIPTION
Without installing the zend-servicemanager, the example code throws an error since AppFactory cannot instantiate the default container.