### PR TITLE
Route options not processed in ApplicationFactory

### DIFF
--- a/src/Container/ApplicationFactory.php
+++ b/src/Container/ApplicationFactory.php
@@ -16,8 +16,8 @@ use Zend\Expressive\Application;
 use Zend\Expressive\Emitter\EmitterStack;
 use Zend\Expressive\Exception;
 use Zend\Expressive\Router\Aura as AuraRouter;
-use Zend\Expressive\Router\RouterInterface;
 use Zend\Expressive\Router\Route;
+use Zend\Expressive\Router\RouterInterface;
 
 /**
  * Factory to use with an IoC container in order to return an Application instance.

--- a/src/Container/ApplicationFactory.php
+++ b/src/Container/ApplicationFactory.php
@@ -17,6 +17,7 @@ use Zend\Expressive\Emitter\EmitterStack;
 use Zend\Expressive\Exception;
 use Zend\Expressive\Router\Aura as AuraRouter;
 use Zend\Expressive\Router\RouterInterface;
+use Zend\Expressive\Router\Route;
 
 /**
  * Factory to use with an IoC container in order to return an Application instance.
@@ -167,11 +168,14 @@ class ApplicationFactory
                 ? $spec['allowed_methods']
                 : null;
             $name    = isset($spec['name']) ? $spec['name'] : null;
-            $route   = $app->route($spec['path'], $spec['middleware'], $methods, $name);
+            $methods = (null === $methods) ? Route::HTTP_METHOD_ANY : $methods;
+            $route   = new Route($spec['path'], $spec['middleware'], $methods, $name);
 
             if (isset($spec['options']) && is_array($spec['options'])) {
                 $route->setOptions($spec['options']);
             }
+
+            $app->route($route);
         }
     }
 


### PR DESCRIPTION
When a route instance is created by calling `$app->route(...)`, that instance is automatically added to the router, which tries to process the route options.
The problem is that the `ApplicationFactory` sets the options after that, which makes the router ignore any option defined for the route.

Creating the route as a new `Zend\Expressive\Router\Route` instance and passing it to the `$app->route(...)` method after processing the options fixes this problem.