### PR TITLE
stringify UTF-8 to fix PHP warning

### DIFF
--- a/doc/book/quick-start-skeleton.md
+++ b/doc/book/quick-start-skeleton.md
@@ -77,7 +77,7 @@ class HelloAction
     {
         $query  = $request->getQueryParams();
         $target = isset($query['target']) ? $query['target'] : 'World';
-        $target = htmlspecialchars($target, ENT_HTML5, UTF-8);
+        $target = htmlspecialchars($target, ENT_HTML5, 'UTF-8');
 
         $response->getBody()->write(sprintf(
             '<h1>Hello, %s!</h1>',


### PR DESCRIPTION
Without the quotes, produces warning: 
Warning: htmlspecialchars(): charset `-8' not supported, assuming utf-8 in ... on line ...

And then fatal error:
Fatal error: Uncaught exception 'RuntimeException' with message 'Unable to emit response; headers already sent' ...