### PR TITLE
Compose an EmitterStack by default

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -458,15 +458,16 @@ class Application extends MiddlewarePipe
     /**
      * Retrieve an emitter to use during run().
      *
-     * If none was registered during instantiation, this will lazy-load a
-     * SapiEmitter instance.
+     * If none was registered during instantiation, this will lazy-load an
+     * EmitterStack composing an SapiEmitter instance.
      *
      * @return EmitterInterface
      */
     public function getEmitter()
     {
         if (! $this->emitter) {
-            $this->emitter = new SapiEmitter;
+            $this->emitter = new Emitter\EmitterStack();
+            $this->emitter->push(new SapiEmitter());
         }
         return $this->emitter;
     }

--- a/src/Container/ApplicationFactory.php
+++ b/src/Container/ApplicationFactory.php
@@ -133,7 +133,7 @@ class ApplicationFactory
 
         $emitter = $container->has(EmitterInterface::class)
             ? $container->get(EmitterInterface::class)
-            : $this->createEmitterStack();
+            : null;
 
         $app = new Application($router, $container, $finalHandler, $emitter);
 
@@ -173,18 +173,6 @@ class ApplicationFactory
                 $route->setOptions($spec['options']);
             }
         }
-    }
-
-    /**
-     * Create the default emitter stack.
-     *
-     * @return EmitterStack
-     */
-    private function createEmitterStack()
-    {
-        $emitter = new EmitterStack();
-        $emitter->push(new SapiEmitter());
-        return $emitter;
     }
 
     /**

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -13,8 +13,10 @@ use Interop\Container\ContainerInterface;
 use PHPUnit_Framework_TestCase as TestCase;
 use Prophecy\Argument;
 use ReflectionProperty;
+use Zend\Diactoros\Response\SapiEmitter;
 use Zend\Diactoros\ServerRequest as Request;
 use Zend\Expressive\Application;
+use Zend\Expressive\Emitter\EmitterStack;
 use Zend\Expressive\Router\Route;
 use Zend\Expressive\Router\RouteResult;
 use Zend\Stratigility\Route as StratigilityRoute;
@@ -260,11 +262,15 @@ class ApplicationTest extends TestCase
         $this->assertSame($finalResponse, $test);
     }
 
-    public function testComposesSapiEmitterByDefault()
+    public function testComposesEmitterStackWithSapiEmitterByDefault()
     {
-        $app     = $this->getApp();
-        $emitter = $app->getEmitter();
-        $this->assertInstanceOf('Zend\Diactoros\Response\SapiEmitter', $emitter);
+        $app   = $this->getApp();
+        $stack = $app->getEmitter();
+        $this->assertInstanceOf(EmitterStack::class, $stack);
+
+        $this->assertCount(1, $stack);
+        $test = $stack->pop();
+        $this->assertInstanceOf(SapiEmitter::class, $test);
     }
 
     public function testAllowsInjectingEmitterAtInstantiation()


### PR DESCRIPTION
It makes sense to compose an EmitterStack by default; that way, users of AppFactory can manipulate the emitter without needing to resort to direct instantiation.