### PR TITLE
1.0.0rc3 readiness

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,13 +36,13 @@ before_script:
   - if [[ $EXECUTE_DOC_CHECK == 'true' ]]; then cp mkdocs.yml mkdocs.yml.orig ; fi
 
 script:
-  - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then ./vendor/bin/phpunit --coverage-clover clover.xml ; fi
-  - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then ./vendor/bin/phpunit ; fi
-  - if [[ $EXECUTE_CS_CHECK == 'true' ]]; then ./vendor/bin/phpcs ; fi
+  - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer test-coverage ; fi
+  - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then composer test ; fi
+  - if [[ $EXECUTE_CS_CHECK == 'true' ]]; then composer cs ; fi
   - if [[ $EXECUTE_DOC_CHECK == 'true' ]]; then make mkdocs ; diff mkdocs.yml mkdocs.yml.orig ; return $? ; fi
 
 after_script:
-  - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then ./vendor/bin/coveralls ; fi
+  - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer coveralls ; fi
 
 notifications:
   email: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
-## 1.0.0rc3 - TBD
+## 1.0.0rc3 - 2015-12-07
 
 Third release candidate.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,13 +54,13 @@ To run tests:
 
   If you don't have `curl` installed, you can also download `composer.phar` from https://getcomposer.org/
 
-- Run the tests via `phpunit` and the provided PHPUnit config, like in this example:
+- Run the tests using the "test" command shipped in the `composer.json`:
 
   ```console
-  $ ./vendor/bin/phpunit
+  $ composer test
   ```
 
-You can turn on conditional tests with the phpunit.xml file.
+You can turn on conditional tests with the `phpunit.xml` file.
 To do so:
 
  -  Copy `phpunit.xml.dist` file to `phpunit.xml`
@@ -69,24 +69,23 @@ To do so:
 
 ## Running Coding Standards Checks
 
-This component uses [phpcs](https://github.com/squizlabs/PHP_CodeSniffer) for coding
-standards checks, and provides configuration for our selected checks.
-`phpcs` is installed by default via Composer.
+First, ensure you've installed dependencies via composer, per the previous
+section on running tests.
 
-To run checks only:
-
-```console
-$ ./vendor/bin/phpcs
-```
-
-`phpcs` also includes a tool for fixing most CS violations, `phpcbf`:
-
+To run CS checks only:
 
 ```console
-$ ./vendor/bin/phpcbf
+$ composer cs
 ```
 
-If you allow `phpcbf` to fix CS issues, please re-run the tests to ensure
+To attempt to automatically fix common CS issues:
+
+
+```console
+$ composer cs-fix
+```
+
+If the above fixes any CS issues, please re-run the tests to ensure
 they pass, and make sure you add and commit the changes after verification.
 
 ## Recommended Workflow for Contributions

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     },
     "require": {
-        "php": ">=5.5",
+        "php": "^5.5 || ^7.0",
         "container-interop/container-interop": "^1.1",
         "psr/http-message": "^1.0",
         "zendframework/zend-diactoros": "^1.1",
@@ -28,9 +28,9 @@
         "filp/whoops": "^1.1",
         "phpunit/phpunit": "^4.7",
         "squizlabs/php_codesniffer": "^2.3",
-        "zendframework/zend-expressive-aurarouter": "~1.0-dev",
-        "zendframework/zend-expressive-fastroute": "~1.0-dev",
-        "zendframework/zend-expressive-zendrouter": "~1.0-dev",
+        "zendframework/zend-expressive-aurarouter": "^1.0",
+        "zendframework/zend-expressive-fastroute": "^1.0",
+        "zendframework/zend-expressive-zendrouter": "^1.0",
         "zendframework/zend-servicemanager": "^2.6"
     },
     "autoload": {
@@ -45,14 +45,25 @@
     },
     "suggest": {
         "filp/whoops": "^1.1 to use the Whoops error handler",
-        "zendframework/zend-expressive-aurarouter": "^0.1 to use the Aura.Router routing adapter",
-        "zendframework/zend-expressive-fastroute": "^0.1 to use the FastRoute routing adapter",
-        "zendframework/zend-expressive-zendrouter": "^0.1 to use the zend-mvc routing adapter",
-        "zendframework/zend-expressive-platesrenderer": "^0.1 to use the Plates template renderer",
-        "zendframework/zend-expressive-twigrenderer": "^0.1 to use the Twig template renderer",
-        "zendframework/zend-expressive-zendviewrenderer": "^0.1 to use the zend-view PhpRenderer template renderer",
+        "zendframework/zend-expressive-aurarouter": "^1.0 to use the Aura.Router routing adapter",
+        "zendframework/zend-expressive-fastroute": "^1.0 to use the FastRoute routing adapter",
+        "zendframework/zend-expressive-zendrouter": "^1.0 to use the zend-mvc routing adapter",
+        "zendframework/zend-expressive-platesrenderer": "^1.0 to use the Plates template renderer",
+        "zendframework/zend-expressive-twigrenderer": "^1.0 to use the Twig template renderer",
+        "zendframework/zend-expressive-zendviewrenderer": "^1.0 to use the zend-view PhpRenderer template renderer",
         "aura/di": "3.0.*@beta to make use of Aura.Di dependency injection container",
         "mouf/pimple-interop": "^1.0 to use Pimple for dependency injection",
         "zendframework/zend-servicemanager": "^2.5 to use zend-servicemanager for dependency injection"
+    },
+    "scripts": {
+        "check": [
+            "@cs",
+            "@test"
+        ],
+        "coveralls": "coveralls",
+        "cs": "phpcs",
+        "cs-fix": "phpcbf",
+        "test": "phpunit",
+        "test-coverage": "phpunit --coverage-clover clover.xml"
     }
 }


### PR DESCRIPTION
- Updated CHANGELOG.
- Updated composer.json:
 - Set all router/template dev/suggest dependencies to `^1.0`.
 - Updated PHP dep to `^5.5 || ^7.0`
 - Added `scripts` section.
- Updated travis.yml:
 - use composer scripts for each task.
- Updated CONTRIBUTING:
 - Detail using composer scripts for testing, CS checks, vs specific tools.