### PR TITLE
Fix example classname in documentation

### DIFF
--- a/doc/book/router/fast-route.md
+++ b/doc/book/router/fast-route.md
@@ -136,7 +136,7 @@ namespace Application\Container;
 use Interop\Container\ContainerInterface;
 use Zend\Expressive\Router\FastRoute as FastRouteBridge;
 
-class FastRouteFactory
+class RouterFactory
 {
     /**
      * @param ContainerInterface $container


### PR DESCRIPTION
Fix for PSR-0/4 compliance. Important for those of us who like to copy/paste examples!