### PR TITLE
Fixed quick start documentation require statement

### DIFF
--- a/doc/book/quick-start.md
+++ b/doc/book/quick-start.md
@@ -58,7 +58,7 @@ root, and we want it to intercept any incoming request; as such, we'll use
 use Zend\Expressive\AppFactory;
 
 chdir(dirname(__DIR__));
-require 'vendor/autoload.php';
+require '../vendor/autoload.php';
 
 $app = AppFactory::create();
 


### PR DESCRIPTION
With this directory structure:

composer.json
composer.lock
vendor/autoload.php
vendor/...
public/index.php

The require statement needs to step back a level before stepping into the vendor directory.

At least, I needed to make this change to make it work on my machine.