### PR TITLE
Clarify that addRoute must raise exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ Third release candidate.
   where received configuration is unusable, instead of silently ignoring it.
   This is a small backwards compatibility break, but is done to eliminate
   difficult to identify issues due to bad configuration.
+- [#202](https://github.com/zendframework/zend-expressive/pull/202) clarifies
+  that `RouterInterface` implements **MUST** throw a `RuntimeException` if
+  `addRoute()` is called after either `match()` or `generateUri()` have been
+  called.
 
 ## 1.0.0rc2 - 2015-10-20
 

--- a/doc/book/router/interface.md
+++ b/doc/book/router/interface.md
@@ -12,6 +12,7 @@ The interface is defined as follows:
 namespace Zend\Expressive\Router;
 
 use Psr\Http\Message\ServerRequestInterface as Request;
+use RuntimeException;
 use Zend\Expressive\Exception;
 
 interface RouterInterface
@@ -26,7 +27,13 @@ interface RouterInterface
      * modify route instances before matching (e.g., to provide route options,
      * inject a name, etc.).
      *
+     * The method MUST raise a RuntimeException if called after either `match()`
+     * or `generateUri()` have already been called, to ensure integrity of the
+     * router between invocations of either of those methods.
+     *
      * @param Route $route
+     * @throws RuntimeException when called after match() or generateUri() have
+     *     been called.
      */
     public function addRoute(Route $route);
 

--- a/src/Router/RouterInterface.php
+++ b/src/Router/RouterInterface.php
@@ -10,6 +10,7 @@
 namespace Zend\Expressive\Router;
 
 use Psr\Http\Message\ServerRequestInterface as Request;
+use RuntimeException;
 use Zend\Expressive\Exception;
 
 /**
@@ -27,7 +28,13 @@ interface RouterInterface
      * modify route instances before matching (e.g., to provide route options,
      * inject a name, etc.).
      *
+     * The method MUST raise a RuntimeException if called after either `match()`
+     * or `generateUri()` have already been called, to ensure integrity of the
+     * router between invocations of either of those methods.
+     *
      * @param Route $route
+     * @throws RuntimeException when called after match() or generateUri() have
+     *     been called.
      */
     public function addRoute(Route $route);
 


### PR DESCRIPTION
Per #189, `addRoute()` **MUST** raise a `RuntimeException` if called after either `match()` or `generateUri()` have been called, to ensure the router state does not change between invocations.

Replaces #189.