### PR TITLE
use --no-dev flag when installing

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ also provides configuration for officially supported dependencies.
 To use the skeleton, use Composer's `create-project` command:
 
 ```bash
-$ composer create-project -s rc zendframework/zend-expressive-skeleton <project dir>
+$ composer create-project --no-dev -s rc zendframework/zend-expressive-skeleton <project dir>
 ```
 
 This will prompt you through choosing your dependencies, and then create and

--- a/doc/book/quick-start-skeleton.md
+++ b/doc/book/quick-start-skeleton.md
@@ -11,7 +11,7 @@ renderer, and error handler from the outset.
 First, we'll create a new project, using Composer's `create-project` command:
 
 ```bash
-$ composer create-project -s rc zendframework/zend-expressive-skeleton expressive
+$ composer create-project --no-dev -s rc zendframework/zend-expressive-skeleton expressive
 ```
 
 > ### Stability
@@ -19,6 +19,12 @@ $ composer create-project -s rc zendframework/zend-expressive-skeleton expressiv
 > The Expressive installer is currently in release candidate status. For Composer
 > to recognize the version as installable, you must pass the `-s rc` flag,
 > indicating it should use packages of RC stability.
+
+> ### Development requirements
+>
+> If you wish to use the development requirements as defined in the skeleton
+> (specifically, PHPUnit and PHP_CodeSniffer), you will need to run a
+> `composer update` after installation.
 
 This will prompt you to choose:
 


### PR DESCRIPTION
Composer installs the dev requirements *as listed before running any scripts* when executing `create-project`. By specifying `--no-dev`, we prevent that from occurring.

This also adds a note that if you want development requirements, you *must* run `composer update` on completion.

See zendframework/zend-expressive-skeleton#60 for details.