### PR TITLE
Prototype for allowing immutable RouterInterface

### DIFF
--- a/src/AppFactory.php
+++ b/src/AppFactory.php
@@ -39,20 +39,20 @@ final class AppFactory
      * @param null|ContainerInterface $container IoC container from which to
      *     fetch middleware defined as services; defaults to a ServiceManager
      *     instance
-     * @param null|Router\RouterInterface $router Router implementation to use;
+     * @param null|Router\RouterFactoryInterface $routerFactory Router factory implementation to use;
      *     defaults to the FastRoute router bridge.
      * @return Application
      */
     public static function create(
         ContainerInterface $container = null,
-        Router\RouterInterface $router = null
+        Router\RouterFactoryInterface $routerFactory = null
     ) {
-        $container = $container ?: new ServiceManager();
-        $router    = $router    ?: new Router\FastRouteRouter();
-        $emitter   = new Emitter\EmitterStack();
+        $container     = $container ?: new ServiceManager();
+        $routerFactory = $routerFactory ?: new Router\FastRouteRouterFactory();
+        $emitter       = new Emitter\EmitterStack();
         $emitter->push(new SapiEmitter());
 
-        return new Application($router, $container, null, $emitter);
+        return new Application($routerFactory, $container, null, $emitter);
     }
 
     /**

--- a/src/Router/AbstractRouterFactory.php
+++ b/src/Router/AbstractRouterFactory.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Router;
+
+/**
+ * Generic implementation of a router factory.
+ */
+abstract class AbstractRouterFactory implements RouterFactoryInterface
+{
+    /**
+     * @var Route[]
+     */
+    protected $routes;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addRoute(Route $route)
+    {
+        $this->routes[] = $route;
+    }
+}

--- a/src/Router/RouterFactoryInterface.php
+++ b/src/Router/RouterFactoryInterface.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Router;
+
+/**
+ * Interface defining required router capabilities.
+ */
+interface RouterFactoryInterface
+{
+    /**
+     * Add a route.
+     *
+     * @param Route $route
+     */
+    public function addRoute(Route $route);
+
+    /**
+     * Build a new router.
+     *
+     * @return RouterInterface
+     */
+    public function buildRouter();
+}

--- a/src/Router/RouterInterface.php
+++ b/src/Router/RouterInterface.php
@@ -18,20 +18,6 @@ use Zend\Expressive\Exception;
 interface RouterInterface
 {
     /**
-     * Add a route.
-     *
-     * This method adds a route against which the underlying implementation may
-     * match. Implementations MUST aggregate route instances, but MUST NOT use
-     * the details to inject the underlying router until `match()` and/or
-     * `generateUri()` is called.  This is required to allow consumers to
-     * modify route instances before matching (e.g., to provide route options,
-     * inject a name, etc.).
-     *
-     * @param Route $route
-     */
-    public function addRoute(Route $route);
-
-    /**
      * Match a request against the known routes.
      *
      * Implementations will aggregate required information from the provided


### PR DESCRIPTION
This PR is aimed to make the `RouterInterface` completely immutable. The way to achieve this is by injecting a `RouterFactoryInterface` into the Application, instead of a `RouterInterface`. The factory allows the same `addRoute()` method as the prior mutable router did. When requested, a router is build using the supplied routes.