### PR TITLE
Add `-s rc` flag in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ also provides configuration for officially supported dependencies.
 To use the skeleton, use Composer's `create-project` command:
 
 ```bash
-$ composer create-project zendframework/zend-expressive-skeleton <project dir>
+$ composer create-project -s rc zendframework/zend-expressive-skeleton <project dir>
 ```
 
 This will prompt you through choosing your dependencies, and then create and


### PR DESCRIPTION
I saw this addition on quick start in e325ee6343bb30420afd40073afc001c7dc978d9 but it was not added in README.me as well.