### PR TITLE
Specify that `generateUri()` MUST NOT encode returned URIs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,7 +7,7 @@ pages:
     - { Applications: application.md }
     - { Containers: [{ Introduction: container/intro.md }, { 'Container Factories': container/factories.md }, { 'Using zend-servicemanager': container/zend-servicemanager.md }, { 'Using Pimple': container/pimple.md }, { 'Using Aura.Di': container/aura-di.md }] }
     - { 'Routing Adapters': [{ Introduction: router/intro.md }, { 'Routing Interface': router/interface.md }, { 'URI Generation': router/uri-generation.md }, { 'Routing vs Piping': router/piping.md }, { 'Using Aura': router/aura.md }, { 'Using FastRoute': router/fast-route.md }, { 'Using the ZF2 Router': router/zf2.md }] }
-    - { Templating: [{ Introduction: template/intro.md }, { 'Template Interface': template/interface.md }, { 'Templated Middleware': template/middleware.md }, { 'Using Plates': template/plates.md }, { 'Using Twig': template/twig.md }, { 'Using zend-view': template/zend-view.md }] }
+    - { Templating: [{ Introduction: template/intro.md }, { 'Template Renderer Interface': template/interface.md }, { 'Templated Middleware': template/middleware.md }, { 'Using Plates': template/plates.md }, { 'Using Twig': template/twig.md }, { 'Using zend-view': template/zend-view.md }] }
     - { 'Error Handling': error-handling.md }
     - { Emitters: emitters.md }
     - { Examples: usage-examples.md }

--- a/src/Router/AuraRouter.php
+++ b/src/Router/AuraRouter.php
@@ -140,7 +140,7 @@ class AuraRouter implements RouterInterface
      */
     public function generateUri($name, array $substitutions = [])
     {
-        return $this->router->generate($name, $substitutions);
+        return $this->router->generateRaw($name, $substitutions);
     }
 
     /**

--- a/src/Router/RouterInterface.php
+++ b/src/Router/RouterInterface.php
@@ -34,6 +34,10 @@ interface RouterInterface
      * Takes the named route and any substitutions, and attempts to generate a
      * URI from it.
      *
+     * The URI generated MUST NOT be escaped. If you wish to escape any part of
+     * the URI, this should be performed afterwards; consider passing the URI
+     * to league/uri to encode it.
+     *
      * @see https://github.com/auraphp/Aura.Router#generating-a-route-path
      * @see http://framework.zend.com/manual/current/en/modules/zend.mvc.routing.html
      * @param string $name

--- a/test/Router/AuraRouterTest.php
+++ b/test/Router/AuraRouterTest.php
@@ -200,4 +200,20 @@ class AuraRouterTest extends TestCase
         $this->assertFalse($result->isMethodFailure());
         $this->assertSame([], $result->getAllowedMethods());
     }
+
+    /**
+     * @group 149
+     */
+    public function testGeneratedUriIsNotEncoded()
+    {
+        $router = new AuraRouter();
+        $route  = new Route('/foo/{id}', 'foo', ['GET'], 'foo');
+
+        $router->addRoute($route);
+
+        $this->assertEquals(
+            '/foo/bar is not encoded',
+            $router->generateUri('foo', ['id' => 'bar is not encoded'])
+        );
+    }
 }


### PR DESCRIPTION
As an alternative to #134. The primary issue reported in that pull request was that the author wished to get the raw URL instead of the escaped version.

2 of the 3 implementations we provide do not encode URIs (ZendRouter and FastRoute), and 3rd party utilities such as league/uri provide escaping capabilities at a fine-grained level. As such, this patch updates the interface to specify that implementations MUST NOT encode URIs returned by `generateUri()`. Additionally, the Aura router was updated to call `generateRaw()` internally to comply with the specification.