### PR TITLE
AuraRouter 2.x is not PSR-7 compatible

### DIFF
--- a/src/Router/AuraRouter.php
+++ b/src/Router/AuraRouter.php
@@ -122,7 +122,10 @@ class AuraRouter implements RouterInterface
     public function match(Request $request)
     {
         $path   = $request->getUri()->getPath();
+        $method = $request->getMethod();
         $params = $request->getServerParams();
+
+        $params['REQUEST_METHOD'] = $method;
         $route  = $this->router->match($path, $params);
 
         if (false === $route) {

--- a/test/Router/AuraRouterTest.php
+++ b/test/Router/AuraRouterTest.php
@@ -78,9 +78,8 @@ class AuraRouterTest extends TestCase
 
         $request = $this->prophesize('Psr\Http\Message\ServerRequestInterface');
         $request->getUri()->willReturn($uri);
-        $request->getServerParams()->willReturn([
-            'REQUEST_METHOD' => 'GET',
-        ]);
+        $request->getMethod()->willReturn('GET');
+        $request->getServerParams()->willReturn([]);
 
         $auraRoute = new TestAsset\AuraRoute;
         $auraRoute->name = '/foo';
@@ -112,9 +111,8 @@ class AuraRouterTest extends TestCase
 
         $request = $this->prophesize('Psr\Http\Message\ServerRequestInterface');
         $request->getUri()->willReturn($uri);
-        $request->getServerParams()->willReturn([
-            'REQUEST_METHOD' => 'GET',
-        ]);
+        $request->getMethod()->willReturn('GET');
+        $request->getServerParams()->willReturn([]);
 
         $this->auraRouter->match('/foo', ['REQUEST_METHOD' => 'GET'])->willReturn(false);
 
@@ -139,9 +137,8 @@ class AuraRouterTest extends TestCase
 
         $request = $this->prophesize('Psr\Http\Message\ServerRequestInterface');
         $request->getUri()->willReturn($uri);
-        $request->getServerParams()->willReturn([
-            'REQUEST_METHOD' => 'PUT',
-        ]);
+        $request->getMethod()->willReturn('PUT');
+        $request->getServerParams()->willReturn([]);
 
 
         $this->auraRouter->match('/bar', ['REQUEST_METHOD' => 'PUT'])->willReturn(false);
@@ -189,9 +186,8 @@ class AuraRouterTest extends TestCase
 
         $request = $this->prophesize('Psr\Http\Message\ServerRequestInterface');
         $request->getUri()->willReturn($uri);
-        $request->getServerParams()->willReturn([
-            'REQUEST_METHOD' => 'PUT',
-        ]);
+        $request->getMethod()->willReturn('PUT');
+        $request->getServerParams()->willReturn([]);
 
 
         $this->auraRouter->match('/bar', ['REQUEST_METHOD' => 'PUT'])->willReturn(false);


### PR DESCRIPTION
Expressive is using AuraRouter 2.3.x, however it is not compatible with PSR-7. I'm trying to write tests for a specific route.

```php
        $request  = new ServerRequest([], [], 'https://example.com/api/ping', 'GET');
        $response = new Response();
        $this->app->run($request, $response);
```

Since the GET request method is set with ``new ServerRequest``, I expect the router to use this. However AuraRouter 2.x is looking at ``$_SERVER['REQUEST_METHOD']`` and not the ``$request->getMethod()``. Obviously in the web application accessed through a web server it is working as expected since the $_SERVER is populated there.

https://github.com/auraphp/Aura.Router/blob/2.x/src/Route.php#L424-L435

AuraRouter 3.x seems to be PSR-7 friendly, but they changed some class names and doesn't work out of the box.

https://github.com/auraphp/Aura.Router/blob/3.x/src/Rule/Allows.php#L34-L42