### PR TITLE
Put middleware DI info in routes.global.php

### DIFF
--- a/doc/book/quick-start-skeleton.md
+++ b/doc/book/quick-start-skeleton.md
@@ -217,7 +217,7 @@ class HelloActionFactory
 ```
 
 With that in place, we'll now update our configuration. Open the file
-`config/autoload/dependencies.global.php`; it should have a structure similar to
+`config/autoload/routes.global.php`; it should have a structure similar to
 the following:
 
 ```php
@@ -226,9 +226,9 @@ return [
         'invokables' => [
             /* ... */
         ],
-        'factories' => [
-            /* ... */
-        ],
+    ],
+    'routes' => [
+        /* ... */
     ],
 ];
 ```
@@ -244,6 +244,9 @@ return [
             /* ... */
             App\Action\HelloAction::class => App\Action\HelloActionFactory::class,
         ],
+    ],
+    'routes' => [
+        /* ... */
     ],
 ];
 ```


### PR DESCRIPTION
Per zendframework/zend-expressive-skeleton#9, this puts the DI definition information in the `routes.global.php` file, in order to keep routing/middleware information in one file.