### PR TITLE
Added support for route-specific middleware pipe via configuration

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -343,7 +343,19 @@ class Application extends MiddlewarePipe
             return $middleware($request, $response, $next);
         }
 
-        if (! is_string($middleware)) {
+        if (is_array($middleware)) {
+            $middlewarePipe = new MiddlewarePipe();
+
+            foreach ($middleware as $middlewareItem) {
+                $middlewarePipe->pipe(
+                    is_callable($middlewareItem) ? $middlewareItem : $this->marshalMiddleware($middlewareItem)
+                );
+            }
+
+            return $middlewarePipe;
+        }
+
+        if (!is_string($middleware)) {
             throw new Exception\InvalidMiddlewareException(
                 'The middleware specified is not callable'
             );
@@ -377,7 +389,7 @@ class Application extends MiddlewarePipe
      * pipeline.
      *
      * @param string|Router\Route $path
-     * @param callable|string $middleware Middleware (or middleware service name) to associate with route.
+     * @param callable|string|array $middleware Middleware (or middleware service name) to associate with route.
      * @param null|array $methods HTTP method to accept; null indicates any.
      * @param null|string $name the name of the route
      * @return Router\Route
@@ -527,6 +539,36 @@ class Application extends MiddlewarePipe
         if (count($matches) > 0) {
             throw new Exception\DuplicateRouteException(
                 'Duplicate route detected; same name or path, and one or more HTTP methods intersect'
+            );
+        }
+    }
+
+    /**
+     * Attempts to retrieve middleware from the container, or instantiate it directly.
+     *
+     * @param string $middleware
+     *
+     * @return array
+     * @throws Exception\InvalidMiddlewareException If unable to obtain callable middleware
+     */
+    private function marshalMiddleware($middleware)
+    {
+        $callable = $this->marshalMiddlewareFromContainer($middleware);
+
+        if (is_callable($callable)) {
+            return $callable;
+        }
+
+        $callable = $this->marshalInvokableMiddleware($middleware);
+
+        if (is_callable($callable)) {
+            return $callable;
+        } else {
+            throw new Exception\InvalidMiddlewareException(
+                sprintf(
+                    'Unable to resolve middleware "%s" to a callable',
+                    $middleware
+                )
             );
         }
     }

--- a/src/Application.php
+++ b/src/Application.php
@@ -352,7 +352,7 @@ class Application extends MiddlewarePipe
                 );
             }
 
-            return $middlewarePipe;
+            return $middlewarePipe($request, $response, $next);
         }
 
         if (!is_string($middleware)) {

--- a/src/Application.php
+++ b/src/Application.php
@@ -563,14 +563,14 @@ class Application extends MiddlewarePipe
 
         if (is_callable($callable)) {
             return $callable;
-        } else {
-            throw new Exception\InvalidMiddlewareException(
-                sprintf(
-                    'Unable to resolve middleware "%s" to a callable',
-                    $middleware
-                )
-            );
         }
+
+        throw new Exception\InvalidMiddlewareException(
+            sprintf(
+                'Unable to resolve middleware "%s" to a callable',
+                $middleware
+            )
+        );
     }
 
     /**

--- a/src/Container/ApplicationFactory.php
+++ b/src/Container/ApplicationFactory.php
@@ -212,12 +212,17 @@ class ApplicationFactory
                 continue;
             }
 
-            $path       = isset($spec['path']) ? $spec['path'] : '/';
-            $middleware = $spec['middleware'];
-            $error      = array_key_exists('error', $spec) ? (bool) $spec['error'] : false;
-            $pipe       = $error ? 'pipeErrorHandler' : 'pipe';
+            $path  = isset($spec['path']) ? $spec['path'] : '/';
+            $error = array_key_exists('error', $spec) ? (bool) $spec['error'] : false;
+            $pipe  = $error ? 'pipeErrorHandler' : 'pipe';
 
-            $app->{$pipe}($path, $middleware);
+            if (is_array($spec['middleware'])) {
+                foreach ($spec['middleware'] as $middleware) {
+                    $app->{$pipe}($path, $middleware);
+                }
+            } else {
+                $app->{$pipe}($path, $spec['middleware']);
+            }
         }
     }
 

--- a/src/Container/ApplicationFactory.php
+++ b/src/Container/ApplicationFactory.php
@@ -179,7 +179,7 @@ class ApplicationFactory
 
             $name = isset($spec['name']) ? $spec['name'] : null;
 
-            if (is_array($spec['middleware'])) {
+            if (!is_callable($spec['middleware']) && is_array($spec['middleware'])) {
                 $middlewarePipe = new MiddlewarePipe();
 
                 foreach ($spec['middleware'] as $middleware) {

--- a/src/Container/ApplicationFactory.php
+++ b/src/Container/ApplicationFactory.php
@@ -176,10 +176,8 @@ class ApplicationFactory
             } else {
                 $methods = Route::HTTP_METHOD_ANY;
             }
-
-            $name = isset($spec['name']) ? $spec['name'] : null;
-
-            $route = new Route($spec['path'], $spec['middleware'], $methods, $name);
+            $name    = isset($spec['name']) ? $spec['name'] : null;
+            $route   = new Route($spec['path'], $spec['middleware'], $methods, $name);
 
             if (isset($spec['options'])) {
                 $options = $spec['options'];

--- a/src/Container/ApplicationFactory.php
+++ b/src/Container/ApplicationFactory.php
@@ -179,16 +179,6 @@ class ApplicationFactory
 
             $name = isset($spec['name']) ? $spec['name'] : null;
 
-            if (!is_callable($spec['middleware']) && is_array($spec['middleware'])) {
-                $middlewarePipe = new MiddlewarePipe();
-
-                foreach ($spec['middleware'] as $middleware) {
-                    $middlewarePipe->pipe(is_callable($middleware) ? $middleware : $container->get($middleware));
-                }
-
-                $spec['middleware'] = $middlewarePipe;
-            }
-
             $route = new Route($spec['path'], $spec['middleware'], $methods, $name);
 
             if (isset($spec['options'])) {

--- a/src/Router/Route.php
+++ b/src/Router/Route.php
@@ -71,7 +71,7 @@ class Route
             throw new Exception\InvalidArgumentException('Invalid path; must be a string');
         }
 
-        if (! is_callable($middleware) && ! is_string($middleware)) {
+        if (! is_callable($middleware) && ! is_string($middleware) && ! is_array($middleware)) {
             throw new Exception\InvalidArgumentException('Invalid middleware; must be callable or a service name');
         }
 
@@ -121,7 +121,7 @@ class Route
     }
 
     /**
-     * @return string|callable
+     * @return string|callable|array
      */
     public function getMiddleware()
     {

--- a/src/Router/RouteResult.php
+++ b/src/Router/RouteResult.php
@@ -127,7 +127,7 @@ class RouteResult
     /**
      * Retrieve the matched middleware, if possible.
      *
-     * @return false|callable|string Returns false if the result represents a
+     * @return false|callable|string|array Returns false if the result represents a
      *     failure; otherwise, a callable or a string service name.
      */
     public function getMatchedMiddleware()

--- a/test/Container/ApplicationFactoryTest.php
+++ b/test/Container/ApplicationFactoryTest.php
@@ -16,10 +16,12 @@ use ReflectionProperty;
 use Zend\Diactoros\Response\EmitterInterface;
 use Zend\Expressive\Application;
 use Zend\Expressive\Container\ApplicationFactory;
+use Zend\Expressive\FinalHandler;
 use Zend\Expressive\Router\Route;
 use Zend\Expressive\Router\RouterInterface;
 use ZendTest\Expressive\ContainerTrait;
 use Zend\Expressive\Container\Exception\InvalidArgumentException;
+use ZendTest\Expressive\TestAsset\InvokableMiddleware;
 
 /**
  * @covers Zend\Expressive\Container\ApplicationFactory
@@ -112,7 +114,7 @@ class ApplicationFactoryTest extends TestCase
                 function () {
                 }
            ],
-           [[\ZendTest\Expressive\TestAsset\InvokableMiddleware::class, 'staticallyCallableMiddleware']],
+           [[InvokableMiddleware::class, 'staticallyCallableMiddleware']],
         ];
     }
 

--- a/test/Container/ApplicationFactoryTest.php
+++ b/test/Container/ApplicationFactoryTest.php
@@ -621,46 +621,25 @@ class ApplicationFactoryTest extends TestCase
         $this->factory->__invoke($this->container->reveal());
     }
 
-    public function testCanPipeRouteSpecificMiddlewareViaConfiguration()
+    public function testExceptionIsRaisedInCaseOfInvalidRouteOptionsConfiguration()
     {
-        $expectedRouteOptions = [
-            'values' => [
-                'foo' => 'bar'
-            ],
-            'tokens' => [
-                'bar' => 'foo'
-            ]
-        ];
-
         $config = [
             'routes' => [
                 [
                     'path' => '/',
-                    'middleware' => [
-                        'Hello',
-                        function () {
-                            return 'World';
-                        }
-                    ],
-                    'name' => 'home',
-                    'allowed_methods' => ['GET'],
-                    'options' => $expectedRouteOptions
+                    'middleware' => 'HelloWorld',
+                    'options' => 'invalid',
                 ],
             ],
         ];
 
         $this->injectServiceInContainer($this->container, 'config', $config);
-        $this->injectServiceInContainer($this->container, 'Hello', function() {});
 
-        $app = $this->factory->__invoke($this->container->reveal());
-
-        $r = new ReflectionProperty($app, 'routes');
-        $r->setAccessible(true);
-        $routes = $r->getValue($app);
-        $route  = array_shift($routes);
-
-        $this->assertInstanceOf(Route::class, $route);
-        $this->assertEquals($expectedRouteOptions, $route->getOptions());
+        $this->setExpectedException(
+            InvalidArgumentException::class,
+            'options must be an array; received "string"'
+        );
+        $this->factory->__invoke($this->container->reveal());
     }
 
     public function testExceptionIsRaisedInCaseOfInvalidPreRoutingMiddlewarePipeline()

--- a/test/Container/ApplicationFactoryTest.php
+++ b/test/Container/ApplicationFactoryTest.php
@@ -359,6 +359,58 @@ class ApplicationFactoryTest extends TestCase
     /**
      * @group piping
      */
+    public function testCanPipePreRoutingMiddlewareAsArray()
+    {
+        $config = [
+            'middleware_pipeline' => [
+                'pre_routing' => [
+                    [
+                        'middleware' => [
+                            'Hello',
+                            function () {
+                            },
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->injectServiceInContainer($this->container, 'config', $config);
+        $this->injectServiceInContainer($this->container, 'Hello', function () {
+        });
+
+        $this->factory->__invoke($this->container->reveal());
+    }
+
+    /**
+     * @group piping
+     */
+    public function testCanPipePostRoutingMiddlewareAsArray()
+    {
+        $config = [
+            'middleware_pipeline' => [
+                'post_routing' => [
+                    [
+                        'middleware' => [
+                            'Hello',
+                            function () {
+                            },
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->injectServiceInContainer($this->container, 'config', $config);
+        $this->injectServiceInContainer($this->container, 'Hello', function () {
+        });
+
+        $this->factory->__invoke($this->container->reveal());
+    }
+
+    /**
+     * @group piping
+     */
     public function testRaisesExceptionForPipedMiddlewareServiceNamesNotFoundInContainer()
     {
         $config = [

--- a/test/Container/ApplicationFactoryTest.php
+++ b/test/Container/ApplicationFactoryTest.php
@@ -623,7 +623,7 @@ class ApplicationFactoryTest extends TestCase
 
     public function testCanPipeRouteSpecificMiddlewareViaConfiguration()
     {
-        $expected = [
+        $expectedRouteOptions = [
             'values' => [
                 'foo' => 'bar'
             ],
@@ -644,7 +644,7 @@ class ApplicationFactoryTest extends TestCase
                     ],
                     'name' => 'home',
                     'allowed_methods' => ['GET'],
-                    'options' => $expected
+                    'options' => $expectedRouteOptions
                 ],
             ],
         ];
@@ -660,7 +660,7 @@ class ApplicationFactoryTest extends TestCase
         $route  = array_shift($routes);
 
         $this->assertInstanceOf(Route::class, $route);
-        $this->assertEquals($expected, $route->getOptions());
+        $this->assertEquals($expectedRouteOptions, $route->getOptions());
     }
 
     public function testExceptionIsRaisedInCaseOfInvalidPreRoutingMiddlewarePipeline()

--- a/test/Container/ApplicationFactoryTest.php
+++ b/test/Container/ApplicationFactoryTest.php
@@ -108,7 +108,10 @@ class ApplicationFactoryTest extends TestCase
     {
         return [
            ['HelloWorld'],
-           [function () {}],
+           [
+                function () {
+                }
+           ],
            [[\ZendTest\Expressive\TestAsset\InvokableMiddleware::class, 'staticallyCallableMiddleware']],
         ];
     }
@@ -633,7 +636,9 @@ class ApplicationFactoryTest extends TestCase
                     'path' => '/',
                     'middleware' => [
                         'Hello',
-                        function () { return 'World'; }
+                        function () {
+                            return 'World';
+                        }
                     ],
                     'name' => 'home',
                     'allowed_methods' => ['GET'],

--- a/test/Container/ApplicationFactoryTest.php
+++ b/test/Container/ApplicationFactoryTest.php
@@ -104,13 +104,25 @@ class ApplicationFactoryTest extends TestCase
         $this->assertSame($this->finalHandler, $app->getFinalHandler());
     }
 
-    public function testFactorySetsUpRoutesFromConfig()
+    public function callableMiddlewares()
+    {
+        return [
+           ['HelloWorld'],
+           [function () {}],
+           [[\ZendTest\Expressive\TestAsset\InvokableMiddleware::class, 'staticallyCallableMiddleware']],
+        ];
+    }
+
+    /**
+     * @dataProvider callableMiddlewares
+     */
+    public function testFactorySetsUpRoutesFromConfig($middleware)
     {
         $config = [
             'routes' => [
                 [
                     'path' => '/',
-                    'middleware' => 'HelloWorld',
+                    'middleware' => $middleware,
                     'allowed_methods' => [ 'GET' ],
                 ],
                 [

--- a/test/TestAsset/InvokableMiddleware.php
+++ b/test/TestAsset/InvokableMiddleware.php
@@ -13,6 +13,11 @@ class InvokableMiddleware
 {
     public function __invoke($request, $response, $next)
     {
+        return self::staticallyCallableMiddleware($request, $response, $next);
+    }
+
+    public static function staticallyCallableMiddleware($request, $response, $next)
+    {
         return $response->withHeader('X-Invoked', __CLASS__);
     }
 }


### PR DESCRIPTION
The ApplicationFactory will check to see if the specified middleware is
an array before injecting it into the Route. If it is, it will attempt
to turn the contents of the array (which must be callable or retrievable
from the DI container) into a MiddlewarePipe, which it will inject
instead.

This change should be backwards compatible unless an application's functionality currently depends on failing if an array is specified in `routes.[].middleware`.

If acceptable, this would resolve #190 