### PR TITLE
Getting started tutorial: no method write() in PSR-7's ResponseInterface

### DIFF
--- a/doc/book/container/aura-di.md
+++ b/doc/book/container/aura-di.md
@@ -107,7 +107,7 @@ class Common extends ContainerConfig
         $router->addRoute(new Route('/hello/{name}', function ($request, $response, $next) {
             $escaper = new Escaper();
             $name = $request->getAttribute('name', 'World');
-            $response->write('Hello ' . $escaper->escapeHtml($name));
+            $response->getBody()->write('Hello ' . $escaper->escapeHtml($name));
             return $response;
         }, Route::HTTP_METHOD_ANY, 'hello'));
         */

--- a/doc/book/quick-start.md
+++ b/doc/book/quick-start.md
@@ -63,7 +63,7 @@ require 'vendor/autoload.php';
 $app = AppFactory::create();
 
 $app->get('/', function ($request, $response, $next) {
-    $response->write('Hello, world!');
+    $response->getBody()->write('Hello, world!');
     return $response;
 });
 


### PR DESCRIPTION
In the getting started tutorial, this sample code is shown:
```php
$app->get('/', function ($request, $response, $next) {
    $response->write('Hello, world!');
    return $response;
});
```

I don't think that's valid as the Psr\Http\Message\ResponseInterface has no write() method.
It should be changed to ```$response->getBody()->write('Hello, world!');```

(If the PSR-7 http implementations are Slim's request and response, this can work, as they added this non-PSR-7's method into their Response implementation, but it doesn't seem correct to me as the router's callback expects a response of the type Psr\Http\Message\ResponseInterface, thus we are violating the contract)
