### PR TITLE
add getRouter() function in Routers

### DIFF
--- a/src/Router/AuraRouter.php
+++ b/src/Router/AuraRouter.php
@@ -67,6 +67,14 @@ class AuraRouter implements RouterInterface
     }
 
     /**
+     * @return Router
+     */
+    public function getRouter()
+    {
+        return $this->router;
+    }
+
+    /**
      * Add a route to the underlying router.
      *
      * Adds the route to the Aura.Router, using the path as the name, and a

--- a/src/Router/FastRouteRouter.php
+++ b/src/Router/FastRouteRouter.php
@@ -158,6 +158,14 @@ class FastRouteRouter implements RouterInterface
     }
 
     /**
+     * @return RouteCollector
+     */
+    public function getRouter()
+    {
+        return $this->router;
+    }
+
+    /**
      * Retrieve the dispatcher instance.
      *
      * Uses the callable factory in $dispatcherCallback, passing it $data

--- a/src/Router/Zf2Router.php
+++ b/src/Router/Zf2Router.php
@@ -169,6 +169,14 @@ class Zf2Router implements RouterInterface
     }
 
     /**
+     * @return TreeRouteStack
+     */
+    public function getRouter()
+    {
+        return $this->zf2Router;
+    }
+
+    /**
      * Create a successful RouteResult from the given RouteMatch.
      *
      * @param RouteMatch $match

--- a/test/Router/AuraRouterTest.php
+++ b/test/Router/AuraRouterTest.php
@@ -26,6 +26,12 @@ class AuraRouterTest extends TestCase
         return new AuraRouter($this->auraRouter->reveal());
     }
 
+    public function testGetAuraRouter()
+    {
+        $router = $this->getRouter();
+        $this->assertSame($this->auraRouter->reveal(), $router->getRouter());
+    }
+
     public function testAddingRouteProxiesToAuraRouter()
     {
         $route = new Route('/foo', 'foo', ['GET']);

--- a/test/Router/AuraRouterTest.php
+++ b/test/Router/AuraRouterTest.php
@@ -26,7 +26,7 @@ class AuraRouterTest extends TestCase
         return new AuraRouter($this->auraRouter->reveal());
     }
 
-    public function testGetAuraRouter()
+    public function testGetAuraRouterRouter()
     {
         $router = $this->getRouter();
         $this->assertSame($this->auraRouter->reveal(), $router->getRouter());

--- a/test/Router/FastRouteRouterTest.php
+++ b/test/Router/FastRouteRouterTest.php
@@ -33,7 +33,7 @@ class FastRouteRouterTest extends TestCase
         );
     }
 
-    public function testGetAuraRouter()
+    public function testGetFastRouteRouterRouter()
     {
         $router = $this->getRouter();
         $this->assertSame($this->fastRouter->reveal(), $router->getRouter());

--- a/test/Router/FastRouteRouterTest.php
+++ b/test/Router/FastRouteRouterTest.php
@@ -33,6 +33,12 @@ class FastRouteRouterTest extends TestCase
         );
     }
 
+    public function testGetAuraRouter()
+    {
+        $router = $this->getRouter();
+        $this->assertSame($this->fastRouter->reveal(), $router->getRouter());
+    }
+
     public function testWillLazyInstantiateAFastRouteCollectorIfNoneIsProvidedToConstructor()
     {
         $router = new FastRouteRouter();

--- a/test/Router/Zf2RouterTest.php
+++ b/test/Router/Zf2RouterTest.php
@@ -27,7 +27,7 @@ class Zf2RouterTest extends TestCase
         return new Zf2Router($this->zf2Router->reveal());
     }
 
-    public function testGetAuraRouter()
+    public function testGetZf2RouterRouter()
     {
         $router = $this->getRouter();
         $this->assertSame($this->zf2Router->reveal(), $router->getRouter());

--- a/test/Router/Zf2RouterTest.php
+++ b/test/Router/Zf2RouterTest.php
@@ -27,6 +27,12 @@ class Zf2RouterTest extends TestCase
         return new Zf2Router($this->zf2Router->reveal());
     }
 
+    public function testGetAuraRouter()
+    {
+        $router = $this->getRouter();
+        $this->assertSame($this->zf2Router->reveal(), $router->getRouter());
+    }
+
     public function testWillLazyInstantiateAZf2TreeRouteStackIfNoneIsProvidedToConstructor()
     {
         $router = new Zf2Router();


### PR DESCRIPTION
I think this may be useful to add `getRouter()` so in real app we can use more function from it's router property when needed.