### PR TITLE
How to setup form view helpers

### DIFF
--- a/doc/book/cookbook.md
+++ b/doc/book/cookbook.md
@@ -360,3 +360,231 @@ This must be done *after*:
 
 This is to ensure that the `NotFound` middleware executes *after* any routed
 middleware, as you only want it to execute if no routed middleware was selected.
+
+## How can I use zend-form view helpers?
+
+If you've selected zend-view as your preferred template renderer, you'll likely
+want to use the various view helpers available in other components, such as:
+
+- zend-form
+- zend-i18n
+- zend-navigation
+
+By default, only the view helpers directly available in zend-view are available;
+how can you add the others?
+
+If you installed Expressive via the skeleton, the service
+`Zend\View\HelperPluginManager` is registered for you, and represents the helper
+plugin manager injected into the `PhpRenderer` instance. As such, you only need
+to configure this. The question is: where?
+
+You have a two options:
+
+- Add a delegator factory to or extend the `HelperPluginManager` service to
+  inject the additional helper configuration; or
+- Add pre_routing pipeline middleware that composes the `HelperPluginManager`
+  and configures it.
+
+### Delegator factories/service extension
+
+[Delegator factories](http://framework.zend.com/manual/current/en/modules/zend.service-manager.delegator-factories.html)
+and [service extension](https://github.com/silexphp/Pimple/tree/1.1#modifying-services-after-creation)
+operate on the same principle: they intercept after the original factory was
+called, and then operate on the generated instance, either modifying or
+replacing it. We'll demonstrate this for zend-servicemanager and Pimple; at the
+time of writing, we're unaware of a mechanism for doing so in Aura.Di.
+
+#### zend-servicemanager
+
+You'll first need to create a delegator factory:
+
+```php
+namespace Your\Application;
+
+use Zend\Form\View\HelperConfig;
+use Zend\ServiceManager\DelegatorFactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class FormHelpersDelegatorFactory
+{
+    public function createDelegatorWithName(
+        ServiceLocatorInterface $container,
+        $name,
+        $requestedName,
+        $callback
+    ) {
+        $helpers = $callback();
+        $config = new HelperConfig();
+        $config->configureServiceManager($helpers);
+        return $helpers;
+    }
+}
+```
+
+The above creates an instance of the `Zend\Form\View\HelperConfig` class,
+uses it to configure the already created `Zend\View\HelperPluginManager`
+instance, and then returns the plugin manager instance.
+
+From here, you'll add a `delegator_factories` configuration key in your
+`config/autoload/templates.global.php` file:
+
+```php
+return [
+    'dependencies' => [
+        'delegator_factories' => [
+            Zend\View\HelperPluginManager::class => [
+                Your\Application\FormHelpersDelegatorFactory::class,
+            ],
+        ],
+        /* ... */
+    ],
+    'templates' => [
+        /* ... */
+    ],
+    'view_helpers' => [
+        /* ... */
+    ],
+];
+```
+
+Note: delegator factories are keyed by the service they modify, and the value is
+an *array* of delegator factories, to allow multiple such factories to be in
+use.
+
+#### Pimple
+
+For Pimple, we don't currently support configuration of service extensions, so
+you'll need to edit the main container configuration file,
+`config/container.php`. Place the following anywhere after the factories and
+invokables are defined:
+
+```php
+// The following assumes you've added the following import statements to
+// the start of the file:
+// use Zend\Form\View\HelperConfig as FormHelperConfig;
+// use Zend\View\HelperPluginManager;
+$container[HelperPluginManager::class] = $container->extend(
+    HelperPluginManager::class,
+    function ($helpers, $container) {
+        $config = new FormHelperConfig();
+        $config->configureServiceManager($helpers);
+        return $helpers;
+    }
+);
+```
+
+### Pipeline middleware
+
+Another option is to use pre_routing pipeline middleware. This approach will
+require that the middleware execute on every request, which introduces (very
+slight) performance overhead. However, it's a portable method that works
+regardless of the container implementation you choose.
+
+First, define the middleware:
+
+```php
+namespace Your\Application
+
+use Zend\Form\View\HelperConfig as FormHelperConfig;
+use Zend\View\HelperPluginManager;
+
+class FormHelpersMiddleware
+{
+    private $helpers;
+
+    public function __construct(HelperPluginManager $helpers)
+    {
+        $this->helpers = $helpers;
+    }
+
+    public function __invoke($request, $response, callable $next)
+    {
+        $config = new FormHelperConfig();
+        $config->configureServiceManager($this->helpers);
+        return $next($request, $response);
+    }
+}
+```
+
+You'll also need a factory for the middleware, to ensure it receives the
+`HelperPluginManager`:
+
+```php
+namespace Your\Application
+
+use Zend\View\HelperPluginManager;
+
+class FormHelpersMiddlewareFactory
+{
+    public function __invoke($container)
+    {
+        return new FormHelpersMiddleware(
+            $container->get(HelperPluginManager::class)
+        );
+    }
+}
+```
+
+Now, register these in the file
+`config/autoload/middleware-pipeline.global.php`:
+
+```php
+return [
+    'dependencies' => [
+        'factories' => [
+            Your\Application\FormHelpersMiddleware::class => Your\Application\FormHelpersMiddlewareFactory::class
+            /* ... */
+        ],
+        /* ... */
+    ],
+    'middleware_pipeline' => [
+        'pre_routing' => [
+            ['middleware' => Your\Application\FormHelpersMiddleware::class],
+            /* ... */
+        ],
+        'post_routing' => [
+            /* ... */
+        ],
+    ],
+];
+```
+
+At that point, you're all set!
+
+### Registering more helpers
+
+What if you need to register helpers from multiple components?
+
+You can do so using the same technique above. Better yet, do them all at once!
+
+- If you chose to use delegator factories/service extension, do all helper
+  configuration registrations for all components in the same factory.
+- If you chose to use middleware, do all helper configuration registrations for
+  all components in the same middleware.
+
+## How do you register custom view helpers when using zend-view?
+
+If you've selected zend-view as your preferred template renderer, you may want
+to define and use custom view helpers. How can you use them?
+
+Assuming you've used the Expressive skeleton to start your application, you will
+already have a factory defined for `Zend\View\HelperPluginManager`, and it will
+be injected into the `PhpRenderer` instance used. Since the
+`HelperPluginManager` is available, we can configure it.
+
+Open the file `config/autoload/templates.global.php`. In that file, you'll see
+three top-level keys:
+
+```php
+return [
+    'dependencies' => [ /* ... */ ],
+    'templates' => [ /* ... */ ],
+    'view_helpers' => [ /* ... */ ],
+];
+```
+
+The last is the one you want. In this, you can define service mappings,
+including aliases, invokables, factories, and abstract factories to define how
+helpers are named and created.
+[See the zend-view custom helpers documentation](http://framework.zend.com/manual/current/en/modules/zend.view.helpers.advanced-usage.html#zend-view-helpers-advanced-usage)
+for information on how to populate this configuration.


### PR DESCRIPTION
I have setup my `Zend\Expressive` application and really like the lightweight approach. But currently I am struggling to set up form view helpers to output a form in a view template. One issue I tracked down is due to the fact, that `Zend\Form` is not fully refactored to use the latest `Zend\ServiceManager` changes. But I am not sure if that is all to fix this.

I found some posts. The first is about integrating with Aura.DI:
http://harikt.com/blog/2015/11/13/integrating-zend-form-in-zend-expressive-and-view/

And the second with `Zend\ServiceManager` (which I could not get to run due to the current incompatibilities mentioned above):
http://www.masterzendframework.com/zend-expressive-enable-form-view-helpers/

It would be nice if the usage of form view helpers could be supported to help beginners adapt `Zend\Expressive`. I don't care if this can be done with an additional package, or within the Cookbook. At least the problem should be addressed to help the beginners.

What needs to be done to use the good old form view helpers within my `Zend\Expressive` project?