### PR TITLE
GLOB_BRACE fails on Win 7 using Xampp stack

### DIFF
--- a/doc/book/usage-examples.md
+++ b/doc/book/usage-examples.md
@@ -256,10 +256,10 @@ repository, and also provides a mechanism for slip-streaming in
 configuration based on our environment (you might use different settings in
 development than in production, after all!).
 
-First, install zend-config:
+First, install zend-config and zend-stdlib:
 
 ```bash
-$ composer require zendframework/zend-config
+$ composer require zendframework/zend-config zendframework/zend-stdlib
 ```
 
 Now we can start creating our configuration files and container factories.
@@ -269,10 +269,13 @@ In `config/config.php`, place the following:
 ```php
 <?php
 use Zend\Config\Factory as ConfigFactory;
+use Zend\Stdlib\Glob;
 
-return ConfigFactory::fromFiles(
-    glob('config/autoload/{global,local}.php', GLOB_BRACE)
-);
+$files = Glob::glob('config/autoload/{{,*.}global,{,*.}local}.php', Glob::GLOB_BRACE);
+if (0 === count($files)) {
+    return [];
+}
+return ConfigFactory::fromFiles($files);
 ```
 
 In `config/autoload/global.php`, place the following:
@@ -299,9 +302,10 @@ In `config/dependencies.php`, place the following:
 ```php
 <?php
 use Zend\Config\Factory as ConfigFactory;
+use Zend\Stdlib\Glob;
 
 return ConfigFactory::fromFiles(
-    glob('config/autoload/dependencies.{global,local}.php', GLOB_BRACE)
+    Glob::glob('config/autoload/dependencies.{global,local}.php', Glob::GLOB_BRACE)
 );
 ```
 


### PR DESCRIPTION
Using code like

return ConfigFactory::fromFiles(
        glob('config/autoload/{global,local}.php', GLOB_BRACE)
);

as described in Expressive example for config/config.php does not work on a stack described in the header (see http://zend-expressive.readthedocs.org/en/stable/usage-examples/#hello-world-using-a-configuration-driven-container).

http://www.php.net/function.glob notes: The GLOB_BRACE flag is not available on some non GNU systems, like Solaris. On my system it produces "Catchable fatal error: Argument 2 passed to Zend\Stdlib\ArrayUtils::merge() must be of the type array, integer given..."

Is there a requirement to change examples, or change Zend Config Factory::fromFiles, or change Zend Stdlib ArrayUtils::merge?