### PR TITLE
Update naming modular-layout.md

### DIFF
--- a/doc/book/cookbook/modular-layout.md
+++ b/doc/book/cookbook/modular-layout.md
@@ -53,9 +53,9 @@ array.
 For instance, this is how your module could provide its own routes:
 
 ```php
-namespace App;
+namespace MyModule;
 
-class AppConfig
+class ModuleConfig
 {
     public function __invoke()
     {
@@ -87,7 +87,7 @@ file:
 
 ```php
 $configManager = new ConfigManager([
-    App\AppConfig::class,
+    MyModule\ModuleConfig::class,
     new PhpFileProvider('config/autoload/{{,*.}global,{,*.}local}.php'),
 ]);
 ```


### PR DESCRIPTION
Hi,

I'd suggest that we update the wording for better consistency and better reflect the fact that your App (the one merging is config), is mostly merging config of modules / standalone-libraries / non-app code (and not other app).

This better reflect the distinction between an app (which is actually the consuming code), and the reusable-code.