### PR TITLE
Create subcomponent-specific exceptions for Template subcomponent

### DIFF
--- a/src/Template/ArrayParametersTrait.php
+++ b/src/Template/ArrayParametersTrait.php
@@ -10,7 +10,6 @@
 namespace Zend\Expressive\Template;
 
 use Traversable;
-use Zend\Expressive\Exception;
 
 trait ArrayParametersTrait
 {

--- a/src/Template/DefaultParamsTrait.php
+++ b/src/Template/DefaultParamsTrait.php
@@ -10,7 +10,6 @@
 namespace Zend\Expressive\Template;
 
 use Traversable;
-use Zend\Expressive\Exception;
 use Zend\Stdlib\ArrayUtils;
 
 trait DefaultParamsTrait

--- a/src/Template/Exception/ExceptionInterface.php
+++ b/src/Template/Exception/ExceptionInterface.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Template\Exception;
+
+interface ExceptionInterface
+{
+}

--- a/src/Template/Exception/InvalidArgumentException.php
+++ b/src/Template/Exception/InvalidArgumentException.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Template\Exception;
+
+class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
+{
+}

--- a/test/Template/ArrayParametersTraitTest.php
+++ b/test/Template/ArrayParametersTraitTest.php
@@ -9,7 +9,7 @@ namespace ZendTest\Expressive\Template;
 use ArrayIterator;
 use PHPUnit_Framework_TestCase as TestCase;
 use stdClass;
-use Zend\Expressive\Exception\InvalidArgumentException;
+use Zend\Expressive\Template\Exception\InvalidArgumentException;
 
 class ArrayParametersTraitTest extends TestCase
 {


### PR DESCRIPTION
In preparation for splitting the Template subcomponent into its own repository, this patch:

- adds an `Exception` subcomponent, with an `ExceptionInterface` marker interface and an `InvalidArgumentException` concrete implementation.
- updates the ArrayParametersTrait and DefaultParamsTrait to use the subcomponent-specific exceptions.
- updates the ArrayParametersTrait to test for the subcomponent-specific exceptions instead of the component-level exceptions.