### PR TITLE
Fix for #290: Update migration links in docs and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,7 @@ In particular:
   addition: a `priority` key can be used to allow you to granularly shape the
   execution order of the middleware pipeline.
 
-A [migration guide](http://zend-expressive.rtfd.org/en/latest/migration/rc-to-v1/)
+A [migration guide](https://zendframework.github.io/zend-expressive/reference/migration/rc-to-v1/)
 was written to help developers migrate to RC6 from earlier versions.
 
 ### Added

--- a/src/Container/ApplicationFactory.php
+++ b/src/Container/ApplicationFactory.php
@@ -245,14 +245,14 @@ class ApplicationFactory
             throw new ContainerInvalidArgumentException(
                 'middleware_pipeline cannot contain a mix of middleware AND pre_/post_routing keys; '
                 . 'please update your configuration to define middleware_pipeline as a single pipeline; '
-                . 'see http://zend-expressive.rtfd.org/en/latest/migration/rc-to-v1/'
+                . 'see https://zendframework.github.io/zend-expressive/reference/migration/rc-to-v1/'
             );
         }
 
         trigger_error(
             'pre_routing and post_routing configuration is deprecated; '
             . 'update your configuration to define the middleware_pipeline as a single pipeline; '
-            . 'see http://zend-expressive.rtfd.org/en/latest/migration/rc-to-v1/',
+            . 'see https://zendframework.github.io/zend-expressive/reference/migration/rc-to-v1/',
             E_USER_DEPRECATED
         );
 


### PR DESCRIPTION
fixes #290

According to phpstorm this updates all references to rtfd.org.