### PR TITLE
Fix typo in templates->render

### DIFF
--- a/doc/book/template/middleware.md
+++ b/doc/book/template/middleware.md
@@ -96,8 +96,8 @@ class EntryMiddleware
 Alternately, you can write to the composed response:
 
 ```php
-$response->getBody()->write($this->templates->render('blog::entry'), [
+$response->getBody()->write($this->templates->render('blog::entry', [
     'entry' => $entry,
-]);
+]));
 return $response;
 ```


### PR DESCRIPTION
The data array should be passed to the template renderer, not the response body stream.