### PR TITLE
RC7: Cannot GET http://localhost:8080/

### DIFF
--- a/doc/book/getting-started/standalone.md
+++ b/doc/book/getting-started/standalone.md
@@ -67,6 +67,8 @@ $app->get('/', function ($request, $response, $next) {
     return $response;
 });
 
+$app->pipeRoutingMiddleware();
+$app->pipeDispatchMiddleware();
 $app->run();
 ```
 
@@ -76,6 +78,21 @@ $app->run();
 > you use Apache, for instance, you'll need to setup rewrite rules to ensure
 > your bootstrap is invoked for unknown URLs. We'll cover that in a later
 > chapter.
+
+> ### Routing and dispatching
+>
+> Note the lines from the above:
+>
+> ```php
+> $app->pipeRoutingMiddleware();
+> $app->pipeDispatchMiddleware();
+> ```
+>
+> Expressive's `Application` class provides two separate middlewares, one for
+> routing, and one for dispatching middleware matched by routing. This allows
+> you to slip in validations between the two activities if desired. They are
+> not automatically piped to the application, however, to allow exactly that
+> situation, which means they must be piped manually.
 
 ## 5. Start a web server
 


### PR DESCRIPTION
I've tried both the standalone setup and the skeleton and I get this same error when trying to load up a page using RC7 (have not tried any other release candidates). 

For the skeleton, I've done minimal setup with FastRoute, Zend ServiceManager, no templates, no error handler. This is Windows, PHP version 5.6.12, composer version 1.0-dev (ae14e0f)

I get this error (not right away, well after the page loads the error):
```
$ composer serve
> php -S 0.0.0.0:8080 -t public public/index.php

  [Symfony\Component\Process\Exception\ProcessTimedOutException]
  The process "php -S 0.0.0.0:8080 -t public public/index.php" exceeded the timeout of 300 seconds.
```

For the standalone setup, same thing, FastRoute, Zend Service manager. I followed the QuickStart Standalone usage in the docs. This is running in a Vagrant Ubuntu box, PHP version 5.6.13, composer version 1.0-dev (f1aa65). I see the same error, "Cannot GET http://....."