### PR TITLE
Adding missing ":" character to fastroute multilanguage parameter

### DIFF
--- a/doc/book/cookbook/setting-locale-depending-routing-parameter.md
+++ b/doc/book/cookbook/setting-locale-depending-routing-parameter.md
@@ -89,7 +89,7 @@ return [
 > ```php
 > [
 >     'name' => 'home',
->     'path' => '/{locale[a-z]{2}}',
+>     'path' => '/{locale:[a-z]{2}}',
 >     'middleware' => Application\Action\HomePageAction::class,
 >     'allowed_methods' => ['GET'],
 > ]


### PR DESCRIPTION
Without it fastroute gives "Number of opening '[' and closing ']' does not match" exception