### PR TITLE
Added the any() method.

### DIFF
--- a/doc/book/application.md
+++ b/doc/book/application.md
@@ -116,9 +116,9 @@ where:
 This method is typically only used if you want a single middleware to handle
 multiple HTTP request methods.
 
-### get(), post(), put(), patch(), delete()
+### get(), post(), put(), patch(), delete(), any()
 
-Each of the methods `get()`, `post()`, `put()`, `patch()`, and `delete()`
+Each of the methods `get()`, `post()`, `put()`, `patch()`, `delete()`, `any()`
 proxies to `route()` and has the signature:
 
 ```php

--- a/doc/book/application.md
+++ b/doc/book/application.md
@@ -118,7 +118,7 @@ multiple HTTP request methods.
 
 ### get(), post(), put(), patch(), delete(), any()
 
-Each of the methods `get()`, `post()`, `put()`, `patch()`, `delete()`, `any()`
+Each of the methods `get()`, `post()`, `put()`, `patch()`, `delete()`, and `any()`
 proxies to `route()` and has the signature:
 
 ```php

--- a/src/Application.php
+++ b/src/Application.php
@@ -163,7 +163,7 @@ class Application extends MiddlewarePipe
      */
     public function any($path, $middleware, $name = null)
     {
-        return $this->route($path, $middleware, $this->httpRouteMethods, $name);
+        return $this->route($path, $middleware, Router\Route::HTTP_METHOD_ANY, $name);
     }
 
     /**

--- a/src/Application.php
+++ b/src/Application.php
@@ -163,7 +163,7 @@ class Application extends MiddlewarePipe
      */
     public function any($path, $middleware, $name = null)
     {
-        return $this->route($path, $middleware, Router\Route::HTTP_METHOD_ANY, $name);
+        return $this->route($path, $middleware, null, $name);
     }
 
     /**

--- a/src/Application.php
+++ b/src/Application.php
@@ -156,6 +156,17 @@ class Application extends MiddlewarePipe
     }
 
     /**
+     * @param string|Router\Route $path
+     * @param callable|string     $middleware Middleware (or middleware service name) to associate with route.
+     * @param null|string         $name the name of the route
+     * @return Router\Route
+     */
+    public function any($path, $middleware, $name = null)
+    {
+        return $this->route($path, $middleware, $this->httpRouteMethods, $name);
+    }
+
+    /**
      * Overload pipe() operation.
      *
      * Middleware piped may be either callables or service names. Middleware

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -68,6 +68,26 @@ class ApplicationTest extends TestCase
         $this->assertSame($this->noopMiddleware, $route->getMiddleware());
     }
 
+    public function testAnyRouteMethod()
+    {
+        $this->router->addRoute(Argument::type(Route::class))->shouldBeCalled();
+        $route = $this->getApp()->any('/foo', $this->noopMiddleware);
+        $this->assertInstanceOf(Route::class, $route);
+        $this->assertEquals('/foo', $route->getPath());
+        $this->assertSame($this->noopMiddleware, $route->getMiddleware());
+
+        $reflClass    = new \ReflectionClass($this->getApp());
+        $routeMethods = $reflClass->getProperty('httpRouteMethods');
+        $routeMethods->setAccessible(true);
+        $routeMethods = $routeMethods->getValue($this->getApp());
+
+        foreach ($routeMethods as $method) {
+            $this->assertTrue($route->allowsMethod($method));
+        }
+
+        $this->assertSame($routeMethods, $route->getAllowedMethods());
+    }
+
     /**
      * @dataProvider commonHttpMethods
      */


### PR DESCRIPTION
This method is useful for defining a single middleware that will respond to any of the $httpRouteMethods. For example, a Restful controller that has logic to route to the appropriate method internally:

```
$app->any('/foo', Api\RestfulController::class);
```