### PR TITLE
Renamed 'Zend\Expressive\FinalHandler' to 'Zend\Stratigility\FinalHandler'

### DIFF
--- a/doc/book/container/factories.md
+++ b/doc/book/container/factories.md
@@ -18,7 +18,7 @@ namespace, and define an `__invoke()` method that accepts an
     - `Zend\Expressive\Router\RouterInterface`. When provided, the service will
       be used to construct the `Application` instance; otherwise, an Aura router
       implementation will be used.
-    - `Zend\Expressive\FinalHandler`. This is a meta-service, as the only concrete
+    - `Zend\Stratigility\FinalHandler`. This is a meta-service, as the only concrete
       type required is a callable that can be used as a final middleware in the
       case that the stack is exhausted before execution ends. By default, an
       instance of `Zend\Stratigility\FinalHandler` will be used.
@@ -113,7 +113,7 @@ order to seed the `Application` instance:
 ## TemplatedErrorHandlerFactory
 
 - **Provides**: `Zend\Expressive\TemplatedErrorHandler`
-- **Suggested Name**: `Zend\Expressive\FinalHandler`
+- **Suggested Name**: `Zend\Stratigility\FinalHandler`
 - **Requires**: no additional services are required.
 - **Optional**:
     - `Zend\Expressive\Template\TemplateInterface`. If not provided, the error
@@ -138,7 +138,7 @@ seed the `Templated` instance:
 ## WhoopsErrorHandlerFactory
 
 - **Provides**: `Zend\Expressive\TemplatedErrorHandler`
-- **Suggested Name**: `Zend\Expressive\FinalHandler`
+- **Suggested Name**: `Zend\Stratigility\FinalHandler`
 - **Requires**:
     - `Zend\Expressive\Whoops`, which should provide a `Whoops\Run` instance.
     - `Zend\Expressive\WhoopsPageHandler`, which should provide a

--- a/doc/book/error-handling.md
+++ b/doc/book/error-handling.md
@@ -134,7 +134,7 @@ factories that work with [container-interop](https://github.com/container-intero
 container implementations to simplify setup.
 
 In each case, you should register the selected error handler's factory as the service
-`Zend\Expressive\FinalHandler`.
+`Zend\Stratigility\FinalHandler`.
 
 - For the `TemplatedErrorHandler`, use [`Zend\Expressive\Container\TemplatedErrorHandlerFactory`](container/factories.md#templatederrorhandlerfactory).
 - For the `WhoopsErrorHandler`, use [`Zend\Expressive\Container\WhoopsErrorHandlerFactory`](container/factories.md#whoopserrorhandlerfactory).

--- a/src/Container/ApplicationFactory.php
+++ b/src/Container/ApplicationFactory.php
@@ -126,8 +126,8 @@ class ApplicationFactory
             ? $container->get(RouterInterface::class)
             : new AuraRouter();
 
-        $finalHandler = $container->has('Zend\Expressive\FinalHandler')
-            ? $container->get('Zend\Expressive\FinalHandler')
+        $finalHandler = $container->has('Zend\Stratigility\FinalHandler')
+            ? $container->get('Zend\Stratigility\FinalHandler')
             : null;
 
         $emitter = $container->has(EmitterInterface::class)

--- a/test/Container/ApplicationFactoryTest.php
+++ b/test/Container/ApplicationFactoryTest.php
@@ -88,10 +88,10 @@ class ApplicationFactoryTest extends TestCase
             });
 
         $this->container
-            ->has('Zend\Expressive\FinalHandler')
+            ->has('Zend\Stratigility\FinalHandler')
             ->willReturn(true);
         $this->container
-            ->get('Zend\Expressive\FinalHandler')
+            ->get('Zend\Stratigility\FinalHandler')
             ->willReturn($finalHandler);
 
         $this->container

--- a/test/Container/ApplicationFactoryTest.php
+++ b/test/Container/ApplicationFactoryTest.php
@@ -148,10 +148,10 @@ class ApplicationFactoryTest extends TestCase
             });
 
         $this->container
-            ->has('Zend\Expressive\FinalHandler')
+            ->has('Zend\Stratigility\FinalHandler')
             ->willReturn(true);
         $this->container
-            ->get('Zend\Expressive\FinalHandler')
+            ->get('Zend\Stratigility\FinalHandler')
             ->willReturn($finalHandler);
 
         $this->container
@@ -190,10 +190,10 @@ class ApplicationFactoryTest extends TestCase
             ->shouldNotBeCalled();
 
         $this->container
-            ->has('Zend\Expressive\FinalHandler')
+            ->has('Zend\Stratigility\FinalHandler')
             ->willReturn(false);
         $this->container
-            ->get('Zend\Expressive\FinalHandler')
+            ->get('Zend\Stratigility\FinalHandler')
             ->shouldNotBeCalled();
 
         $this->container
@@ -260,10 +260,10 @@ class ApplicationFactoryTest extends TestCase
             });
 
         $this->container
-            ->has('Zend\Expressive\FinalHandler')
+            ->has('Zend\Stratigility\FinalHandler')
             ->willReturn(true);
         $this->container
-            ->get('Zend\Expressive\FinalHandler')
+            ->get('Zend\Stratigility\FinalHandler')
             ->willReturn($finalHandler);
 
         $this->container
@@ -348,10 +348,10 @@ class ApplicationFactoryTest extends TestCase
             });
 
         $this->container
-            ->has('Zend\Expressive\FinalHandler')
+            ->has('Zend\Stratigility\FinalHandler')
             ->willReturn(true);
         $this->container
-            ->get('Zend\Expressive\FinalHandler')
+            ->get('Zend\Stratigility\FinalHandler')
             ->willReturn($finalHandler);
 
         $this->container
@@ -430,10 +430,10 @@ class ApplicationFactoryTest extends TestCase
             });
 
         $this->container
-            ->has('Zend\Expressive\FinalHandler')
+            ->has('Zend\Stratigility\FinalHandler')
             ->willReturn(true);
         $this->container
-            ->get('Zend\Expressive\FinalHandler')
+            ->get('Zend\Stratigility\FinalHandler')
             ->willReturn($finalHandler);
 
         $this->container
@@ -533,10 +533,10 @@ class ApplicationFactoryTest extends TestCase
             });
 
         $this->container
-            ->has('Zend\Expressive\FinalHandler')
+            ->has('Zend\Stratigility\FinalHandler')
             ->willReturn(true);
         $this->container
-            ->get('Zend\Expressive\FinalHandler')
+            ->get('Zend\Stratigility\FinalHandler')
             ->willReturn($finalHandler);
 
         $this->container
@@ -593,10 +593,10 @@ class ApplicationFactoryTest extends TestCase
             });
 
         $this->container
-            ->has('Zend\Expressive\FinalHandler')
+            ->has('Zend\Stratigility\FinalHandler')
             ->willReturn(true);
         $this->container
-            ->get('Zend\Expressive\FinalHandler')
+            ->get('Zend\Stratigility\FinalHandler')
             ->willReturn($finalHandler);
 
         $this->container
@@ -655,10 +655,10 @@ class ApplicationFactoryTest extends TestCase
             });
 
         $this->container
-            ->has('Zend\Expressive\FinalHandler')
+            ->has('Zend\Stratigility\FinalHandler')
             ->willReturn(true);
         $this->container
-            ->get('Zend\Expressive\FinalHandler')
+            ->get('Zend\Stratigility\FinalHandler')
             ->willReturn($finalHandler);
 
         $this->container
@@ -746,10 +746,10 @@ class ApplicationFactoryTest extends TestCase
             });
 
         $this->container
-            ->has('Zend\Expressive\FinalHandler')
+            ->has('Zend\Stratigility\FinalHandler')
             ->willReturn(true);
         $this->container
-            ->get('Zend\Expressive\FinalHandler')
+            ->get('Zend\Stratigility\FinalHandler')
             ->willReturn($finalHandler);
 
         $this->container
@@ -812,10 +812,10 @@ class ApplicationFactoryTest extends TestCase
             });
 
         $this->container
-            ->has('Zend\Expressive\FinalHandler')
+            ->has('Zend\Stratigility\FinalHandler')
             ->willReturn(true);
         $this->container
-            ->get('Zend\Expressive\FinalHandler')
+            ->get('Zend\Stratigility\FinalHandler')
             ->willReturn($finalHandler);
 
         $this->container
@@ -899,10 +899,10 @@ class ApplicationFactoryTest extends TestCase
             });
 
         $this->container
-            ->has('Zend\Expressive\FinalHandler')
+            ->has('Zend\Stratigility\FinalHandler')
             ->willReturn(true);
         $this->container
-            ->get('Zend\Expressive\FinalHandler')
+            ->get('Zend\Stratigility\FinalHandler')
             ->willReturn($finalHandler);
 
         $this->container
@@ -973,10 +973,10 @@ class ApplicationFactoryTest extends TestCase
             });
 
         $this->container
-            ->has('Zend\Expressive\FinalHandler')
+            ->has('Zend\Stratigility\FinalHandler')
             ->willReturn(true);
         $this->container
-            ->get('Zend\Expressive\FinalHandler')
+            ->get('Zend\Stratigility\FinalHandler')
             ->willReturn($finalHandler);
 
         $this->container
@@ -1044,10 +1044,10 @@ class ApplicationFactoryTest extends TestCase
             });
 
         $this->container
-            ->has('Zend\Expressive\FinalHandler')
+            ->has('Zend\Stratigility\FinalHandler')
             ->willReturn(true);
         $this->container
-            ->get('Zend\Expressive\FinalHandler')
+            ->get('Zend\Stratigility\FinalHandler')
             ->willReturn($finalHandler);
 
         $this->container


### PR DESCRIPTION
I'm not actually in a position to run the tests at the moment. I'm creating this as a PR because it's a bit more helpful than creating an issue and I'm hoping a bot will tell me if the tests pass when I submit!

Essentially, 'Zend\Expressive\FinalHandler' doesn't exist, and as such violates the service naming convention suggested in the docs. The actual path is 'Zend\Stratigility\FinalHandler'.