### PR TITLE
Updated config path typos.

### DIFF
--- a/doc/book/usage-examples.md
+++ b/doc/book/usage-examples.md
@@ -275,7 +275,7 @@ return ConfigFactory::fromFiles(
 );
 ```
 
-In `config/global.php`, place the following:
+In `config/autoload/global.php`, place the following:
 
 ```php
 return [
@@ -311,7 +311,7 @@ In `config/autoload/dependencies.global.php`, place the following:
 <?php
 return [
     'services' => [
-        'config' => include __DIR__ . '/config.php',
+        'config' => include __DIR__ . '/../config.php',
     ],
     'invokables' => [
         'Application\HelloWorld' => 'Application\HelloWorld',


### PR DESCRIPTION
Looks like a few of the paths were incorrect in the usage-examples.md when using merged config files.

- It appears global.php should be config/autoload/global.php as opposed to config/global.php
- the config service defined in config/autoload/dependencies.global.php points to absolute path __DIR__ . /config.php" which would not exist since config.php is actually in the parent directory.

