### PR TITLE
Renamed Zf2Router to ZendRouter

### DIFF
--- a/doc/book/router/zf2.md
+++ b/doc/book/router/zf2.md
@@ -5,7 +5,7 @@ implementation; for HTTP applications, the default used in ZF2 applications is
 `Zend\Mvc\Router\Http\TreeRouteStack`, which can compose a number of different
 routes of differing types in order to perform routing.
 
-The ZF2 bridge we provide, `Zend\Expressive\Router\Zf2Router`, uses the
+The ZF2 bridge we provide, `Zend\Expressive\Router\ZendRouter`, uses the
 `TreeRouteStack`, and injects `Segment` routes to it; these are in turn injected
 with `Method` routes, and a special "method not allowed" route at negative
 priority to enable us to distinguish between failure to match the path and
@@ -16,9 +16,9 @@ If you instantiate it with no arguments, it will create an empty
 
 ```php
 use Zend\Expressive\AppFactory;
-use Zend\Expressive\Router\Zf2Router;
+use Zend\Expressive\Router\ZendRouter;
 
-$app = AppFactory(null, new Zf2Router());
+$app = AppFactory(null, new ZendRouter());
 ```
 
 The `TreeRouteStack` offers some unique features:
@@ -52,32 +52,32 @@ $ composer require zendframework/zend-mvc zendframework/zend-psr7bridge
 
 ## Quick Start
 
-At its simplest, you can instantiate a `Zend\Expressive\Router\Zf2Router` instance
+At its simplest, you can instantiate a `Zend\Expressive\Router\ZendRouter` instance
 with no arguments; it will create the underlying zend-mvc routing objects
 required and compose them for you:
 
 ```php
-use Zend\Expressive\Router\Zf2Router;
+use Zend\Expressive\Router\ZendRouter;
 
-$router = new Zf2Router();
+$router = new ZendRouter();
 ```
 
 ## Programmatic Creation
 
 If you need greater control over the zend-mvc router setup and configuration,
 you can create the instances necessary and inject them into
-`Zend\Expressive\Router\Zf2` during instantiation.
+`Zend\Expressive\Router\ZendRouter` during instantiation.
 
 ```php
 use Zend\Expressive\AppFactory;
-use Zend\Expressive\Router\Zf2Router as Zf2Bridge;
+use Zend\Expressive\Router\ZendRouter as Zf2Bridge;
 use Zend\Mvc\Router\Http\TreeRouteStack;
 
-$zf2Router = new TreeRouteStack();
-$zf2Router->addPrototypes(/* ... */);
-$zf2Router->setBaseUrl(/* ... */);
+$zendRouter = new TreeRouteStack();
+$zendRouter->addPrototypes(/* ... */);
+$zendRouter->setBaseUrl(/* ... */);
 
-$router = new Zf2Bridge($zf2Router);
+$router = new Zf2Bridge($zendRouter);
 
 // First argument is the container to use, if not using the default;
 // second is the router.
@@ -101,7 +101,7 @@ two strategies for creating your zend-mvc router implementation.
 ### Basic Router
 
 If you don't need to provide any setup or configuration, you can simply
-instantiate and return an instance of `Zend\Expressive\Router\Zf2Router` for the
+instantiate and return an instance of `Zend\Expressive\Router\ZendRouter` for the
 service name `Zend\Expressive\Router\RouterInterface`.
 
 A factory would look like this:
@@ -111,17 +111,17 @@ A factory would look like this:
 namespace Application\Container;
 
 use Interop\Container\ContainerInterface;
-use Zend\Expressive\Router\Zf2Router;
+use Zend\Expressive\Router\ZendRouter;
 
 class RouterFactory
 {
     /**
      * @param ContainerInterface $container
-     * @return Zf2Router
+     * @return ZendRouter
      */
     public function __invoke(ContainerInterface $container)
     {
-        return new Zf2Router();
+        return new ZendRouter();
     }
 }
 ```
@@ -147,7 +147,7 @@ class as an invokable:
 ```php
 $container->setInvokableClass(
     'Zend\Expressive\Router\RouterInterface',
-    'Zend\Expressive\Router\Zf2Router'
+    'Zend\Expressive\Router\ZendRouter'
 );
 ```
 
@@ -159,7 +159,7 @@ example, we will be defining two factories:
 - A factory to register as and generate an `Zend\Mvc\Router\Http\TreeRouteStack`
   instance.
 - A factory registered as `Zend\Expressive\Router\RouterInterface`, which
-  creates and returns a `Zend\Expressive\Router\Zf2Router` instance composing the
+  creates and returns a `Zend\Expressive\Router\ZendRouter` instance composing the
   `Zend\Mvc\Router\Http\TreeRouteStack` instance.
 
 Sound difficult? It's not; we've essentially done it above already!
@@ -191,7 +191,7 @@ class TreeRouteStackFactory
 namespace Application\Container;
 
 use Interop\Container\ContainerInterface;
-use Zend\Expressive\Router\Zf2Router as Zf2Bridge;
+use Zend\Expressive\Router\ZendRouter as Zf2Bridge;
 
 class RouterFactory
 {

--- a/src/Router/ZendRouter.php
+++ b/src/Router/ZendRouter.php
@@ -26,7 +26,7 @@ use Zend\Psr7Bridge\Psr7ServerRequest;
  * matches with this special route, we can send the HTTP allowed methods stored
  * for that path.
  */
-class Zf2Router implements RouterInterface
+class ZendRouter implements RouterInterface
 {
     const METHOD_NOT_ALLOWED_ROUTE = 'method_not_allowed';
 
@@ -47,7 +47,7 @@ class Zf2Router implements RouterInterface
     /**
      * @var TreeRouteStack
      */
-    private $zf2Router;
+    private $zendRouter;
 
     /**
      * Constructor.
@@ -62,7 +62,7 @@ class Zf2Router implements RouterInterface
             $router = $this->createRouter();
         }
 
-        $this->zf2Router = $router;
+        $this->zendRouter = $router;
     }
 
     /**
@@ -82,7 +82,7 @@ class Zf2Router implements RouterInterface
 
         $allowedMethods = $route->getAllowedMethods();
         if (Route::HTTP_METHOD_ANY === $allowedMethods) {
-            $this->zf2Router->addRoute($name, [
+            $this->zendRouter->addRoute($name, [
                 'type'    => 'segment',
                 'options' => $options,
             ]);
@@ -116,7 +116,7 @@ class Zf2Router implements RouterInterface
             unset($spec['child_routes'][self::METHOD_NOT_ALLOWED_ROUTE]);
         }
 
-        $this->zf2Router->addRoute($name, $spec);
+        $this->zendRouter->addRoute($name, $spec);
         $this->allowedMethodsByPath[$path] = $allowedMethods;
         $this->routeNameMap[$name] = sprintf('%s/%s', $name, $httpMethodRouteName);
     }
@@ -129,7 +129,7 @@ class Zf2Router implements RouterInterface
      */
     public function match(PsrRequest $request)
     {
-        $match = $this->zf2Router->match(Psr7ServerRequest::toZend($request, true));
+        $match = $this->zendRouter->match(Psr7ServerRequest::toZend($request, true));
 
         if (null === $match) {
             return RouteResult::fromRouteFailure();
@@ -143,7 +143,7 @@ class Zf2Router implements RouterInterface
      */
     public function generateUri($name, array $substitutions = [])
     {
-        if (! $this->zf2Router->hasRoute($name)) {
+        if (! $this->zendRouter->hasRoute($name)) {
             throw new Exception\RuntimeException(sprintf(
                 'Cannot generate URI based on route "%s"; route not found',
                 $name
@@ -157,7 +157,7 @@ class Zf2Router implements RouterInterface
             'only_return_path' => true,
         ];
 
-        return $this->zf2Router->assemble($substitutions, $options);
+        return $this->zendRouter->assemble($substitutions, $options);
     }
 
     /**

--- a/test/RouteMiddlewareTest.php
+++ b/test/RouteMiddlewareTest.php
@@ -267,7 +267,7 @@ class RouteMiddlewareTest extends TestCase
         return [
           'aura'       => [ 'Zend\Expressive\Router\AuraRouter' ],
           'fast-route' => [ 'Zend\Expressive\Router\FastRouteRouter' ],
-          'zf2'        => [ 'Zend\Expressive\Router\Zf2Router' ],
+          'zf2'        => [ 'Zend\Expressive\Router\ZendRouter' ],
         ];
     }
 

--- a/test/Router/ZendRouterTest.php
+++ b/test/Router/ZendRouterTest.php
@@ -13,24 +13,24 @@ use PHPUnit_Framework_TestCase as TestCase;
 use Prophecy\Argument;
 use Zend\Diactoros\ServerRequest;
 use Zend\Expressive\Router\Route;
-use Zend\Expressive\Router\Zf2Router;
+use Zend\Expressive\Router\ZendRouter;
 
-class Zf2RouterTest extends TestCase
+class ZendRouterTest extends TestCase
 {
     public function setUp()
     {
-        $this->zf2Router = $this->prophesize('Zend\Mvc\Router\Http\TreeRouteStack');
+        $this->zendRouter = $this->prophesize('Zend\Mvc\Router\Http\TreeRouteStack');
     }
 
     public function getRouter()
     {
-        return new Zf2Router($this->zf2Router->reveal());
+        return new ZendRouter($this->zendRouter->reveal());
     }
 
-    public function testWillLazyInstantiateAZf2TreeRouteStackIfNoneIsProvidedToConstructor()
+    public function testWillLazyInstantiateAZendTreeRouteStackIfNoneIsProvidedToConstructor()
     {
-        $router = new Zf2Router();
-        $this->assertAttributeInstanceOf('Zend\Mvc\Router\Http\TreeRouteStack', 'zf2Router', $router);
+        $router = new ZendRouter();
+        $this->assertAttributeInstanceOf('Zend\Mvc\Router\Http\TreeRouteStack', 'zendRouter', $router);
     }
 
     public function createRequestProphecy()
@@ -51,11 +51,11 @@ class Zf2RouterTest extends TestCase
         return $request;
     }
 
-    public function testAddingRouteProxiesToZf2Router()
+    public function testAddingRouteProxiesToZendRouter()
     {
         $route = new Route('/foo', 'foo', ['GET']);
 
-        $this->zf2Router->addRoute('/foo^GET', [
+        $this->zendRouter->addRoute('/foo^GET', [
             'type' => 'segment',
             'options' => [
                 'route' => '/foo',
@@ -71,13 +71,13 @@ class Zf2RouterTest extends TestCase
                         ],
                     ],
                 ],
-                Zf2Router::METHOD_NOT_ALLOWED_ROUTE => [
+                ZendRouter::METHOD_NOT_ALLOWED_ROUTE => [
                     'type'     => 'regex',
                     'priority' => -1,
                     'options'  => [
                         'regex' => '/*$',
                         'defaults' => [
-                            Zf2Router::METHOD_NOT_ALLOWED_ROUTE => '/foo',
+                            ZendRouter::METHOD_NOT_ALLOWED_ROUTE => '/foo',
                         ],
                         'spec' => '',
                     ],
@@ -101,7 +101,7 @@ class Zf2RouterTest extends TestCase
             ],
         ]);
 
-        $this->zf2Router->addRoute('/foo/:id^GET', [
+        $this->zendRouter->addRoute('/foo/:id^GET', [
             'type' => 'segment',
             'options' => [
                 'route' => '/foo/:id',
@@ -123,13 +123,13 @@ class Zf2RouterTest extends TestCase
                         ],
                     ],
                 ],
-                Zf2Router::METHOD_NOT_ALLOWED_ROUTE => [
+                ZendRouter::METHOD_NOT_ALLOWED_ROUTE => [
                     'type'     => 'regex',
                     'priority' => -1,
                     'options'  => [
                         'regex' => '/*$',
                         'defaults' => [
-                            Zf2Router::METHOD_NOT_ALLOWED_ROUTE => '/foo/:id',
+                            ZendRouter::METHOD_NOT_ALLOWED_ROUTE => '/foo/:id',
                         ],
                         'spec' => '',
                     ],
@@ -163,12 +163,12 @@ class Zf2RouterTest extends TestCase
         };
 
         $route = new Route('/foo', $middleware, ['GET']);
-        $zf2Router = new Zf2Router();
-        $zf2Router->addRoute($route);
+        $zendRouter = new ZendRouter();
+        $zendRouter->addRoute($route);
 
         $request = new ServerRequest([ 'REQUEST_METHOD' => 'GET' ], [], '/foo', 'GET');
 
-        $result = $zf2Router->match($request);
+        $result = $zendRouter->match($request);
         $this->assertInstanceOf('Zend\Expressive\Router\RouteResult', $result);
         $this->assertEquals('/foo^GET', $result->getMatchedRouteName());
         $this->assertEquals($middleware, $result->getMatchedMiddleware());
@@ -185,7 +185,7 @@ class Zf2RouterTest extends TestCase
             'middleware' => 'bar',
         ]);
 
-        $this->zf2Router
+        $this->zendRouter
             ->match(Argument::type('Zend\Http\PhpEnvironment\Request'))
             ->willReturn($routeMatch->reveal());
 
@@ -204,7 +204,7 @@ class Zf2RouterTest extends TestCase
      */
     public function testNonSuccessfulMatchNotDueToHttpMethodsIsPossible()
     {
-        $this->zf2Router
+        $this->zendRouter
             ->match(Argument::type('Zend\Http\PhpEnvironment\Request'))
             ->willReturn(null);
 
@@ -222,7 +222,7 @@ class Zf2RouterTest extends TestCase
      */
     public function testMatchFailureDueToHttpMethodReturnsRouteResultWithAllowedMethods()
     {
-        $router = new Zf2Router();
+        $router = new ZendRouter();
         $router->addRoute(new Route('/foo', 'bar', ['POST', 'DELETE']));
         $request = new ServerRequest([ 'REQUEST_METHOD' => 'GET' ], [], '/foo', 'GET');
         $result = $router->match($request);
@@ -238,7 +238,7 @@ class Zf2RouterTest extends TestCase
      */
     public function testMatchFailureDueToMethodNotAllowedWithParamsInTheRoute()
     {
-        $router = new Zf2Router();
+        $router = new ZendRouter();
         $router->addRoute(new Route('/foo[/:id]', 'foo', ['POST', 'DELETE']));
         $request = new ServerRequest([ 'REQUEST_METHOD' => 'GET' ], [], '/foo/1', 'GET');
         $result = $router->match($request);
@@ -254,7 +254,7 @@ class Zf2RouterTest extends TestCase
      */
     public function testCanGenerateUriFromRoutes()
     {
-        $router = new Zf2Router();
+        $router = new ZendRouter();
         $route1 = new Route('/foo', 'foo', ['POST'], 'foo-create');
         $route2 = new Route('/foo', 'foo', ['GET'], 'foo-list');
         $route3 = new Route('/foo/:id', 'foo', ['GET'], 'foo');


### PR DESCRIPTION
Renamed Zf2Router to ZendRouter per discussion with @weierophinney at IRC for better consistency throughout the library (ZendView for example)