### PR TITLE
Inject the route result as an attribute

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -325,6 +325,8 @@ class Application extends MiddlewarePipe
             return $next($request, $response);
         }
 
+        // Inject the actual route result, as well as individual matched parameters.
+        $request = $request->withAttribute(Router\RouteResult::class, $result);
         foreach ($result->getMatchedParams() as $param => $value) {
             $request = $request->withAttribute($param, $value);
         }


### PR DESCRIPTION
On successful routing, inject the route result as the `Zend\Expressive\Router\RouteResult` request attribute. This allows users to introspect it later, allowing for features such as injection into URL helpers or similar.

One part of a multi-part solution addressing #186.