### PR TITLE
Use FastRoute by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file, in reverse 
 - [#132](https://github.com/zendframework/zend-expressive/pull/132) adds
   `Zend\Expressive\Router\ZendRouter`, replacing
   `Zend\Expressive\Router\Zf2Router`.
-- [#139](https://github.com/zendframework/zend-expressive/pull/134) adds:
+- [#139](https://github.com/zendframework/zend-expressive/pull/139) adds:
   - `Zend\Expressive\Template\TemplateRendererInterface`, replacing
     `Zend\Expressive\Template\TemplateInterface`.
   - `Zend\Expressive\Template\PlatesRenderer`, replacing
@@ -24,6 +24,16 @@ All notable changes to this project will be documented in this file, in reverse 
   template-specific default parameters to use when rendering. To implement the
   feature, the patch also provides `Zend\Expressive\Template\DefaultParamsTrait`
   to simplify incorporating the feature in implementations.
+- [#133](https://github.com/zendframework/zend-expressive/pull/133) adds a
+  stipulation to `Zend\Expressive\Router\RouterInterface` that `addRoute()`
+  should *aggregate* `Route` instances only, and delay injection until `match()`
+  and/or `generateUri()` are called; all shipped routers now follow this. This
+  allows manipulating `Route` instances before calling `match()` or
+  `generateUri()` — for instance, to inject options or a name.
+- [#133](https://github.com/zendframework/zend-expressive/pull/133) re-instates
+  the `Route::setName()` method, as the changes to lazy-inject routes means that
+  setting names and options after adding them to the application now works
+  again.
 
 ### Deprecated
 
@@ -34,7 +44,7 @@ All notable changes to this project will be documented in this file, in reverse 
 - [#132](https://github.com/zendframework/zend-expressive/pull/132) removes
   `Zend\Expressive\Router\Zf2Router`, renaming it to
   `Zend\Expressive\Router\ZendRouter`.
-- [#139](https://github.com/zendframework/zend-expressive/pull/134) removes:
+- [#139](https://github.com/zendframework/zend-expressive/pull/139) removes:
   - `Zend\Expressive\Template\TemplateInterface`, renaming it to
     `Zend\Expressive\Template\TemplateRendererInterface`.
   - `Zend\Expressive\Template\Plates`, renaming it to

--- a/doc/book/router/interface.md
+++ b/doc/book/router/interface.md
@@ -17,11 +17,27 @@ use Zend\Expressive\Exception;
 interface RouterInterface
 {
     /**
+     * Add a route.
+     *
+     * This method adds a route against which the underlying implementation may
+     * match. Implementations MUST aggregate route instances, but MUST NOT use
+     * the details to inject the underlying router until `match()` and/or
+     * `generateUri()` is called.  This is required to allow consumers to
+     * modify route instances before matching (e.g., to provide route options,
+     * inject a name, etc.).
+     *
      * @param Route $route
      */
     public function addRoute(Route $route);
 
     /**
+     * Match a request against the known routes.
+     *
+     * Implementations will aggregate required information from the provided
+     * request instance, and pass them to the underlying router implementation;
+     * when done, they will then marshal a `RouteResult` instance indicating
+     * the results of the matching operation and return it to the caller.
+     *
      * @param  Request $request
      * @return RouteResult
      */
@@ -91,6 +107,13 @@ class Route
      * @return string
      */
     public function getPath();
+
+    /**
+     * Set the route name.
+     *
+     * @param string $name
+     */
+    public function setName($name);
 
     /**
      * @return string

--- a/doc/book/router/uri-generation.md
+++ b/doc/book/router/uri-generation.md
@@ -25,6 +25,13 @@ the name:
   $app->get('/foo', $middleware); // "foo^GET"
   ```
 
+  Alternately, these methods return a `Route` instance, and you can set the
+  name on it:
+
+  ```php
+  $app->get('/foo', $middleware)->setName('foo'); // "foo"
+  ```
+
 - If you call `route()` and specify a list of HTTP methods accepted, the name
   will be the literal path, followed by a caret (`^`), followed by a colon
   (`:`)-separated list of the uppercase HTTP method names, in the order in which
@@ -32,6 +39,14 @@ the name:
 
   ```php
   $app->route('/foo, $middleware', ['GET', 'POST']); // "foo^GET:POST"
+  ```
+
+  Like the HTTP-specific methods, `route()` also returns a `Route` instance,
+  and you can set the name on it:
+
+  ```php
+  $route = $app->route('/foo, $middleware', ['GET', 'POST']); // "foo^GET:POST"
+  $route->setName('foo'); // "foo"
   ```
 
 Clearly, this can become difficult to remember. As such, Expressive offers the
@@ -42,6 +57,15 @@ argument to any of the above:
 $app->route('/foo', $middleware, 'foo'); // 'foo'
 $app->get('/foo/:id', $middleware, 'foo-item'); // 'foo-item'
 $app->route('/foo', $middleware, ['GET', 'POST'], 'foo-collection'); // 'foo-collection'
+```
+
+As noted above, these methods also return `Route` instances, allowing you to
+set the name after-the-fact; this is particularly useful with the `route()`
+method, where you may want to omit the HTTP methods if any HTTP method is
+allowed:
+
+```php
+$app->route('/foo', $middleware)->setName('foo'); // 'foo'
 ```
 
 We recommend that if you plan on generating URIs for given routes, you provide a

--- a/src/AppFactory.php
+++ b/src/AppFactory.php
@@ -20,8 +20,8 @@ use Zend\ServiceManager\ServiceManager;
  * programmatic vs service-driven environment.
  *
  * The Application instance returned is guaranteed to have a router, a
- * container, and an emitter stack; by default, the Aura router and the ZF2
- * ServiceManager are used.
+ * container, and an emitter stack; by default, the FastRoute router and the
+ * ZF2 ServiceManager are used.
  */
 final class AppFactory
 {
@@ -29,8 +29,8 @@ final class AppFactory
      * Create and return an Application instance.
      *
      * Will inject the instance with the container and/or router when provided;
-     * otherwise, it will use a ZF2 ServiceManager instance and the Aura router
-     * bridge.
+     * otherwise, it will use a ZF2 ServiceManager instance and the FastRoute
+     * router bridge.
      *
      * The factory also injects the Application with an Emitter\EmitterStack that
      * composes a SapiEmitter at the bottom of the stack (i.e., will execute last
@@ -40,7 +40,7 @@ final class AppFactory
      *     fetch middleware defined as services; defaults to a ServiceManager
      *     instance
      * @param null|Router\RouterInterface $router Router implementation to use;
-     *     defaults to the Aura router bridge.
+     *     defaults to the FastRoute router bridge.
      * @return Application
      */
     public static function create(
@@ -48,7 +48,7 @@ final class AppFactory
         Router\RouterInterface $router = null
     ) {
         $container = $container ?: new ServiceManager();
-        $router    = $router    ?: new Router\AuraRouter();
+        $router    = $router    ?: new Router\FastRouteRouter();
         $emitter   = new Emitter\EmitterStack();
         $emitter->push(new SapiEmitter());
 

--- a/src/Container/ApplicationFactory.php
+++ b/src/Container/ApplicationFactory.php
@@ -13,7 +13,7 @@ use Interop\Container\ContainerInterface;
 use Zend\Diactoros\Response\EmitterInterface;
 use Zend\Expressive\Application;
 use Zend\Expressive\Exception;
-use Zend\Expressive\Router\AuraRouter;
+use Zend\Expressive\Router\FastRouteRouter;
 use Zend\Expressive\Router\Route;
 use Zend\Expressive\Router\RouterInterface;
 
@@ -22,8 +22,8 @@ use Zend\Expressive\Router\RouterInterface;
  *
  * This factory uses the following services, if available:
  *
- * - 'Zend\Expressive\Router\RouterInterface'. If missing, an Aura router bridge
- *   will be instantiated and used.
+ * - 'Zend\Expressive\Router\RouterInterface'. If missing, a FastRoute router
+ *   bridge will be instantiated and used.
  * - 'Zend\Expressive\FinalHandler'. The service should be a callable to use as
  *   the final handler when the middleware pipeline is exhausted.
  * - 'Zend\Diactoros\Response\EmitterInterface'. If missing, an EmitterStack is
@@ -124,7 +124,7 @@ class ApplicationFactory
     {
         $router = $container->has(RouterInterface::class)
             ? $container->get(RouterInterface::class)
-            : new AuraRouter();
+            : new FastRouteRouter();
 
         $finalHandler = $container->has('Zend\Expressive\FinalHandler')
             ? $container->get('Zend\Expressive\FinalHandler')

--- a/src/Router/Route.php
+++ b/src/Router/Route.php
@@ -103,6 +103,16 @@ class Route
     }
 
     /**
+     * Set the route name.
+     *
+     * @param string $name
+     */
+    public function setName($name)
+    {
+        $this->name = (string) $name;
+    }
+
+    /**
      * @return string
      */
     public function getName()

--- a/src/Router/RouterInterface.php
+++ b/src/Router/RouterInterface.php
@@ -18,11 +18,26 @@ use Zend\Expressive\Exception;
 interface RouterInterface
 {
     /**
+     * Add a route.
+     *
+     * This method adds a route against which the underlying implementation may
+     * match. Implementations MUST aggregate route instances, but MUST NOT use
+     * the details to inject the underlying router until `match()` is called.
+     * This is required to allow consumers to modify route instances before
+     * matching (e.g., to provide route options, inject a name, etc.).
+     *
      * @param Route $route
      */
     public function addRoute(Route $route);
 
     /**
+     * Match a request against the known routes.
+     *
+     * Implementations will aggregate required information from the provided
+     * request instance, and pass them to the underlying router implementation;
+     * when done, they will then marshal a `RouteResult` instance indicating
+     * the results of the matching operation and return it to the caller.
+     *
      * @param  Request $request
      * @return RouteResult
      */

--- a/src/Router/RouterInterface.php
+++ b/src/Router/RouterInterface.php
@@ -22,9 +22,10 @@ interface RouterInterface
      *
      * This method adds a route against which the underlying implementation may
      * match. Implementations MUST aggregate route instances, but MUST NOT use
-     * the details to inject the underlying router until `match()` is called.
-     * This is required to allow consumers to modify route instances before
-     * matching (e.g., to provide route options, inject a name, etc.).
+     * the details to inject the underlying router until `match()` and/or
+     * `generateUri()` is called.  This is required to allow consumers to
+     * modify route instances before matching (e.g., to provide route options,
+     * inject a name, etc.).
      *
      * @param Route $route
      */

--- a/src/Router/ZendRouter.php
+++ b/src/Router/ZendRouter.php
@@ -45,6 +45,13 @@ class ZendRouter implements RouterInterface
     private $routeNameMap = [];
 
     /**
+     * Routes aggregated to inject.
+     *
+     * @var Route[]
+     */
+    private $routesToInject = [];
+
+    /**
      * @var TreeRouteStack
      */
     private $zendRouter;
@@ -66,69 +73,21 @@ class ZendRouter implements RouterInterface
     }
 
     /**
-     * @param Route $route
+     * @inheritDoc
      */
     public function addRoute(Route $route)
     {
-        $name    = $route->getName();
-        $path    = $route->getPath();
-        $options = $route->getOptions();
-        $options = array_replace_recursive($options, [
-            'route'    => $path,
-            'defaults' => [
-                'middleware' => $route->getMiddleware(),
-            ],
-        ]);
-
-        $allowedMethods = $route->getAllowedMethods();
-        if (Route::HTTP_METHOD_ANY === $allowedMethods) {
-            $this->zendRouter->addRoute($name, [
-                'type'    => 'segment',
-                'options' => $options,
-            ]);
-            $this->routeNameMap[$name] = $name;
-            return;
-        }
-
-        // Remove the middleware from the segment route in favor of method route
-        unset($options['defaults']['middleware']);
-        if (empty($options['defaults'])) {
-            unset($options['defaults']);
-        }
-
-        $httpMethodRouteName   = implode(':', $allowedMethods);
-        $httpMethodRoute       = $this->createHttpMethodRoute($route);
-        $methodNotAllowedRoute = $this->createMethodNotAllowedRoute($path);
-
-        $spec = [
-            'type'          => 'segment',
-            'options'       => $options,
-            'may_terminate' => false,
-            'child_routes'  => [
-                $httpMethodRouteName           => $httpMethodRoute,
-                self::METHOD_NOT_ALLOWED_ROUTE => $methodNotAllowedRoute,
-            ]
-        ];
-
-        if (array_key_exists($path, $this->allowedMethodsByPath)) {
-            $allowedMethods = array_merge($this->allowedMethodsByPath[$path], $allowedMethods);
-            // Remove the method not allowed route as it is already present for the path
-            unset($spec['child_routes'][self::METHOD_NOT_ALLOWED_ROUTE]);
-        }
-
-        $this->zendRouter->addRoute($name, $spec);
-        $this->allowedMethodsByPath[$path] = $allowedMethods;
-        $this->routeNameMap[$name] = sprintf('%s/%s', $name, $httpMethodRouteName);
+        $this->routesToInject[] = $route;
     }
 
     /**
-     * Attempt to match an incoming request to a registered route.
-     *
-     * @param PsrRequest $request
-     * @return RouteResult
+     * @inheritDoc
      */
     public function match(PsrRequest $request)
     {
+        // Must inject routes prior to matching.
+        $this->injectRoutes();
+
         $match = $this->zendRouter->match(Psr7ServerRequest::toZend($request, true));
 
         if (null === $match) {
@@ -143,6 +102,9 @@ class ZendRouter implements RouterInterface
      */
     public function generateUri($name, array $substitutions = [])
     {
+        // Must inject routes prior to generating URIs.
+        $this->injectRoutes();
+
         if (! $this->zendRouter->hasRoute($name)) {
             throw new Exception\RuntimeException(sprintf(
                 'Cannot generate URI based on route "%s"; route not found',
@@ -256,5 +218,74 @@ class ZendRouter implements RouterInterface
 
         // Otherwise, just use the name.
         return $name;
+    }
+
+    /**
+     * Inject any unprocessed routes into the underlying router implementation.
+     */
+    private function injectRoutes()
+    {
+        foreach ($this->routesToInject as $index => $route) {
+            $this->injectRoute($route);
+            unset($this->routesToInject[$index]);
+        }
+    }
+
+    /**
+     * Inject route into the underlying router implemetation.
+     *
+     * @param Route $route
+     */
+    private function injectRoute(Route $route)
+    {
+        $name    = $route->getName();
+        $path    = $route->getPath();
+        $options = $route->getOptions();
+        $options = array_replace_recursive($options, [
+            'route'    => $path,
+            'defaults' => [
+                'middleware' => $route->getMiddleware(),
+            ],
+        ]);
+
+        $allowedMethods = $route->getAllowedMethods();
+        if (Route::HTTP_METHOD_ANY === $allowedMethods) {
+            $this->zendRouter->addRoute($name, [
+                'type'    => 'segment',
+                'options' => $options,
+            ]);
+            $this->routeNameMap[$name] = $name;
+            return;
+        }
+
+        // Remove the middleware from the segment route in favor of method route
+        unset($options['defaults']['middleware']);
+        if (empty($options['defaults'])) {
+            unset($options['defaults']);
+        }
+
+        $httpMethodRouteName   = implode(':', $allowedMethods);
+        $httpMethodRoute       = $this->createHttpMethodRoute($route);
+        $methodNotAllowedRoute = $this->createMethodNotAllowedRoute($path);
+
+        $spec = [
+            'type'          => 'segment',
+            'options'       => $options,
+            'may_terminate' => false,
+            'child_routes'  => [
+                $httpMethodRouteName           => $httpMethodRoute,
+                self::METHOD_NOT_ALLOWED_ROUTE => $methodNotAllowedRoute,
+            ]
+        ];
+
+        if (array_key_exists($path, $this->allowedMethodsByPath)) {
+            $allowedMethods = array_merge($this->allowedMethodsByPath[$path], $allowedMethods);
+            // Remove the method not allowed route as it is already present for the path
+            unset($spec['child_routes'][self::METHOD_NOT_ALLOWED_ROUTE]);
+        }
+
+        $this->zendRouter->addRoute($name, $spec);
+        $this->allowedMethodsByPath[$path] = $allowedMethods;
+        $this->routeNameMap[$name] = sprintf('%s/%s', $name, $httpMethodRouteName);
     }
 }

--- a/test/AppFactoryTest.php
+++ b/test/AppFactoryTest.php
@@ -29,11 +29,11 @@ class AppFactoryTest extends TestCase
         $this->assertInstanceOf('Zend\Expressive\Application', $app);
     }
 
-    public function testFactoryUsesAuraRouterByDefault()
+    public function testFactoryUsesFastRouteByDefault()
     {
         $app    = AppFactory::create();
         $router = $this->getRouterFromApplication($app);
-        $this->assertInstanceOf('Zend\Expressive\Router\AuraRouter', $router);
+        $this->assertInstanceOf('Zend\Expressive\Router\FastRouteRouter', $router);
     }
 
     public function testFactoryUsesZf2ServiceManagerByDefault()

--- a/test/Container/ApplicationFactoryTest.php
+++ b/test/Container/ApplicationFactoryTest.php
@@ -203,7 +203,7 @@ class ApplicationFactoryTest extends TestCase
         $app = $this->factory->__invoke($this->container->reveal());
         $this->assertInstanceOf('Zend\Expressive\Application', $app);
         $router = $this->getRouterFromApplication($app);
-        $this->assertInstanceOf('Zend\Expressive\Router\AuraRouter', $router);
+        $this->assertInstanceOf('Zend\Expressive\Router\FastRouteRouter', $router);
         $this->assertSame($this->container->reveal(), $app->getContainer());
         $this->assertInstanceOf('Zend\Expressive\Emitter\EmitterStack', $app->getEmitter());
         $this->assertCount(1, $app->getEmitter());


### PR DESCRIPTION
Hi,

I don't know where this discussion (https://github.com/zendframework/zend-expressive/issues/131) will bring us, but if we keep one default router, I think it should be FastRoute.

I've tried FastRoute and Aura, and FastRoute is definitely easier to use. See the comparaison:

Aura:
```php
return [
    'routes' => [
        [
            'path' => '/users/:id',
            'options' => [
                'tokens' => [
                    'id' => '[0-9]+'
                ]
            ],
            'middleware' => 'Application\HelloWorld',
            'allowed_methods' => [ 'GET' ],
        ],
    ],
];
```

FastRoute:
```php
return [
    'routes' => [
        [
            'path' => '/users/{id:[0-9]+}',
            'middleware' => 'Application\HelloWorld',
            'allowed_methods' => [ 'GET' ],
        ],
    ],
];
```

Aura reminds me a bit the verbosity of ZF2. FastRoute allows very compact definitions.

I don't know though if FastRoute lacks some important features that Aura could have, though.