### PR TITLE
Support casting zend-view models to arrays

### DIFF
--- a/src/Template/ArrayParametersTrait.php
+++ b/src/Template/ArrayParametersTrait.php
@@ -17,6 +17,16 @@ trait ArrayParametersTrait
     /**
      * Cast params to an array, if possible.
      *
+     * Casts the provided $params argument to an array, using the following rules:
+     *
+     * - null values result in an empty array
+     * - array values are returned verbatim
+     * - zend-view view models return the result of getVariables()
+     * - Traversables are cast using iterator_to_array
+     * - objects that are not zend-view view models nor traversables are cast
+     *   using PHP's type casting
+     * - scalar values result in an exception
+     *
      * @param mixed $params
      * @return array
      * @throws Exception\InvalidArgumentException for non-array, non-object parameters.
@@ -29,6 +39,12 @@ trait ArrayParametersTrait
 
         if (is_array($params)) {
             return $params;
+        }
+
+        // Special case for zendframework/zend-view view models.
+        // Not using typehinting, so as not to require zend-view as a dependency.
+        if (is_object($params) && method_exists($params, 'getVariables')) {
+            return $params->getVariables();
         }
 
         if ($params instanceof Traversable) {

--- a/test/Template/ArrayParametersTraitTest.php
+++ b/test/Template/ArrayParametersTraitTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZendTest\Expressive\Template;
+
+use ArrayIterator;
+use PHPUnit_Framework_TestCase as TestCase;
+use stdClass;
+use Zend\Expressive\Exception\InvalidArgumentException;
+
+class ArrayParametersTraitTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->subject = new TestAsset\ArrayParameters();
+    }
+
+    public function testNullParamsAreReturnedAsEmptyArray()
+    {
+        $this->assertEquals([], $this->subject->normalize(null));
+    }
+
+    public function testArrayParamsAreReturnedVerbatim()
+    {
+        $params = ['foo' => 'bar'];
+        $this->assertSame($params, $this->subject->normalize($params));
+    }
+
+    public function testExtractsVariablesFromObjectsImplementingGetVariables()
+    {
+        $params = ['foo' => 'bar'];
+        $model  = new TestAsset\ViewModel($params);
+        $this->assertSame($params, $this->subject->normalize($model));
+    }
+
+    public function testCastsTraversablesToArrays()
+    {
+        $params = ['foo' => 'bar'];
+        $model  = new ArrayIterator($params);
+        $this->assertSame($params, $this->subject->normalize($model));
+    }
+
+    public function testCastsObjectsToArrays()
+    {
+        $params = ['foo' => 'bar'];
+        $model  = (object) $params;
+        $this->assertSame($params, $this->subject->normalize($model));
+    }
+
+    public function nonNullScalarParameters()
+    {
+        // @codingStandardsIgnoreStart
+        //                  [scalar,       expected exception string]
+        return [
+            'true'       => [true,         'bool'],
+            'false'      => [false,        'bool'],
+            'zero'       => [0,            'int'],
+            'int'        => [1,            'int'],
+            'zero-float' => [0.0,          'double'],
+            'float'      => [1.1,          'double'],
+            'string'     => ['view param', 'string'],
+        ];
+        // @codingStandardsIgnoreEnd
+    }
+
+    /**
+     * @dataProvider nonNullScalarParameters
+     */
+    public function testNonNullScalarsRaiseAnException($scalar, $expectedString)
+    {
+        $this->setExpectedException(InvalidArgumentException::class, $expectedString);
+        $this->subject->normalize($scalar);
+    }
+}

--- a/test/Template/TestAsset/ArrayParameters.php
+++ b/test/Template/TestAsset/ArrayParameters.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZendTest\Expressive\Template\TestAsset;
+
+use Zend\Expressive\Template\ArrayParametersTrait;
+
+class ArrayParameters
+{
+    use ArrayParametersTrait;
+
+    public function normalize($params)
+    {
+        return $this->normalizeParams($params);
+    }
+}

--- a/test/Template/TestAsset/ViewModel.php
+++ b/test/Template/TestAsset/ViewModel.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZendTest\Expressive\Template\TestAsset;
+
+class ViewModel
+{
+    private $variables;
+
+    public function __construct(array $variables)
+    {
+        $this->variables = $variables;
+    }
+
+    public function getVariables()
+    {
+        return $this->variables;
+    }
+}


### PR DESCRIPTION
Currently, if you use zend-view view models, but decide to switch to an alternate template implementation, you must also change the rest of your code to eliminate the view models (see discussion on [zend-view Expressive renderer repository](https://github.com/zendframework/zend-expressive-zendviewrenderer/issues/2).

This patch introduces the following:

- Tests for the `ArrayParametersTrait::normalizeParams()` implementation.
- Code that uses duck-typing to locate zend-view view models, and, when discovered, return the result of `getVariables()`.

Duck-typing was used so as to eliminate the need for an additional dependency. Hopefully, a future update to zend-view will eliminate the need for this check at all. In the meantime, this allows each of the `Zend\View\Model\ModelInterface` implementations to be used with any of the template renderer implementations.