### PR TITLE
Rename router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 0.2.0 - TBD
+
+Initial tagged release.
+
+### Added
+
+- Everything.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Router classes were renamed for easier discoverability and better reflect their usage. `Aura` becomes `AuraRouter`,
+`FastRoute` becomes `FastRouteRouter` and `Zf2` becomes `Zf2Router`.
+
 ## 0.1.0 - 2015-08-26
 
 Initial tagged release.

--- a/doc/book/router/aura.md
+++ b/doc/book/router/aura.md
@@ -46,27 +46,27 @@ $ composer require aura/router
 
 ## Quick Start
 
-At its simplest, you can instantiate a `Zend\Expressive\Router\Aura` instance
+At its simplest, you can instantiate a `Zend\Expressive\Router\AuraRouter` instance
 with no arguments; it will create the underlying Aura.Router objects required
 and compose them for you:
 
 ```php
-use Zend\Expressive\Router\Aura;
+use Zend\Expressive\Router\AuraRouter;
 
-$router = new Aura();
+$router = new AuraRouter();
 ```
 
 ## Programmatic Creation
 
 If you need greater control over the Aura.Router setup and configuration, you
 can create the instances necessary and inject them into
-`Zend\Expressive\Router\Aura` during instantiation.
+`Zend\Expressive\Router\AuraRouter` during instantiation.
 
 ```php
 <?php
 use Aura\Router\RouterFactory;
 use Zend\Expressive\AppFactory;
-use Zend\Expressive\Router\Aura as AuraBridge;
+use Zend\Expressive\Router\AuraRouter as AuraBridge;
 
 $auraRouter = (new RouterFactory())->newInstance();
 $auraRouter->setSecure(true);
@@ -98,7 +98,7 @@ two strategies for creating your Aura.Router implementation.
 ### Basic Router
 
 If you don't need to provide any setup or configuration, you can simply
-instantiate and return an instance of `Zend\Expressive\Router\Aura` for the
+instantiate and return an instance of `Zend\Expressive\Router\AuraRouter` for the
 service name `Zend\Expressive\Router\RouterInterface`.
 
 A factory would look like this:
@@ -108,17 +108,17 @@ A factory would look like this:
 namespace Application\Container;
 
 use Interop\Container\ContainerInterface;
-use Zend\Expressive\Router\Aura;
+use Zend\Expressive\Router\AuraRouter;
 
 class RouterFactory
 {
     /**
      * @param ContainerInterface $container
-     * @return Aura
+     * @return AuraRouter
      */
     public function __invoke(ContainerInterface $container)
     {
-        return new Aura();
+        return new AuraRouter();
     }
 }
 ```
@@ -144,7 +144,7 @@ class as an invokable:
 ```php
 $container->setInvokableClass(
     'Zend\Expressive\Router\RouterInterface',
-    'Zend\Expressive\Router\Aura'
+    'Zend\Expressive\Router\AuraRouter'
 );
 ```
 
@@ -155,7 +155,7 @@ example, we will be defining two factories:
 
 - A factory to register as and generate an `Aura\Router\Router` instance.
 - A factory registered as `Zend\Expressive\Router\RouterInterface`, which
-  creates and returns a `Zend\Expressive\Router\Aura` instance composing the
+  creates and returns a `Zend\Expressive\Router\AuraRouter` instance composing the
   `Aura\Router\Router` instance.
 
 Sound difficult? It's not; we've essentially done it above already!
@@ -189,7 +189,7 @@ class AuraRouterFactory
 namespace Application\Container;
 
 use Interop\Container\ContainerInterface;
-use Zend\Expressive\Router\Aura as AuraBridge;
+use Zend\Expressive\Router\AuraRouter as AuraBridge;
 
 class RouterFactory
 {

--- a/doc/book/router/fast-route.md
+++ b/doc/book/router/fast-route.md
@@ -10,9 +10,9 @@ dispatcher to match incoming requests against routes.
 
 If you wish to use a different combination — e.g., to use the Group Position
 Based route matcher — you will need to create your own instances and inject them
-into the `Zend\Expressive\Router\FastRoute` class, at instantiation.
+into the `Zend\Expressive\Router\FastRouteRouter` class, at instantiation.
 
-The `FastRoute` bridge class accepts two arguments at instantiation:
+The `FastRouteRouter` bridge class accepts two arguments at instantiation:
 
 - A `FastRoute\RouteCollector` instance
 - A callable that will return a `FastRoute\Dispatcher\RegexBasedAbstract`
@@ -31,7 +31,7 @@ $ composer require nikic/fast-route
 
 ## Quick Start
 
-At its simplest, you can instantiate a `Zend\Expressive\Router\FastRoute` instance
+At its simplest, you can instantiate a `Zend\Expressive\Router\FastRouteRouter` instance
 with no arguments; it will create the underlying FastRoute objects required
 and compose them for you:
 
@@ -45,11 +45,11 @@ $router = new FastRoute();
 
 If you need greater control over the FastRoute setup and configuration, you
 can create the instances necessary and inject them into
-`Zend\Expressive\Router\FastRoute` during instantiation.
+`Zend\Expressive\Router\FastRouteRouter` during instantiation.
 
 To do so, you will need to setup your `RouteCollector` instance and/or
 optionally callable to return your `RegexBasedAbstract` instance manually,
-inject them in your `Zend\Expressive\Router\FastRoute` instance, and inject use
+inject them in your `Zend\Expressive\Router\FastRouteRouter` instance, and inject use
 that when creating your `Application` instance.
 
 ```php
@@ -60,7 +60,7 @@ use FastRoute\RouteCollector;
 use FastRoute\RouteGenerator;
 use FastRoute\RouteParser\Std as RouteParser;
 use Zend\Expressive\AppFactory;
-use Zend\Expressive\Router\FastRoute as FastRouteBridge;
+use Zend\Expressive\Router\FastRouteRouter as FastRouteBridge;
 
 $fastRoute = new RouteCollector(
     new RouteParser(),
@@ -95,7 +95,7 @@ two strategies for creating your FastRoute implementation.
 ### Basic Router
 
 If you don't need to provide any setup or configuration, you can simply
-instantiate and return an instance of `Zend\Expressive\Router\FastRoute` for the
+instantiate and return an instance of `Zend\Expressive\Router\FastRouteRouter` for the
 service name `Zend\Expressive\Router\RouterInterface`.
 
 A factory would look like this:
@@ -105,17 +105,17 @@ A factory would look like this:
 namespace Application\Container;
 
 use Interop\Container\ContainerInterface;
-use Zend\Expressive\Router\FastRoute;
+use Zend\Expressive\Router\FastRouteRouter;
 
 class RouterFactory
 {
     /**
      * @param ContainerInterface $container
-     * @return FastRoute
+     * @return FastRouteRouter
      */
     public function __invoke(ContainerInterface $container)
     {
-        return new FastRoute();
+        return new FastRouteRouter();
     }
 }
 ```
@@ -141,7 +141,7 @@ class as an invokable:
 ```php
 $container->setInvokableClass(
     'Zend\Expressive\Router\RouterInterface',
-    'Zend\Expressive\Router\FastRoute'
+    'Zend\Expressive\Router\FastRouteRouter'
 );
 ```
 
@@ -154,7 +154,7 @@ example, we will be defining three factories:
 - A factory to register as `FastRoute\DispatcherFactory` and return a callable
   factory that returns a `RegexBasedAbstract` instance.
 - A factory registered as `Zend\Expressive\Router\RouterInterface`, which
-  creates and returns a `Zend\Expressive\Router\FastRoute` instance composing the
+  creates and returns a `Zend\Expressive\Router\FastRouteRouter` instance composing the
   two services.
 
 Sound difficult? It's not; we've essentially done it above already!
@@ -208,7 +208,7 @@ class FastRouteDispatcherFactory
 namespace Application\Container;
 
 use Interop\Container\ContainerInterface;
-use Zend\Expressive\Router\FastRoute as FastRouteBridge;
+use Zend\Expressive\Router\FastRouteRouter as FastRouteBridge;
 
 class RouterFactory
 {

--- a/doc/book/router/zf2.md
+++ b/doc/book/router/zf2.md
@@ -5,7 +5,7 @@ implementation; for HTTP applications, the default used in ZF2 applications is
 `Zend\Mvc\Router\Http\TreeRouteStack`, which can compose a number of different
 routes of differing types in order to perform routing.
 
-The ZF2 bridge we provide, `Zend\Expressive\Router\Zf`, uses the
+The ZF2 bridge we provide, `Zend\Expressive\Router\Zf2Router`, uses the
 `TreeRouteStack`, and injects `Segment` routes to it; these are in turn injected
 with `Method` routes, and a special "method not allowed" route at negative
 priority to enable us to distinguish between failure to match the path and
@@ -16,7 +16,7 @@ If you instantiate it with no arguments, it will create an empty
 
 ```php
 use Zend\Expressive\AppFactory;
-use Zend\Expressive\Router\Zf2 as Zf2Router;
+use Zend\Expressive\Router\Zf2Router;
 
 $app = AppFactory(null, new Zf2Router());
 ```
@@ -52,14 +52,14 @@ $ composer require zendframework/zend-mvc zendframework/zend-psr7bridge
 
 ## Quick Start
 
-At its simplest, you can instantiate a `Zend\Expressive\Router\Zf2` instance
+At its simplest, you can instantiate a `Zend\Expressive\Router\Zf2Router` instance
 with no arguments; it will create the underlying zend-mvc routing objects
 required and compose them for you:
 
 ```php
-use Zend\Expressive\Router\Zf2;
+use Zend\Expressive\Router\Zf2Router;
 
-$router = new Zf2();
+$router = new Zf2Router();
 ```
 
 ## Programmatic Creation
@@ -70,7 +70,7 @@ you can create the instances necessary and inject them into
 
 ```php
 use Zend\Expressive\AppFactory;
-use Zend\Expressive\Router\Zf2 as Zf2Bridge;
+use Zend\Expressive\Router\Zf2Router as Zf2Bridge;
 use Zend\Mvc\Router\Http\TreeRouteStack;
 
 $zf2Router = new TreeRouteStack();
@@ -101,7 +101,7 @@ two strategies for creating your zend-mvc router implementation.
 ### Basic Router
 
 If you don't need to provide any setup or configuration, you can simply
-instantiate and return an instance of `Zend\Expressive\Router\Zf2` for the
+instantiate and return an instance of `Zend\Expressive\Router\Zf2Router` for the
 service name `Zend\Expressive\Router\RouterInterface`.
 
 A factory would look like this:
@@ -111,17 +111,17 @@ A factory would look like this:
 namespace Application\Container;
 
 use Interop\Container\ContainerInterface;
-use Zend\Expressive\Router\Zf2;
+use Zend\Expressive\Router\Zf2Router;
 
 class RouterFactory
 {
     /**
      * @param ContainerInterface $container
-     * @return Zf2
+     * @return Zf2Router
      */
     public function __invoke(ContainerInterface $container)
     {
-        return new Zf2();
+        return new Zf2Router();
     }
 }
 ```
@@ -147,7 +147,7 @@ class as an invokable:
 ```php
 $container->setInvokableClass(
     'Zend\Expressive\Router\RouterInterface',
-    'Zend\Expressive\Router\Zf2'
+    'Zend\Expressive\Router\Zf2Router'
 );
 ```
 
@@ -159,7 +159,7 @@ example, we will be defining two factories:
 - A factory to register as and generate an `Zend\Mvc\Router\Http\TreeRouteStack`
   instance.
 - A factory registered as `Zend\Expressive\Router\RouterInterface`, which
-  creates and returns a `Zend\Expressive\Router\Zf2` instance composing the
+  creates and returns a `Zend\Expressive\Router\Zf2Router` instance composing the
   `Zend\Mvc\Router\Http\TreeRouteStack` instance.
 
 Sound difficult? It's not; we've essentially done it above already!
@@ -191,7 +191,7 @@ class TreeRouteStackFactory
 namespace Application\Container;
 
 use Interop\Container\ContainerInterface;
-use Zend\Expressive\Router\Zf2 as Zf2Bridge;
+use Zend\Expressive\Router\Zf2Router as Zf2Bridge;
 
 class RouterFactory
 {

--- a/src/AppFactory.php
+++ b/src/AppFactory.php
@@ -48,7 +48,7 @@ final class AppFactory
         Router\RouterInterface $router = null
     ) {
         $container = $container ?: new ServiceManager();
-        $router    = $router    ?: new Router\Aura();
+        $router    = $router    ?: new Router\AuraRouter();
         $emitter   = new Emitter\EmitterStack();
         $emitter->push(new SapiEmitter());
 

--- a/src/Container/ApplicationFactory.php
+++ b/src/Container/ApplicationFactory.php
@@ -11,11 +11,9 @@ namespace Zend\Expressive\Container;
 
 use Interop\Container\ContainerInterface;
 use Zend\Diactoros\Response\EmitterInterface;
-use Zend\Diactoros\Response\SapiEmitter;
 use Zend\Expressive\Application;
-use Zend\Expressive\Emitter\EmitterStack;
 use Zend\Expressive\Exception;
-use Zend\Expressive\Router\AuraRouter as AuraRouter;
+use Zend\Expressive\Router\AuraRouter;
 use Zend\Expressive\Router\RouterInterface;
 
 /**

--- a/src/Container/ApplicationFactory.php
+++ b/src/Container/ApplicationFactory.php
@@ -15,7 +15,7 @@ use Zend\Diactoros\Response\SapiEmitter;
 use Zend\Expressive\Application;
 use Zend\Expressive\Emitter\EmitterStack;
 use Zend\Expressive\Exception;
-use Zend\Expressive\Router\Aura as AuraRouter;
+use Zend\Expressive\Router\AuraRouter as AuraRouter;
 use Zend\Expressive\Router\RouterInterface;
 
 /**

--- a/src/Router/AuraRouter.php
+++ b/src/Router/AuraRouter.php
@@ -19,7 +19,7 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 /**
  * Router implementation bridging the Aura.Router.
  */
-class Aura implements RouterInterface
+class AuraRouter implements RouterInterface
 {
     /**
      * Aura router

--- a/src/Router/FastRouteRouter.php
+++ b/src/Router/FastRouteRouter.php
@@ -19,7 +19,7 @@ use Zend\Expressive\Exception;
 /**
  * Router implementation bridging nikic/fast-route.
  */
-class FastRoute implements RouterInterface
+class FastRouteRouter implements RouterInterface
 {
     /**
      * @var callable A factory callback that can return a dispatcher.

--- a/src/Router/Zf2Router.php
+++ b/src/Router/Zf2Router.php
@@ -11,7 +11,6 @@ namespace Zend\Expressive\Router;
 
 use Psr\Http\Message\ServerRequestInterface as PsrRequest;
 use Zend\Expressive\Exception;
-use Zend\Mvc\Router\Http\Part as PartRoute;
 use Zend\Mvc\Router\Http\TreeRouteStack;
 use Zend\Mvc\Router\RouteMatch;
 use Zend\Psr7Bridge\Psr7ServerRequest;

--- a/src/Router/Zf2Router.php
+++ b/src/Router/Zf2Router.php
@@ -27,7 +27,7 @@ use Zend\Psr7Bridge\Psr7ServerRequest;
  * matches with this special route, we can send the HTTP allowed methods stored
  * for that path.
  */
-class Zf2 implements RouterInterface
+class Zf2Router implements RouterInterface
 {
     const METHOD_NOT_ALLOWED_ROUTE = 'method_not_allowed';
 

--- a/src/Template/Twig.php
+++ b/src/Template/Twig.php
@@ -10,8 +10,8 @@
 namespace Zend\Expressive\Template;
 
 use LogicException;
-use Twig_Loader_Filesystem as TwigFilesystem;
 use Twig_Environment as TwigEnvironment;
+use Twig_Loader_Filesystem as TwigFilesystem;
 
 /**
  * Template implementation bridging league/plates

--- a/src/Template/ZendView.php
+++ b/src/Template/ZendView.php
@@ -9,13 +9,12 @@
 
 namespace Zend\Expressive\Template;
 
+use Zend\Expressive\Exception;
 use Zend\View\Model\ModelInterface;
 use Zend\View\Model\ViewModel;
-use Zend\View\Renderer\RendererInterface;
 use Zend\View\Renderer\PhpRenderer;
+use Zend\View\Renderer\RendererInterface;
 use Zend\View\Resolver\AggregateResolver;
-use Zend\View\Resolver\ResolverInterface;
-use Zend\Expressive\Exception;
 
 /**
  * Template implementation bridging zendframework/zend-view.

--- a/test/AppFactoryTest.php
+++ b/test/AppFactoryTest.php
@@ -33,7 +33,7 @@ class AppFactoryTest extends TestCase
     {
         $app    = AppFactory::create();
         $router = $this->getRouterFromApplication($app);
-        $this->assertInstanceOf('Zend\Expressive\Router\Aura', $router);
+        $this->assertInstanceOf('Zend\Expressive\Router\AuraRouter', $router);
     }
 
     public function testFactoryUsesZf2ServiceManagerByDefault()

--- a/test/Container/ApplicationFactoryTest.php
+++ b/test/Container/ApplicationFactoryTest.php
@@ -203,7 +203,7 @@ class ApplicationFactoryTest extends TestCase
         $app = $this->factory->__invoke($this->container->reveal());
         $this->assertInstanceOf('Zend\Expressive\Application', $app);
         $router = $this->getRouterFromApplication($app);
-        $this->assertInstanceOf('Zend\Expressive\Router\Aura', $router);
+        $this->assertInstanceOf('Zend\Expressive\Router\AuraRouter', $router);
         $this->assertSame($this->container->reveal(), $app->getContainer());
         $this->assertInstanceOf('Zend\Expressive\Emitter\EmitterStack', $app->getEmitter());
         $this->assertCount(1, $app->getEmitter());

--- a/test/IntegrationTest.php
+++ b/test/IntegrationTest.php
@@ -16,7 +16,7 @@ use Zend\Diactoros\ServerRequest;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\Response\EmitterInterface;
 use Zend\Expressive\Application;
-use Zend\Expressive\Router\Aura as AuraRouter;
+use Zend\Expressive\Router\AuraRouter as AuraRouter;
 use Zend\Expressive\TemplatedErrorHandler;
 
 class IntegrationTest extends TestCase

--- a/test/RouteMiddlewareTest.php
+++ b/test/RouteMiddlewareTest.php
@@ -265,9 +265,9 @@ class RouteMiddlewareTest extends TestCase
     public function routerAdapters()
     {
         return [
-          'aura'       => [ 'Zend\Expressive\Router\Aura' ],
-          'fast-route' => [ 'Zend\Expressive\Router\FastRoute' ],
-          'zf2'        => [ 'Zend\Expressive\Router\Zf2' ],
+          'aura'       => [ 'Zend\Expressive\Router\AuraRouter' ],
+          'fast-route' => [ 'Zend\Expressive\Router\FastRouteRouter' ],
+          'zf2'        => [ 'Zend\Expressive\Router\Zf2Router' ],
         ];
     }
 

--- a/test/Router/AuraRouterTest.php
+++ b/test/Router/AuraRouterTest.php
@@ -10,10 +10,10 @@
 namespace ZendTest\Expressive\Router;
 
 use PHPUnit_Framework_TestCase as TestCase;
-use Zend\Expressive\Router\Aura as AuraRouter;
+use Zend\Expressive\Router\AuraRouter as AuraRouter;
 use Zend\Expressive\Router\Route;
 
-class AuraRouteTest extends TestCase
+class AuraRouterTest extends TestCase
 {
     public function setUp()
     {

--- a/test/Router/AuraRouterTest.php
+++ b/test/Router/AuraRouterTest.php
@@ -10,7 +10,7 @@
 namespace ZendTest\Expressive\Router;
 
 use PHPUnit_Framework_TestCase as TestCase;
-use Zend\Expressive\Router\AuraRouter as AuraRouter;
+use Zend\Expressive\Router\AuraRouter;
 use Zend\Expressive\Router\Route;
 
 class AuraRouterTest extends TestCase

--- a/test/Router/FastRouteRouterTest.php
+++ b/test/Router/FastRouteRouterTest.php
@@ -11,10 +11,10 @@ namespace ZendTest\Expressive\Router;
 
 use FastRoute\Dispatcher\GroupCountBased as Dispatcher;
 use PHPUnit_Framework_TestCase as TestCase;
-use Zend\Expressive\Router\FastRoute;
+use Zend\Expressive\Router\FastRouteRouter;
 use Zend\Expressive\Router\Route;
 
-class FastRouteTest extends TestCase
+class FastRouteRouterTest extends TestCase
 {
     public function setUp()
     {
@@ -27,7 +27,7 @@ class FastRouteTest extends TestCase
 
     public function getRouter()
     {
-        return new FastRoute(
+        return new FastRouteRouter(
             $this->fastRouter->reveal(),
             $this->dispatchCallback
         );
@@ -35,7 +35,7 @@ class FastRouteTest extends TestCase
 
     public function testWillLazyInstantiateAFastRouteCollectorIfNoneIsProvidedToConstructor()
     {
-        $router = new FastRoute();
+        $router = new FastRouteRouter();
         $this->assertAttributeInstanceOf('FastRoute\RouteCollector', 'router', $router);
     }
 
@@ -169,7 +169,7 @@ class FastRouteTest extends TestCase
      */
     public function testCanGenerateUriFromRoutes()
     {
-        $router = new FastRoute();
+        $router = new FastRouteRouter();
         $route1 = new Route('/foo', 'foo', ['POST'], 'foo-create');
         $route2 = new Route('/foo', 'foo', ['GET'], 'foo-list');
         $route3 = new Route('/foo/{id:\d+}', 'foo', ['GET'], 'foo');

--- a/test/Router/Zf2RouterTest.php
+++ b/test/Router/Zf2RouterTest.php
@@ -11,8 +11,7 @@ namespace ZendTest\Expressive\Router;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use Prophecy\Argument;
-use ReflectionProperty;
-use Zend\Expressive\Router\Zf2Router as Zf2Router;
+use Zend\Expressive\Router\Zf2Router;
 use Zend\Expressive\Router\Route;
 use Zend\Diactoros\ServerRequest;
 

--- a/test/Router/Zf2RouterTest.php
+++ b/test/Router/Zf2RouterTest.php
@@ -12,11 +12,11 @@ namespace ZendTest\Expressive\Router;
 use PHPUnit_Framework_TestCase as TestCase;
 use Prophecy\Argument;
 use ReflectionProperty;
-use Zend\Expressive\Router\Zf2 as Zf2Router;
+use Zend\Expressive\Router\Zf2Router as Zf2Router;
 use Zend\Expressive\Router\Route;
 use Zend\Diactoros\ServerRequest;
 
-class Zf2Test extends TestCase
+class Zf2RouterTest extends TestCase
 {
     public function setUp()
     {


### PR DESCRIPTION
As per #119 , this appends the "Router" word after all "router" class, to avoid ambiguousness between Route and Router.