### PR TITLE
Added second argument to Container::has callas in order to make the ServiceManager to include abstract factories

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -201,10 +201,14 @@ class Application extends MiddlewarePipe
     {
         // Lazy-load middleware from the container when possible
         $container = $this->container;
-        if (null === $middleware && is_string($path) && $container && $container->has($path)) {
+        if (null === $middleware && is_string($path) && $container && $container->has($path, true)) {
             $middleware = $this->marshalLazyMiddlewareService($path, $container);
             $path       = '/';
-        } elseif (is_string($middleware) && ! is_callable($middleware) && $container && $container->has($middleware)) {
+        } elseif (is_string($middleware)
+            && ! is_callable($middleware)
+            && $container
+            && $container->has($middleware, true)
+        ) {
             $middleware = $this->marshalLazyMiddlewareService($middleware, $container);
         } elseif (null === $middleware && is_callable($path)) {
             $middleware = $path;
@@ -259,10 +263,14 @@ class Application extends MiddlewarePipe
     {
         // Lazy-load middleware from the container
         $container = $this->container;
-        if (null === $middleware && is_string($path) && $container && $container->has($path)) {
+        if (null === $middleware && is_string($path) && $container && $container->has($path, true)) {
             $middleware = $this->marshalLazyErrorMiddlewareService($path, $container);
             $path       = '/';
-        } elseif (is_string($middleware) && ! is_callable($middleware) && $container && $container->has($middleware)) {
+        } elseif (is_string($middleware)
+            && ! is_callable($middleware)
+            && $container
+            && $container->has($middleware, true)
+        ) {
             $middleware = $this->marshalLazyErrorMiddlewareService($middleware, $container);
         } elseif (null === $middleware && is_callable($path)) {
             $middleware = $path;
@@ -532,7 +540,7 @@ class Application extends MiddlewarePipe
     private function marshalMiddlewareFromContainer($middleware)
     {
         $container = $this->container;
-        if (! $container || ! $container->has($middleware)) {
+        if (! $container || ! $container->has($middleware, true)) {
             return $middleware;
         }
 

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -415,7 +415,7 @@ class ApplicationTest extends TestCase
         };
 
         $container = $this->prophesize(ContainerInterface::class);
-        $container->has('foo')->willReturn(true);
+        $container->has('foo', true)->willReturn(true);
         $container->get('foo')->willReturn($middleware);
 
         $app = new Application($this->router->reveal(), $container->reveal());
@@ -442,7 +442,7 @@ class ApplicationTest extends TestCase
         };
 
         $container = $this->prophesize(ContainerInterface::class);
-        $container->has('foo')->willReturn(true);
+        $container->has('foo', true)->willReturn(true);
         $container->get('foo')->willReturn($middleware);
 
         $app = new Application($this->router->reveal(), $container->reveal());
@@ -469,7 +469,7 @@ class ApplicationTest extends TestCase
         };
 
         $container = $this->prophesize(ContainerInterface::class);
-        $container->has('foo')->willReturn(true);
+        $container->has('foo', true)->willReturn(true);
         $container->get('foo')->willReturn($middleware);
 
         $app = new Application($this->router->reveal(), $container->reveal());
@@ -496,7 +496,7 @@ class ApplicationTest extends TestCase
         };
 
         $container = $this->prophesize(ContainerInterface::class);
-        $container->has('foo')->willReturn(true);
+        $container->has('foo', true)->willReturn(true);
         $container->get('foo')->willReturn($middleware);
 
         $app = new Application($this->router->reveal(), $container->reveal());

--- a/test/Container/ApplicationFactoryTest.php
+++ b/test/Container/ApplicationFactoryTest.php
@@ -445,7 +445,7 @@ class ApplicationFactoryTest extends TestCase
             ->willReturn($config);
 
         $this->container
-            ->has('Middleware')
+            ->has('Middleware', true)
             ->willReturn(true);
 
         $this->container
@@ -548,7 +548,7 @@ class ApplicationFactoryTest extends TestCase
             ->willReturn($config);
 
         $this->container
-            ->has('/')
+            ->has('/', true)
             ->willReturn(false);
 
         $this->setExpectedException('InvalidArgumentException');
@@ -608,7 +608,7 @@ class ApplicationFactoryTest extends TestCase
             ->willReturn($config);
 
         $this->container
-            ->has('Middleware')
+            ->has('Middleware', true)
             ->willReturn(false);
 
         $this->setExpectedException('InvalidArgumentException');
@@ -670,7 +670,7 @@ class ApplicationFactoryTest extends TestCase
             ->willReturn($config);
 
         $this->container
-            ->has('Middleware')
+            ->has('Middleware', true)
             ->willReturn(true);
 
         $this->container
@@ -827,7 +827,7 @@ class ApplicationFactoryTest extends TestCase
             ->willReturn($config);
 
         $this->container
-            ->has('Middleware')
+            ->has('Middleware', true)
             ->willReturn(true);
 
         $this->container

--- a/test/RouteMiddlewareTest.php
+++ b/test/RouteMiddlewareTest.php
@@ -218,7 +218,7 @@ class RouteMiddlewareTest extends TestCase
 
         $this->router->match($request)->willReturn($result);
 
-        $this->container->has('TestAsset\Middleware')->willReturn(true);
+        $this->container->has('TestAsset\Middleware', true)->willReturn(true);
         $this->container->get('TestAsset\Middleware')->willReturn($middleware);
 
         $app = $this->getApplication();
@@ -246,7 +246,7 @@ class RouteMiddlewareTest extends TestCase
 
         $this->router->match($request)->willReturn($result);
 
-        $this->container->has('TestAsset\Middleware')->willReturn(true);
+        $this->container->has('TestAsset\Middleware', true)->willReturn(true);
         $this->container->get('TestAsset\Middleware')->willThrow(new TestAsset\ContainerException());
 
         $app = $this->getApplication();


### PR DESCRIPTION
Every time the `Container::has` method is internally called, the second argument is set to true, so that when using the Zend\ServiceManager, it includes abstract factories.
Without this, when using the ServiceManager v3, regular middleware, route middleware and any service that is internally fetched and should be created by abstract factories is instantiated instead of being pulled from the Container.