### PR TITLE
Fix broken build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
   - if [[ $EXECUTE_DOC_CHECK == 'true' ]]; then composer require --dev --no-update phly/bookdown2mkdocs ; fi
 
 install:
-  - COMPOSER_ROOT_VERSION=0.4.1 travis_retry composer install --no-interaction --ignore-platform-reqs --prefer-source
+  - COMPOSER_ROOT_VERSION=dev-master travis_retry composer install --no-interaction --ignore-platform-reqs --prefer-source
   - composer info -i
 
 before_script:


### PR DESCRIPTION
[This change](https://github.com/zendframework/zend-expressive/blob/1a979e6202af19af9271b154a90ac93eb7e6b696/composer.json#L30-L32) in 1a979e6 broke the build.

The router dependencies were previously pinned to `^0.1`, which was installing the `0.1.0` versions of the various `zendframework/zend-expressive-*router` packages, which in turn were dependent on `^0.4` of `zendframework/zend-expressive`.

Now they are pinned to version `~1.0-dev` of the router packages, i.e. `dev-master`, which depend on `^1.0@rc"` of `zendframework/zend-expressive`. Since the root version is set to 0.4.1 via `COMPOSER_ROOT_VERSION=0.4.1` install fails, even though there is otherwise no issue with the composer dependencies.

Using `COMPOSER_ROOT_VERSION=dev-master` allows the install to complete and should fix the build.

**Note:** `COMPOSER_ROOT_VERSION=1.0.0` would also work, as would removing the entire `COMPOSER_ROOT_VERSION=____` setting, if you wish.