### PR TITLE
change composer require from *@dev to ~0.* ?

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ features:
 Install this library using composer:
 
 ```bash
-$ composer require zendframework/zend-expressive:*@dev
+$ composer require zendframework/zend-expressive
 ```
 
 You will also need a router. We currently support:


### PR DESCRIPTION
as currently there is a release, should we update the composer require command in doc to to a version ?