### PR TITLE
Nested error middleware does not work correctly

### DIFF
--- a/src/ErrorMiddlewarePipe.php
+++ b/src/ErrorMiddlewarePipe.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive;
+
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Message\ResponseInterface as Response;
+use Zend\Stratigility\FinalHandler;
+use Zend\Stratigility\MiddlewarePipe;
+use Zend\Stratigility\Next;
+
+/**
+ * MiddlewarePipe implementation that acts as error middleware.
+ *
+ * Normal MiddlewarePipe implementations implement Zend\Stratigility\MiddlewareInterface,
+ * which can be consumed as normal middleware, but not as error middleware, as
+ * the signature for error middleware differs.
+ *
+ * This class wraps a MiddlewarePipe, and consumes its internal pipeline
+ * within a functor signature that works for error middleware.
+ *
+ * It is not implemented as an extension of MiddlewarePipe, as that class
+ * implements the MiddlewareInterface, which prevents its use as error
+ * middleware.
+ */
+class ErrorMiddlewarePipe
+{
+    /**
+     * @var MiddlewarePipe
+     */
+    private $pipeline;
+
+    /**
+     * @param MiddlewarePipe $pipe
+     */
+    public function __construct(MiddlewarePipe $pipeline)
+    {
+        $this->pipeline = $pipeline;
+    }
+
+    /**
+     * Handle an error request.
+     *
+     * This is essentially a version of the MiddlewarePipe that acts as a pipeline
+     * for solely error middleware; it's primary use case is to allow configuring
+     * arrays of error middleware as a single pipeline.
+     *
+     * Operation is identical to MiddlewarePipe, with the single exception that
+     * $next is called with the $error argument.
+     *
+     * @param mixed $error
+     * @param Request $request
+     * @param Response $response
+     * @param callable $out
+     * @return Response
+     */
+    public function __invoke($error, Request $request, Response $response, callable $out = null)
+    {
+        $pipeline = $this->getInternalPipeline();
+        $done = $out ?: new FinalHandler([], $response);
+        $next = new Next($pipeline, $done);
+        $result = $next($request, $response, $error);
+
+        return ($result instanceof Response ? $result : $response);
+    }
+
+    /**
+     * Retrieve the internal pipeline from the composed MiddlewarePipe.
+     *
+     * Uses reflection to retrieve the internal pipeline from the composed
+     * MiddlewarePipe, in order to allow using it to create a Next instance.
+     *
+     * @return \SplQueue
+     */
+    private function getInternalPipeline()
+    {
+        $r = new ReflectionProperty($this->pipeline, 'pipeline');
+        $r->setAccessible();
+        return $r->getValue($this->pipeline);
+    }
+}

--- a/src/ErrorMiddlewarePipe.php
+++ b/src/ErrorMiddlewarePipe.php
@@ -11,6 +11,7 @@ namespace Zend\Expressive;
 
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Message\ResponseInterface as Response;
+use ReflectionProperty;
 use Zend\Stratigility\FinalHandler;
 use Zend\Stratigility\MiddlewarePipe;
 use Zend\Stratigility\Next;
@@ -81,7 +82,7 @@ class ErrorMiddlewarePipe
     private function getInternalPipeline()
     {
         $r = new ReflectionProperty($this->pipeline, 'pipeline');
-        $r->setAccessible();
+        $r->setAccessible(true);
         return $r->getValue($this->pipeline);
     }
 }

--- a/src/MarshalMiddlewareTrait.php
+++ b/src/MarshalMiddlewareTrait.php
@@ -87,7 +87,7 @@ trait MarshalMiddlewareTrait
      * @param null|ContainerInterface $container
      * @param bool $forError Whether or not the middleware pipe generated is
      *     intended to be populated with error middleware; defaults to false.
-     * @return MiddlewarePipe
+     * @return MiddlewarePipe When $forError is true, returns an ErrorMiddlewarePipe.
      * @throws Exception\InvalidMiddlewareException for any invalid middleware items.
      */
     private function marshalMiddlewarePipe(array $middlewares, ContainerInterface $container = null, $forError = false)
@@ -98,6 +98,10 @@ trait MarshalMiddlewareTrait
             $middlewarePipe->pipe(
                 $this->prepareMiddleware($middleware, $container, $forError)
             );
+        }
+
+        if ($forError) {
+            return new ErrorMiddlewarePipe($middlewarePipe);
         }
 
         return $middlewarePipe;

--- a/src/MarshalMiddlewareTrait.php
+++ b/src/MarshalMiddlewareTrait.php
@@ -87,7 +87,8 @@ trait MarshalMiddlewareTrait
      * @param null|ContainerInterface $container
      * @param bool $forError Whether or not the middleware pipe generated is
      *     intended to be populated with error middleware; defaults to false.
-     * @return MiddlewarePipe When $forError is true, returns an ErrorMiddlewarePipe.
+     * @return MiddlewarePipe|ErrorMiddlewarePipe When $forError is true,
+     *     returns an ErrorMiddlewarePipe.
      * @throws Exception\InvalidMiddlewareException for any invalid middleware items.
      */
     private function marshalMiddlewarePipe(array $middlewares, ContainerInterface $container = null, $forError = false)

--- a/test/Container/ApplicationFactoryTest.php
+++ b/test/Container/ApplicationFactoryTest.php
@@ -14,6 +14,7 @@ use InvalidArgumentException;
 use PHPUnit_Framework_TestCase as TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
 use ReflectionFunction;
+use ReflectionMethod;
 use ReflectionProperty;
 use SplQueue;
 use Zend\Diactoros\Response\EmitterInterface;
@@ -26,6 +27,7 @@ use Zend\Expressive\Exception\InvalidMiddlewareException;
 use Zend\Expressive\Router\FastRouteRouter;
 use Zend\Expressive\Router\Route;
 use Zend\Expressive\Router\RouterInterface;
+use Zend\Stratigility\ErrorMiddlewareInterface;
 use Zend\Stratigility\MiddlewarePipe;
 use Zend\Stratigility\Route as StratigilityRoute;
 use ZendTest\Expressive\ContainerTrait;
@@ -1252,5 +1254,44 @@ class ApplicationFactoryTest extends TestCase
             }
             $this->assertContains($middleware, $innerPipeline);
         }
+    }
+
+    public function testProperlyRegistersNestedErrorMiddlewareAsLazyErrorMiddleware()
+    {
+        $config = ['middleware_pipeline' => [
+            'error' => [
+                'middleware' => [
+                    'FooError',
+                ],
+                'error' => true,
+                'priority' => -10000,
+            ],
+        ]];
+
+        $this->injectServiceInContainer($this->container, 'config', $config);
+        $fooError = $this->prophesize(ErrorMiddlewareInterface::class)->reveal();
+        $this->injectServiceInContainer($this->container, 'FooError', $fooError);
+
+        $app = $this->factory->__invoke($this->container->reveal());
+
+        $r = new ReflectionProperty($app, 'pipeline');
+        $r->setAccessible(true);
+        $pipeline = $r->getValue($app);
+
+        $nestedPipeline = $pipeline->dequeue()->handler;
+
+        $this->assertInstanceOf(MiddlewarePipe::class, $nestedPipeline);
+        $r = new ReflectionMethod($nestedPipeline, '__invoke');
+        $this->assertEquals(4, $r->getNumberOfParameters(), 'Error pipeline is not error middleware');
+
+        $r = new ReflectionProperty($nestedPipeline, 'pipeline');
+        $r->setAccessible(true);
+        $pipeline = $r->getValue($nestedPipeline);
+        $middleware = $pipeline->dequeue()->handler;
+
+        $this->assertInstanceOf(Closure::class, $middleware);
+        $r = new ReflectionFunction($middleware);
+        $this->assertTrue($r->isClosure(), 'Configured middleware is not the expected lazy-middleware closure');
+        $this->assertEquals(4, $r->getNumberOfParameters(), 'Configured middleware is not error middleware');
     }
 }

--- a/test/ErrorMiddlewarePipeTest.php
+++ b/test/ErrorMiddlewarePipeTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @see       http://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\UriInterface as Uri;
+use Zend\Expressive\ErrorMiddlewarePipe;
+use Zend\Stratigility\MiddlewarePipe;
+
+class ErrorMiddlewarePipeTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->internalPipe = new MiddlewarePipe();
+        $this->errorPipe = new ErrorMiddlewarePipe($this->internalPipe);
+    }
+
+    public function testWillDispatchErrorMiddlewareComposedInInternalPipeline()
+    {
+        $error = (object) ['error' => true];
+        $triggered = (object) [
+            'first' => false,
+            'second' => false,
+            'third' => false,
+        ];
+
+        $first = function ($err, $request, $response, $next) use ($error, $triggered) {
+            $this->assertSame($error, $err);
+            $triggered->first = true;
+            return $next($request, $response, $err);
+        };
+        $second = function ($request, $response, $next) use ($triggered) {
+            $triggered->second = true;
+            return $next($request, $response);
+        };
+        $third = function ($err, $request, $response, $next) use ($error, $triggered) {
+            $this->assertSame($error, $err);
+            $triggered->third = true;
+            return $response;
+        };
+
+        $this->internalPipe->pipe($first);
+        $this->internalPipe->pipe($second);
+        $this->internalPipe->pipe($third);
+
+        $uri = $this->prophesize(Uri::class);
+        $uri->getPath()->willReturn('/');
+        $request = $this->prophesize(Request::class);
+        $request->getUri()->willReturn($uri->reveal());
+        $response = $this->prophesize(Response::class);
+
+        $final = function ($request, $response, $err = null) {
+            $this->fail('Final handler should not be triggered');
+        };
+
+        $result = $this->errorPipe->__invoke($error, $request->reveal(), $response->reveal(), $final);
+        $this->assertSame($response->reveal(), $result);
+        $this->assertTrue($triggered->first);
+        $this->assertFalse($triggered->second);
+        $this->assertTrue($triggered->third);
+    }
+}


### PR DESCRIPTION
Given the following middleware specification:

```php
[
    'middleware' => [
        Unauthorized::class,
        Unauthenticated::class,
    ],
    'error' => true,
    'priority' => -10000,
]
```

Neither middleware listed triggers. Each will trigger, however, if you do them separately, not as part of a list:

```php
[
    'middleware' => Unauthorized::class,
    'error' => true,
    'priority' => -10000,
],
[
    'middleware' => Unauthenticated::class,
    'error' => true,
    'priority' => -10000,
],
```

The error is because the `MarshalMiddlewareTrait` ~~is not retaining the `error` flag when marshaling lazy middleware services.~~ composes a `MiddlewarePipe` instance when creating an error middleware pipeline, but that class does not implement the error middleware signature.

This patch creates a `Zend\Expressive\ErrorMiddlewarePipe` implementation that consumes a `MiddlewarePipe` instance while implementing the error middleware signature. `MarshalMiddlewareTrait` is updated to pass the generated `MiddlewarePipe` instance to `ErrorMiddlewarePipe` when generating an error pipeline.
