### PR TITLE
Update docs to use xtreamwayz\pimple-container-interop

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ can recommend the following implementations:
 
 - [zend-servicemanager](https://github.com/zendframework/zend-servicemanager):
   `composer require zendframework/zend-servicemanager`
-- [pimple-interop](https://github.com/moufmouf/pimple-interop):
-  `composer require mouf/pimple-interop`
+- [pimple-container-interop](https://github.com/xtreamwayz/pimple-container-interop):
+  `composer require xtreamwayz/pimple-container-interop`
 - [Aura.Di](https://github.com/auraphp/Aura.Di):
   `composer require aura/di:3.0.*@beta`
 

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "zendframework/zend-expressive-twigrenderer": "^1.0 to use the Twig template renderer",
         "zendframework/zend-expressive-zendviewrenderer": "^1.0 to use the zend-view PhpRenderer template renderer",
         "aura/di": "3.0.*@beta to make use of Aura.Di dependency injection container",
-        "mouf/pimple-interop": "^1.0 to use Pimple for dependency injection",
+        "xtreamwayz/pimple-container-interop": "^1.0 to use Pimple for dependency injection",
         "zendframework/zend-servicemanager": "^2.5 to use zend-servicemanager for dependency injection"
     },
     "scripts": {

--- a/doc/book/container/pimple.md
+++ b/doc/book/container/pimple.md
@@ -14,11 +14,11 @@ Pimple only supports programmatic creation at this time.
 
 Pimple does not currently (as of v3) implement
 [container-interop](https://github.com/container-interop/container-interop); as
-such, you need to install the `mouf/pimple-interop` project, which provides a
-container-interop wrapper around Pimple:
+such, you need to install the `xtreamwayz/pimple-container-interop` project,
+which provides a container-interop wrapper around Pimple v3:
 
 ```bash
-$ composer require mouf/pimple-interop
+$ composer require xtreamwayz/pimple-container-interop
 ```
 
 ## Configuring Pimple
@@ -28,7 +28,7 @@ recommend doing this in a dedicated script that returns the Pimple instance; in
 this example, we'll have that in `config/services.php`.
 
 ```php
-use Interop\Container\Pimple\PimpleInterop as Pimple;
+use Xtreamwayz\Pimple\Container as Pimple;
 use Zend\Expressive\Container;
 use Zend\Expressive\Plates\PlatesRenderer;
 use Zend\Expressive\Router;


### PR DESCRIPTION
Following on zendframework/zend-expressive-skeleton#49, this patch updates the codebase to recommend xtreamwayz/pimple-container-interop for Pimple users. This is to ensure developers are using the latest stable release of Pimple (currently v3), and using a container with the same public API as Pimple itself.

Fixes #129