### PR TITLE
Support for setting PHP settings through configuration

### DIFF
--- a/src/Container/ApplicationFactory.php
+++ b/src/Container/ApplicationFactory.php
@@ -146,7 +146,7 @@ class ApplicationFactory
 
     /**
      * Sets provided PHP settings, if any.
-     * 
+     *
      * @param ContainerInterface $container
      */
     private function setPhpSettings(ContainerInterface $container)

--- a/src/Container/ApplicationFactory.php
+++ b/src/Container/ApplicationFactory.php
@@ -136,11 +136,30 @@ class ApplicationFactory
 
         $app = new Application($router, $container, $finalHandler, $emitter);
 
+        $this->setPhpSettings($container);
         $this->injectPreMiddleware($app, $container);
         $this->injectRoutes($app, $container);
         $this->injectPostMiddleware($app, $container);
 
         return $app;
+    }
+
+    /**
+     * Sets provided PHP settings, if any.
+     * 
+     * @param ContainerInterface $container
+     */
+    private function setPhpSettings(ContainerInterface $container)
+    {
+        $config = $container->has('config') ? $container->get('config') : [];
+
+        if (!isset($config['php_settings']) || !is_array($config['php_settings'])) {
+            return;
+        }
+
+        foreach ($config['php_settings'] as $name => $value) {
+            ini_set($name, $value);
+        }
     }
 
     /**

--- a/src/Container/ApplicationFactory.php
+++ b/src/Container/ApplicationFactory.php
@@ -159,7 +159,7 @@ class ApplicationFactory
         if (!isset($config['php_settings'])) {
             return;
         }
-        
+
         if (!is_array($config['php_settings'])) {
             throw new Exception\InvalidArgumentException('Invalid PHP settings configuration; must be an array');
         }

--- a/src/Container/ApplicationFactory.php
+++ b/src/Container/ApplicationFactory.php
@@ -13,6 +13,7 @@ use Interop\Container\ContainerInterface;
 use Zend\Diactoros\Response\EmitterInterface;
 use Zend\Expressive\Application;
 use Zend\Expressive\Exception;
+use Zend\Expressive\Container\Exception\PhpSettingsFailureException;
 use Zend\Expressive\Router\FastRouteRouter;
 use Zend\Expressive\Router\Route;
 use Zend\Expressive\Router\RouterInterface;
@@ -148,17 +149,23 @@ class ApplicationFactory
      * Sets provided PHP settings, if any.
      *
      * @param ContainerInterface $container
+     * @throws Exception\InvalidArgumentException for invalid PHP settings.
+     * @throws PhpSettingsFailureException if setting of PHP configuration fails.
      */
     private function setPhpSettings(ContainerInterface $container)
     {
         $config = $container->has('config') ? $container->get('config') : [];
 
-        if (!isset($config['php_settings']) || !is_array($config['php_settings'])) {
-            return;
-        }
+        if (isset($config['php_settings'])) {
+            if (!is_array($config['php_settings'])) {
+                throw new Exception\InvalidArgumentException('Invalid PHP settings configuration; must be an array');
+            }
 
-        foreach ($config['php_settings'] as $name => $value) {
-            ini_set($name, $value);
+            foreach ($config['php_settings'] as $name => $value) {
+                if (false === ini_set($name, $value)) {
+                    throw PhpSettingsFailureException::forOption($name, $value);
+                }
+            }
         }
     }
 

--- a/src/Container/ApplicationFactory.php
+++ b/src/Container/ApplicationFactory.php
@@ -156,15 +156,17 @@ class ApplicationFactory
     {
         $config = $container->has('config') ? $container->get('config') : [];
 
-        if (isset($config['php_settings'])) {
-            if (!is_array($config['php_settings'])) {
-                throw new Exception\InvalidArgumentException('Invalid PHP settings configuration; must be an array');
-            }
+        if (!isset($config['php_settings'])) {
+            return;
+        }
+        
+        if (!is_array($config['php_settings'])) {
+            throw new Exception\InvalidArgumentException('Invalid PHP settings configuration; must be an array');
+        }
 
-            foreach ($config['php_settings'] as $name => $value) {
-                if (false === ini_set($name, $value)) {
-                    throw PhpSettingsFailureException::forOption($name, $value);
-                }
+        foreach ($config['php_settings'] as $name => $value) {
+            if (false === ini_set($name, $value)) {
+                throw PhpSettingsFailureException::forOption($name, $value);
             }
         }
     }

--- a/src/Container/Exception/PhpSettingsFailureException.php
+++ b/src/Container/Exception/PhpSettingsFailureException.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       http://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Container\Exception;
+
+use RuntimeException;
+
+/**
+ * Exception indicating that setting of some PHP configuration option has failed.
+ */
+class PhpSettingsFailureException extends RuntimeException implements ExceptionInterface
+{
+    public static function forOption($name, $value)
+    {
+        return new self("Setting PHP configuration '$name' with a value of '$value' has failed");
+    }
+}

--- a/test/Container/ApplicationFactoryTest.php
+++ b/test/Container/ApplicationFactoryTest.php
@@ -65,6 +65,60 @@ class ApplicationFactoryTest extends TestCase
         return $r->getValue($app);
     }
 
+    public function testFactorySetsPhpSettingsFromConfig()
+    {
+        $this->container
+            ->has('Zend\Expressive\Router\RouterInterface')
+            ->willReturn(false);
+        $this->container
+            ->get('Zend\Expressive\Router\RouterInterface')
+            ->shouldNotBeCalled();
+
+        $this->container
+            ->has('Zend\Diactoros\Response\EmitterInterface')
+            ->willReturn(false);
+        $this->container
+            ->get('Zend\Diactoros\Response\EmitterInterface')
+            ->shouldNotBeCalled();
+
+        $this->container
+            ->has('Zend\Expressive\FinalHandler')
+            ->willReturn(false);
+        $this->container
+            ->get('Zend\Expressive\FinalHandler')
+            ->shouldNotBeCalled();
+
+        $config = [
+            'php_settings' => [
+                'display_errors' => 1,
+                'date.timezone' => 'Europe/Belgrade',
+            ],
+        ];
+
+        $currentPhpSettings = [];
+        foreach ($config['php_settings'] as $name => $value) {
+            $currentPhpSettings[$name] = ini_get($name);
+        }
+
+        $this->container
+            ->has('config')
+            ->willReturn(true);
+
+        $this->container
+            ->get('config')
+            ->willReturn($config);
+
+        $this->factory->__invoke($this->container->reveal());
+
+        foreach ($config['php_settings'] as $name => $value) {
+            $this->assertEquals($value, ini_get($name));
+        }
+
+        foreach ($currentPhpSettings as $name => $value) {
+            ini_set($name, $value);
+        }
+    }
+
     public function testFactoryWillPullAllReplaceableDependenciesFromContainerWhenPresent()
     {
         $router       = $this->prophesize('Zend\Expressive\Router\RouterInterface');

--- a/test/Container/ApplicationFactoryTest.php
+++ b/test/Container/ApplicationFactoryTest.php
@@ -160,11 +160,13 @@ class ApplicationFactoryTest extends TestCase
             ],
         ];
 
+        $this->iniSet('display_errors', 0);
+        $this->iniSet('date.timezone', 'UTC');
+
         $this->factory->__invoke($this->getContainer($config)->reveal());
 
         foreach ($config['php_settings'] as $name => $value) {
             $this->assertEquals($value, ini_get($name));
-            ini_restore($name);
         }
     }
 


### PR DESCRIPTION
Per-environment PHP configuration is very common use-case and so far it has been usually implemented by placing inline `ini_set` calls within some `php_settings.php` configuration itself. It would be much nicer if we can have clean configurations, for example:
```php
return [
    'php_settings' => [
        'display_startup_errors'        => false,
        'display_errors'                => false,
        'date.timezone'                 => 'Europe/Belgrade'
    ]
];
```
In order to achieve that, PHP settings must be set at some point, and I think that the most suitable context is the `ApplicationFactory`.