### PR TITLE
Document the `composer serve` command

### DIFF
--- a/doc/book/quick-start-skeleton.md
+++ b/doc/book/quick-start-skeleton.md
@@ -40,7 +40,7 @@ server](http://php.net/manual/en/features.commandline.webserver.php).
 From the project root directory, execute the following:
 
 ```bash
-$ php -S 0.0.0.0:8080 -t public/
+$ composer serve
 ```
 
 This starts up a web server on localhost port 8080; browse to

--- a/doc/book/quick-start.md
+++ b/doc/book/quick-start.md
@@ -91,6 +91,23 @@ $ php -S 0.0.0.0:8080 -t public/
 This starts up a web server on localhost port 8080; browse to
 http://localhost:8080/ to see if your application responds correctly!
 
+> ### Tip: Serve via Composer
+>
+> To simplify starting up a local web server, try adding the following to your
+> `composer.json`:
+>
+> ```json
+> "scripts": {
+>     "server": "php -S 0.0.0.0:8080 -t public/
+> }
+> ```
+>
+> Once you've added that, you can fire up the web server using:
+>
+> ```bash
+> $ composer serve
+> ```
+
 ## Next steps
 
 At this point, you have a working zend-expressive application, that responds to

--- a/doc/book/usage-examples.md
+++ b/doc/book/usage-examples.md
@@ -32,7 +32,12 @@ We assume also that:
 > ```
 >
 > from the application root to start up a web server running on port 8080, and
-> then browse to http://localhost:8080
+> then browse to http://localhost:8080/. If you used the Expressive installer,
+> the following is equivalent:
+>
+> ```bash
+> $ composer serve
+> ```
 
 > ## Setting up autoloading for the Application namespace
 >


### PR DESCRIPTION
This follows on from zendframework/zend-expressive-skeleton#41, demonstrating how to use the built-in `composer serve` command from the installer, as well as how to create the command in standalone installations.