### PR TITLE
Removed $checkAbstractFactories flag from ServiceManager::has()

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -201,13 +201,13 @@ class Application extends MiddlewarePipe
     {
         // Lazy-load middleware from the container when possible
         $container = $this->container;
-        if (null === $middleware && is_string($path) && $container && $container->has($path, true)) {
+        if (null === $middleware && is_string($path) && $container && $container->has($path)) {
             $middleware = $this->marshalLazyMiddlewareService($path, $container);
             $path       = '/';
         } elseif (is_string($middleware)
             && ! is_callable($middleware)
             && $container
-            && $container->has($middleware, true)
+            && $container->has($middleware)
         ) {
             $middleware = $this->marshalLazyMiddlewareService($middleware, $container);
         } elseif (null === $middleware && is_callable($path)) {
@@ -263,13 +263,13 @@ class Application extends MiddlewarePipe
     {
         // Lazy-load middleware from the container
         $container = $this->container;
-        if (null === $middleware && is_string($path) && $container && $container->has($path, true)) {
+        if (null === $middleware && is_string($path) && $container && $container->has($path)) {
             $middleware = $this->marshalLazyErrorMiddlewareService($path, $container);
             $path       = '/';
         } elseif (is_string($middleware)
             && ! is_callable($middleware)
             && $container
-            && $container->has($middleware, true)
+            && $container->has($middleware)
         ) {
             $middleware = $this->marshalLazyErrorMiddlewareService($middleware, $container);
         } elseif (null === $middleware && is_callable($path)) {
@@ -542,7 +542,7 @@ class Application extends MiddlewarePipe
     private function marshalMiddlewareFromContainer($middleware)
     {
         $container = $this->container;
-        if (! $container || ! $container->has($middleware, true)) {
+        if (! $container || ! $container->has($middleware)) {
             return $middleware;
         }
 

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -418,7 +418,7 @@ class ApplicationTest extends TestCase
         };
 
         $container = $this->prophesize(ContainerInterface::class);
-        $container->has('foo', true)->willReturn(true);
+        $container->has('foo')->willReturn(true);
         $container->get('foo')->willReturn($middleware);
 
         $app = new Application($this->router->reveal(), $container->reveal());
@@ -445,7 +445,7 @@ class ApplicationTest extends TestCase
         };
 
         $container = $this->prophesize(ContainerInterface::class);
-        $container->has('foo', true)->willReturn(true);
+        $container->has('foo')->willReturn(true);
         $container->get('foo')->willReturn($middleware);
 
         $app = new Application($this->router->reveal(), $container->reveal());
@@ -472,7 +472,7 @@ class ApplicationTest extends TestCase
         };
 
         $container = $this->prophesize(ContainerInterface::class);
-        $container->has('foo', true)->willReturn(true);
+        $container->has('foo')->willReturn(true);
         $container->get('foo')->willReturn($middleware);
 
         $app = new Application($this->router->reveal(), $container->reveal());
@@ -499,7 +499,7 @@ class ApplicationTest extends TestCase
         };
 
         $container = $this->prophesize(ContainerInterface::class);
-        $container->has('foo', true)->willReturn(true);
+        $container->has('foo')->willReturn(true);
         $container->get('foo')->willReturn($middleware);
 
         $app = new Application($this->router->reveal(), $container->reveal());

--- a/test/Container/ApplicationFactoryTest.php
+++ b/test/Container/ApplicationFactoryTest.php
@@ -448,7 +448,7 @@ class ApplicationFactoryTest extends TestCase
             ->willReturn($config);
 
         $this->container
-            ->has('Middleware', true)
+            ->has('Middleware')
             ->willReturn(true);
 
         $this->container
@@ -551,7 +551,7 @@ class ApplicationFactoryTest extends TestCase
             ->willReturn($config);
 
         $this->container
-            ->has('/', true)
+            ->has('/')
             ->willReturn(false);
 
         $this->setExpectedException('InvalidArgumentException');
@@ -611,7 +611,7 @@ class ApplicationFactoryTest extends TestCase
             ->willReturn($config);
 
         $this->container
-            ->has('Middleware', true)
+            ->has('Middleware')
             ->willReturn(false);
 
         $this->setExpectedException('InvalidArgumentException');
@@ -673,7 +673,7 @@ class ApplicationFactoryTest extends TestCase
             ->willReturn($config);
 
         $this->container
-            ->has('Middleware', true)
+            ->has('Middleware')
             ->willReturn(true);
 
         $this->container
@@ -830,7 +830,7 @@ class ApplicationFactoryTest extends TestCase
             ->willReturn($config);
 
         $this->container
-            ->has('Middleware', true)
+            ->has('Middleware')
             ->willReturn(true);
 
         $this->container

--- a/test/RouteMiddlewareTest.php
+++ b/test/RouteMiddlewareTest.php
@@ -218,7 +218,7 @@ class RouteMiddlewareTest extends TestCase
 
         $this->router->match($request)->willReturn($result);
 
-        $this->container->has('TestAsset\Middleware', true)->willReturn(true);
+        $this->container->has('TestAsset\Middleware')->willReturn(true);
         $this->container->get('TestAsset\Middleware')->willReturn($middleware);
 
         $app = $this->getApplication();
@@ -246,7 +246,7 @@ class RouteMiddlewareTest extends TestCase
 
         $this->router->match($request)->willReturn($result);
 
-        $this->container->has('TestAsset\Middleware', true)->willReturn(true);
+        $this->container->has('TestAsset\Middleware')->willReturn(true);
         $this->container->get('TestAsset\Middleware')->willThrow(new TestAsset\ContainerException());
 
         $app = $this->getApplication();


### PR DESCRIPTION
Reverts 117b2195371eb8285bc63c443babc6bb520f58e5

Related:
* https://github.com/zendframework/zend-servicemanager/pull/49
* https://github.com/zendframework/zend-expressive/pull/156