### PR TITLE
Fixing code blocks and removing extra characters from docs.

### DIFF
--- a/doc/book/container/factories.md
+++ b/doc/book/container/factories.md
@@ -37,78 +37,78 @@ order to seed the `Application` instance:
 
 - `middleware_pipeline` can be used to seed pre- and/or post-routing middleware:
 
-  ```php
-  'middleware_pipeline' => [
-      // An array of middleware to register prior to registration of the
-      // routing middleware:
-      'pre_routing' => [
-      ],
-      // An array of middleware to register after registration of the
-      // routing middleware:
-      'post_routing' => [
-      ],
+```php
+'middleware_pipeline' => [
+  // An array of middleware to register prior to registration of the
+  // routing middleware:
+  'pre_routing' => [
   ],
-  ```
-
-  Each item of each array must be an array itself, with the following structure:
-
-  ```php
-  [
-      // required:
-      'middleware' => 'Name of middleware service, or a callable',
-      // optional:
-      'path'  => '/path/to/match',
-      'error' => true,
+  // An array of middleware to register after registration of the
+  // routing middleware:
+  'post_routing' => [
   ],
-  ```
+],
+```
 
-  The `middleware` key itself is the middleware to execute, and must be a
-  callable or the name of another defined service. If the `path` key is present,
-  that key will be used to segregate the middleware to a specific matched path
-  (in other words, it will not execute if the path is not matched). If the
-  `error` key is present and boolean `true`, then the middleware will be
-  registered as error middleware. (This is necessary due to the fact that the
-  factory defines a callable wrapper around middleware to enable lazy-loading of
-  middleware.)
+Each item of each array must be an array itself, with the following structure:
+
+```php
+[
+  // required:
+  'middleware' => 'Name of middleware service, or a callable',
+  // optional:
+  'path'  => '/path/to/match',
+  'error' => true,
+],
+```
+
+The `middleware` key itself is the middleware to execute, and must be a
+callable or the name of another defined service. If the `path` key is present,
+that key will be used to segregate the middleware to a specific matched path
+(in other words, it will not execute if the path is not matched). If the
+`error` key is present and boolean `true`, then the middleware will be
+registered as error middleware. (This is necessary due to the fact that the
+factory defines a callable wrapper around middleware to enable lazy-loading of
+middleware.)
 
 - `routes` is used to define routed middleware. The value must be an array,
-  consisting of arrays defining each middleware:
+consisting of arrays defining each middleware:
 
-  ```php
-  'routes' => [
-      [
-          'path' => '/path/to/match',
-          'middleware' => 'Middleware Service Name or Callable',
-          'allowed_methods' => [ 'GET', 'POST', 'PATCH' ],
-          'options' => [
-              'stuff' => 'to',
-              'pass'  => 'to',
-              'the'   => 'underlying router',
-          ],
+```php
+'routes' => [
+  [
+      'path' => '/path/to/match',
+      'middleware' => 'Middleware Service Name or Callable',
+      'allowed_methods' => [ 'GET', 'POST', 'PATCH' ],
+      'options' => [
+          'stuff' => 'to',
+          'pass'  => 'to',
+          'the'   => 'underlying router',
       ],
-      // etc.
   ],
-  ```
+  // etc.
+],
+```
 
-  Each route *requires*:
+Each route *requires*:
 
-  - `path`: the path to match. Format will be based on the router you choose for
-    your project.
+- `path`: the path to match. Format will be based on the router you choose for
+your project.
 
-  - `middleware`: a callable or a service name for the middleware to execute
-    when the route matches.
+- `middleware`: a callable or a service name for the middleware to execute
+when the route matches.
 
-  Optionally, the route definition may provide:
+Optionally, the route definition may provide:
 
-  - `allowed_methods`: an array of allowed HTTP methods. If not provided, the
-    application assumes any method is allowed.
+- `allowed_methods`: an array of allowed HTTP methods. If not provided, the
+application assumes any method is allowed.
 
-  - `name`: if not provided, the path will be used as the route name (and, if
-    specific HTTP methods are allowed, a list of those).
+- `name`: if not provided, the path will be used as the route name (and, if
+specific HTTP methods are allowed, a list of those).
 
-  - `options`: a key/value set of additional options to pass to the underlying
-    router implementation for the given route. (Typical use cases include
-    passing constraints or default values.)
+- `options`: a key/value set of additional options to pass to the underlying
+router implementation for the given route. (Typical use cases include
+passing constraints or default values.)
 
 ## TemplatedErrorHandlerFactory
 

--- a/doc/book/router/aura.md
+++ b/doc/book/router/aura.md
@@ -6,28 +6,28 @@ configuration is to provide default specifications:
 
 - A regular expression that applies the same for a given routing match:
 
-  ```php
-  // Parameters named "id" will only match digits by default:
-  $router->addTokens([
-    'id' => '\d+',
-  ]);
-  ```
+```php
+// Parameters named "id" will only match digits by default:
+$router->addTokens([
+'id' => '\d+',
+]);
+```
 
 - A default parameter and/or its default value to always provide:
 
-  ```php
-  // mediatype defaults to "application/xhtml+xml" and will be available in all
-  // requests:
-  $router->addValues([
-    'mediatype' => 'application/xhtml+xml',
-  ]);
-  ```
+```php
+// mediatype defaults to "application/xhtml+xml" and will be available in all
+// requests:
+$router->addValues([
+'mediatype' => 'application/xhtml+xml',
+]);
+```
 
 - Only match if secure (i.e., under HTTPS):
 
-  ```php
-  $router->setSecure(true);
-  ```
+```php
+$router->setSecure(true);
+```
 
 In order to specify these, you need access to the underlying Aura.Router
 instance, however, and the `RouterInterface` does not provide an accessor!
@@ -69,13 +69,13 @@ $router = new AuraBridge($auraRouter);
 $app = AppFactory::create(null, $router);
 ```
 
-> ### Piping the route middleware
->
-> As a reminder, you will need to ensure that middleware is piped in the order
-> in which it needs to be executed; please see the section on "Controlling
-> middleware execution order" in the [piping documentation](piping.md). This is
-> particularly salient when defining routes before injecting the router in the
-> application instance!
+### Piping the route middleware
+
+As a reminder, you will need to ensure that middleware is piped in the order
+in which it needs to be executed; please see the section on "Controlling
+middleware execution order" in the [piping documentation](piping.md). This is
+particularly salient when defining routes before injecting the router in the
+application instance!
 
 ## Factory-Driven Creation
 

--- a/doc/book/router/uri-generation.md
+++ b/doc/book/router/uri-generation.md
@@ -13,26 +13,26 @@ the name:
 - If you call `route()` with no HTTP methods, the name is the literal path with
   no changes.
 
-  ```php
-  $app->route('/foo', $middleware); // "foo"
-  ```
+```php
+$app->route('/foo', $middleware); // "foo"
+```
 
 - If you call `get()`, `post()`, `put()`, `patch()`, or `delete()`, the name
   will be the literal path, followed by a caret (`^`), followed by the
   uppercase HTTP method name:
 
-  ```php
-  $app->get('/foo', $middleware); // "foo^GET"
-  ```
+```php
+$app->get('/foo', $middleware); // "foo^GET"
+```
 
 - If you call `route()` and specify a list of HTTP methods accepted, the name
   will be the literal path, followed by a caret (`^`), followed by a colon
   (`:`)-separated list of the uppercase HTTP method names, in the order in which
   they were added.
 
-  ```php
-  $app->route('/foo, $middleware', ['GET', 'POST']); // "foo^GET:POST"
-  ```
+```php
+$app->route('/foo, $middleware', ['GET', 'POST']); // "foo^GET:POST"
+```
 
 Clearly, this can become difficult to remember. As such, Expressive offers the
 ability to specify a custom string for the route name as an additional, optional
@@ -58,8 +58,8 @@ $uri = $router->generateUri('foo-item', ['id' => 'bar']); // "/foo/bar"
 
 You can omit the second argument if no substitutions are necessary.
 
-> ### Compose the router
->
-> For this to work, you'll need to compose the router instance in any class that
-> requires the URI generation facility. Inject the
-> `Zend\Expressive\Router\RouterInterface` service in these situations.
+### Compose the router
+
+For this to work, you'll need to compose the router instance in any class that
+requires the URI generation facility. Inject the
+`Zend\Expressive\Router\RouterInterface` service in these situations.

--- a/doc/book/usage-examples.md
+++ b/doc/book/usage-examples.md
@@ -23,16 +23,16 @@ We assume also that:
 - Your own classes are under `src/` with the top-level namespace `Application`,
   and you have configured [autoloading](https://getcomposer.org/doc/01-basic-usage.md#autoloading) in your `composer.json` for those classes.
 
-> ## Using the built-in web server
->
-> You can use the built-in web server to run the examples. Run:
->
-> ```bash
-> $ php -S 0.0.0.0:8080 -t public
-> ```
->
-> from the application root to start up a web server running on port 8080, and
-> then browse to http://localhost:8080
+## Using the built-in web server
+
+You can use the built-in web server to run the examples. Run:
+
+```bash
+$ php -S 0.0.0.0:8080 -t public
+```
+
+from the application root to start up a web server running on port 8080, and
+then browse to http://localhost:8080
 
 ### Routing
 
@@ -478,46 +478,46 @@ application that match a common path root.
 `error` indicates whether or not the middleware represents error middleware;
 this is done to ensure that lazy-loading of error middleware works as expected.
 
-> #### Lazy-loaded Middleware
->
-> One feature of the `middleware_pipeline` is that any middleware service pulled
-> from the container is actually wrapped in a closure:
->
-> ```php
-> function ($request, $response, $next = null) use ($container, $middleware) {
->     $invokable = $container->get($middleware);
->     if (! is_callable($invokable)) {
->         throw new Exception\InvalidMiddlewareException(sprintf(
->             'Lazy-loaded middleware "%s" is not invokable',
->             $middleware
->         ));
->     }
->     return $invokable($request, $response, $next);
-> };
-> ```
->
-> If the `error` flag is specified and is truthy, the closure looks like this
-> instead, to ensure the middleware is treated by Stratigility as error
-> middleware:
->
-> ```php
-> function ($error, $request, $response, $next) use ($container, $middleware) {
->     $invokable = $container->get($middleware);
->     if (! is_callable($invokable)) {
->         throw new Exception\InvalidMiddlewareException(sprintf(
->             'Lazy-loaded middleware "%s" is not invokable',
->             $middleware
->         ));
->     }
->     return $invokable($error, $request, $response, $next);
-> };
-> ```
->
-> This implements *lazy-loading* for middleware pipeline services, delaying
-> retrieval from the container until the middleware is actually invoked.
->
-> This also means that if the service specified is not valid middleware, you
-> will not find out until the application attempts to invoke it.
+#### Lazy-loaded Middleware
+
+One feature of the `middleware_pipeline` is that any middleware service pulled
+from the container is actually wrapped in a closure:
+
+```php
+function ($request, $response, $next = null) use ($container, $middleware) {
+    $invokable = $container->get($middleware);
+    if (! is_callable($invokable)) {
+        throw new Exception\InvalidMiddlewareException(sprintf(
+            'Lazy-loaded middleware "%s" is not invokable',
+            $middleware
+        ));
+    }
+    return $invokable($request, $response, $next);
+};
+```
+
+If the `error` flag is specified and is truthy, the closure looks like this
+instead, to ensure the middleware is treated by Stratigility as error
+middleware:
+
+```php
+function ($error, $request, $response, $next) use ($container, $middleware) {
+    $invokable = $container->get($middleware);
+    if (! is_callable($invokable)) {
+        throw new Exception\InvalidMiddlewareException(sprintf(
+            'Lazy-loaded middleware "%s" is not invokable',
+            $middleware
+        ));
+    }
+    return $invokable($error, $request, $response, $next);
+};
+```
+
+This implements *lazy-loading* for middleware pipeline services, delaying
+retrieval from the container until the middleware is actually invoked.
+
+This also means that if the service specified is not valid middleware, you
+will not find out until the application attempts to invoke it.
 
 ## Segregating your application to a subpath
 


### PR DESCRIPTION
Only things removed/changed were removing the > characters and tabs. The extra tabs on the code blocks made each line into it's own code block.