### PR TITLE
Moves the RouteResultObserverInterface back to the Expressive namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,15 +17,16 @@ Third release candidate.
   array **must** be callables, service names resolving to callable middleware,
   or fully qualified class names that can be instantiated without arguments, and
   which result in invokable middleware.
-- [#200](https://github.com/zendframework/zend-expressive/pull/200) adds a new
-  interface, `Zend\Expressive\Router\RouteResultObserverInterface` (since moved
-  to the zend-expressive-router package). `Zend\Expressive\Application` now
-  also defines two methods, `attachRouteResultObserver()` and
-  `detachRouteResultObserver()`, which accept instances of the interface. During
-  `routeMiddleware()`, all observers are updated immediately following the call
-  to `RouterInterface::match()` with the `RouteResult` instance. This feature
-  enables the ability to notify objects of the calculated `RouteResult` without
-  needing to inject middleware into the system.
+- [#200](https://github.com/zendframework/zend-expressive/pull/200) and
+  [#206](https://github.com/zendframework/zend-expressive/pull/206) add a new
+  interface, `Zend\Expressive\RouteResultObserverInterface`.
+  `Zend\Expressive\Application` now also defines two methods,
+  `attachRouteResultObserver()` and `detachRouteResultObserver()`, which accept
+  instances of the interface. During `routeMiddleware()`, all observers are
+  updated immediately following the call to `RouterInterface::match()` with the
+  `RouteResult` instance. This feature enables the ability to notify objects of
+  the calculated `RouteResult` without needing to inject middleware into the
+  system.
 - [#81](https://github.com/zendframework/zend-expressive/pull/81) adds a
   cookbook entry for creating 404 handlers.
 

--- a/doc/book/router/result-observers.md
+++ b/doc/book/router/result-observers.md
@@ -21,7 +21,9 @@ you to notify such utilities of the results of matching.
 Route result observers must implement the `RouteResultObserverInterface`:
 
 ```php
-namespace Zend\Expressive\Router;
+namespace Zend\Expressive;
+
+use Zend\Expressive\Router\RouteResult;
 
 interface RouteResultObserverInterface
 {
@@ -59,7 +61,7 @@ when invoked, generate a URI.
 ```php
 use Zend\Expressive\Router\RouterInterface;
 use Zend\Expressive\Router\RouteResult;
-use Zend\Expressive\Router\RouteResultObserverInterface;
+use Zend\Expressive\RouteResultObserverInterface;
 
 class UriGenerator implements RouteResultObserverInterface
 {

--- a/src/Application.php
+++ b/src/Application.php
@@ -176,9 +176,9 @@ class Application extends MiddlewarePipe
     /**
      * Attach a route result observer.
      *
-     * @param Router\RouteResultObserverInterface $observer
+     * @param RouteResultObserverInterface $observer
      */
-    public function attachRouteResultObserver(Router\RouteResultObserverInterface $observer)
+    public function attachRouteResultObserver(RouteResultObserverInterface $observer)
     {
         $this->routeResultObservers[] = $observer;
     }
@@ -186,9 +186,9 @@ class Application extends MiddlewarePipe
     /**
      * Detach a route result observer.
      *
-     * @param Router\RouteResultObserverInterface $observer
+     * @param RouteResultObserverInterface $observer
      */
-    public function detachRouteResultObserver(Router\RouteResultObserverInterface $observer)
+    public function detachRouteResultObserver(RouteResultObserverInterface $observer)
     {
         if (false === ($index = array_search($observer, $this->routeResultObservers, true))) {
             return;

--- a/src/RouteResultObserverInterface.php
+++ b/src/RouteResultObserverInterface.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive;
+
+use Zend\Expressive\Router\RouteResult;
+
+interface RouteResultObserverInterface
+{
+    /**
+     * Observe a route result.
+     *
+     * @param RouteResult $result
+     */
+    public function update(RouteResult $result);
+}

--- a/test/RouteMiddlewareTest.php
+++ b/test/RouteMiddlewareTest.php
@@ -16,7 +16,7 @@ use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequest;
 use Zend\Expressive\Application;
 use Zend\Expressive\Router\RouteResult;
-use Zend\Expressive\Router\RouteResultObserverInterface;
+use Zend\Expressive\RouteResultObserverInterface;
 use Zend\Expressive\Router\RouterInterface;
 
 class RouteMiddlewareTest extends TestCase


### PR DESCRIPTION
This patch moves the `RouteResultObserverInterface` into the `Zend\Expressive` namespace. Since it is triggered by `Application`, it is an application-level responsibility, not the router's.

Since the class names do not conflict, this can lead to an immediate deprecation of the original interface in the zend-expressive-router package. However, zend-expressive-zendviewrenderer will need updates so that it fulfills the new interface via its `UrlHelper` instance.

Since the interface has not been part of an official Expressive release yet, this change is backwards compatible.