### PR TITLE
Use absolute urls to fix links in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ documentation.
 
 ## Documentation
 
-Documentation is [in the doc tree](doc/), and can be compiled using [bookdown](http://bookdown.io):
+Documentation is [in the doc tree](https://github.com/zendframework/zend-expressive/tree/master/doc/), and can be compiled using [bookdown](http://bookdown.io):
 
 ```bash
 $ bookdown doc/bookdown.json
@@ -100,6 +100,6 @@ http://zend-expressive.rtfd.org.
 
 ## Architecture
 
-Architectural notes are in [NOTES.md](NOTES.md).
+Architectural notes are in [NOTES.md](https://github.com/zendframework/zend-expressive/blob/master/NOTES.md).
 
 Please see the tests for full information on capabilities.


### PR DESCRIPTION
README.md is used as the index page for the documentation. However the links for docs and the notes are relative links. They should be absolute urls to work on https://zend-expressive.readthedocs.org/en/latest/.