### PR TITLE
Fix not pushing error handler

### DIFF
--- a/src/WhoopsErrorHandler.php
+++ b/src/WhoopsErrorHandler.php
@@ -77,6 +77,8 @@ class WhoopsErrorHandler extends TemplatedErrorHandler
     {
         $this->prepareWhoopsHandler($request);
 
+        $this->whoops->pushHandler($this->whoopsHandler);
+
         $response
             ->getBody()
             ->write($this->whoops->handleException($exception));


### PR DESCRIPTION
There is no error handler pushed. That's why the pages are empty on errors. This fixes #124.