### PR TITLE
Update docs to use xtreamwayz\pimple-container-interop

### DIFF
--- a/doc/book/helpers/server-url-helper.md
+++ b/doc/book/helpers/server-url-helper.md
@@ -61,9 +61,9 @@ $services->setInvokableClass(ServerUrlHelper::class, ServerUrlHelper::class);
 $services->setFactory(ServerUrlMiddleware::class, ServerUrlMiddlewareFactory::class);
 
 // Pimple:
-$pimple[ServerUrlHelper::class] = $pimple->share(function ($container) {
+$pimple[ServerUrlHelper::class] = function ($container) {
     return new ServerUrlHelper();
-});
+};
 $pimple[ServerUrlMiddleware::class] = $pimple->share(function ($container) {
     $factory = new ServerUrlMiddlewareFactory();
     return $factory($container);

--- a/doc/book/helpers/url-helper.md
+++ b/doc/book/helpers/url-helper.md
@@ -81,10 +81,10 @@ use Zend\Expressive\Helper\UrlHelperFactory;
 $services->setFactory(UrlHelper::class, UrlHelperFactory::class);
 
 // Pimple:
-$pimple[UrlHelper::class] = $pimple->share(function ($container) {
+$pimple[UrlHelper::class] = function ($container) {
     $factory = new UrlHelperFactory();
     return $factory($container);
-});
+};
 
 // Aura.Di:
 $container->set(UrlHelperFactory::class, $container->lazyNew(UrlHelperFactory::class));


### PR DESCRIPTION
xtreamwayz\pimple-container-interop is a container-interop wrapper for Pimple v3.
*(Note: maybe we should use $container for zend-servicemanager and pimple as well to match the skeleton app nomenclature)*