### PR TITLE
Create configured FinalHandler if one is not available in the container

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "zendframework/zend-diactoros": "^1.1",
         "zendframework/zend-expressive-router": "^1.1",
         "zendframework/zend-expressive-template": "^1.0.1",
-        "zendframework/zend-stratigility": "^1.1"
+        "zendframework/zend-stratigility": "^1.2.0"
     },
     "require-dev": {
         "filp/whoops": "^1.1",

--- a/src/Container/ApplicationFactory.php
+++ b/src/Container/ApplicationFactory.php
@@ -18,6 +18,7 @@ use Zend\Expressive\Container\Exception\InvalidArgumentException as ContainerInv
 use Zend\Expressive\Router\FastRouteRouter;
 use Zend\Expressive\Router\Route;
 use Zend\Expressive\Router\RouterInterface;
+use Zend\Stratigility\FinalHandler;
 use Zend\Stratigility\MiddlewarePipe;
 
 /**
@@ -144,7 +145,7 @@ class ApplicationFactory
 
         $finalHandler = $container->has('Zend\Expressive\FinalHandler')
             ? $container->get('Zend\Expressive\FinalHandler')
-            : null;
+            : $this->marshalFinalHandler($container);
 
         $emitter = $container->has(EmitterInterface::class)
             ? $container->get(EmitterInterface::class)
@@ -472,5 +473,19 @@ class ApplicationFactory
             $queue->insert($item, [$priority, $serial--]);
             return $queue;
         };
+    }
+
+    /**
+     * Create default FinalHandler with options configured under the key final_handler.options.
+     *
+     * @param ContainerInterface $container
+     *
+     * @return FinalHandler
+     */
+    private function marshalFinalHandler(ContainerInterface $container)
+    {
+        $config = $container->has('config') ? $container->get('config') : [];
+        $options = isset($config['final_handler']['options']) ? $config['final_handler']['options'] : [];
+        return new FinalHandler($options, null);
     }
 }

--- a/test/Container/ApplicationFactoryTest.php
+++ b/test/Container/ApplicationFactoryTest.php
@@ -29,6 +29,7 @@ use Zend\Expressive\Router\FastRouteRouter;
 use Zend\Expressive\Router\Route;
 use Zend\Expressive\Router\RouterInterface;
 use Zend\Stratigility\ErrorMiddlewareInterface;
+use Zend\Stratigility\FinalHandler;
 use Zend\Stratigility\MiddlewarePipe;
 use Zend\Stratigility\Route as StratigilityRoute;
 use ZendTest\Expressive\ContainerTrait;
@@ -198,7 +199,18 @@ class ApplicationFactoryTest extends TestCase
         $this->assertInstanceOf(EmitterStack::class, $app->getEmitter());
         $this->assertCount(1, $app->getEmitter());
         $this->assertInstanceOf(SapiEmitter::class, $app->getEmitter()->pop());
-        $this->assertNull($app->getFinalHandler());
+        $this->assertEquals(new FinalHandler([], null), $app->getFinalHandler());
+    }
+
+    public function testUsesFinalHandlerConfigOptionsForDefaultFinalHandler()
+    {
+        $container = $this->mockContainerInterface();
+        $this->injectServiceInContainer($container, 'config', ['final_handler' => ['options' => ['it' => 'worked']]]);
+        $factory = new ApplicationFactory();
+
+        $app = $factory->__invoke($container->reveal());
+        $final = $app->getFinalHandler();
+        $this->assertSame(['it' => 'worked'], self::readAttribute($final, 'options'));
     }
 
     /**


### PR DESCRIPTION
@weierophinney this piggybacks on what we discussed earlier with regard to the issue that inspired [this PR](https://github.com/zendframework/zend-stratigility/pull/46) on the Stratigility repo.

The first part of the other PR fixes the stack traces in production issue, and the second adds the `setOriginalResponse($response);` to the `FinalHandler` in order to allow someone to create a properly configured `FinalHandler` ahead of time. The `Application` would then inject the original response when it calls `->getFinalHandler()`.

The purpose of this new PR is to provide support for configuring the `FinalHandler` that Expressive automatically creates without needing to create a new factory class. Developers would just need to add the desired final handler options to their config.

**There's a caveat, though - it depends on the Stratigility PR.**

This version of this PR should not be merged until the Stratigility PR is merged, a new version is tagged, and Expressive's `composer.json` entry for `zendframework/zend-stratigility` reflects the dependency on that version. This implementation needs `FinalHandler` to support `setOriginalResponse`, otherwise, `200 OK` responses will return 404s instead (since no original response is being injected into the `FinalHandler`).

I don't think the full solution would be considered a BC break, though, since people who were providing their own `FinalHandler` will not be affected, and people who were relying on the default will not notice a thing.

Let me know if you think a proper `Zend\Expressive\FinalHandlerFactory` that folks need to explicitly add to their dependencies config would be a better solution, otherwise, I'll take care of the `composer.json` update once the other PR is merged and tagged and update this PR.