### PR TITLE
Fix: Reduce visibility to protected

### DIFF
--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -42,7 +42,7 @@ class ApplicationTest extends TestCase
 {
     use ContainerTrait;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->noopMiddleware = function ($req, $res, $next) {
         };

--- a/test/Container/ApplicationFactoryIntegrationTest.php
+++ b/test/Container/ApplicationFactoryIntegrationTest.php
@@ -39,7 +39,7 @@ class ApplicationFactoryIntegrationTest extends TestCase
 
     protected $container;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->container = $this->mockContainerInterface();
         $this->factory   = new ApplicationFactory();

--- a/test/Container/ApplicationFactoryTest.php
+++ b/test/Container/ApplicationFactoryTest.php
@@ -53,7 +53,7 @@ class ApplicationFactoryTest extends TestCase
     /** @var ObjectProphecy */
     protected $router;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->container = $this->mockContainerInterface();
         $this->factory   = new ApplicationFactory();

--- a/test/Container/TemplatedErrorHandlerFactoryTest.php
+++ b/test/Container/TemplatedErrorHandlerFactoryTest.php
@@ -26,7 +26,7 @@ class TemplatedErrorHandlerFactoryTest extends TestCase
     /** @var ObjectProphecy */
     protected $container;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->container = $this->mockContainerInterface();
         $this->factory   = new TemplatedErrorHandlerFactory();

--- a/test/Container/WhoopsErrorHandlerFactoryTest.php
+++ b/test/Container/WhoopsErrorHandlerFactoryTest.php
@@ -28,7 +28,7 @@ class WhoopsErrorHandlerFactoryTest extends TestCase
     /** @var ObjectProphecy */
     protected $container;
 
-    public function setUp()
+    protected function setUp()
     {
         $whoops      = $this->prophesize(Whoops::class);
         $pageHandler = $this->prophesize(PrettyPageHandler::class);

--- a/test/Container/WhoopsFactoryTest.php
+++ b/test/Container/WhoopsFactoryTest.php
@@ -29,7 +29,7 @@ class WhoopsFactoryTest extends TestCase
     /** @var ObjectProphecy */
     protected $container;
 
-    public function setUp()
+    protected function setUp()
     {
         $pageHandler = $this->prophesize(PrettyPageHandler::class);
         $this->container = $this->mockContainerInterface();

--- a/test/Container/WhoopsPageHandlerFactoryTest.php
+++ b/test/Container/WhoopsPageHandlerFactoryTest.php
@@ -28,7 +28,7 @@ class WhoopsPageHandlerFactoryTest extends TestCase
     /** @var ObjectProphecy */
     protected $container;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->container = $this->mockContainerInterface();
         $this->factory   = new WhoopsPageHandlerFactory();

--- a/test/Emitter/EmitterStackTest.php
+++ b/test/Emitter/EmitterStackTest.php
@@ -25,7 +25,7 @@ class EmitterStackTest extends TestCase
     /** @var EmitterStack */
     private $emitter;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->emitter = new EmitterStack();
     }

--- a/test/ErrorMiddlewarePipeTest.php
+++ b/test/ErrorMiddlewarePipeTest.php
@@ -19,7 +19,7 @@ use Zend\Stratigility\MiddlewarePipe;
 
 class ErrorMiddlewarePipeTest extends TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         $this->internalPipe = new MiddlewarePipe();
         $this->errorPipe = new ErrorMiddlewarePipe($this->internalPipe);

--- a/test/IntegrationTest.php
+++ b/test/IntegrationTest.php
@@ -23,7 +23,7 @@ class IntegrationTest extends TestCase
 {
     public $response;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->response = null;
     }

--- a/test/RouteMiddlewareTest.php
+++ b/test/RouteMiddlewareTest.php
@@ -31,7 +31,7 @@ class RouteMiddlewareTest extends TestCase
     /** @var ObjectProphecy */
     protected $container;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->router    = $this->prophesize(RouterInterface::class);
         $this->container = $this->mockContainerInterface();


### PR DESCRIPTION
This PR
- [x] removes visibility of `setUp()` in tests to `protected`

:information_desk_person: There's no need to increase the visibility, is there? For reference, see [`PHPUnit_Framework_TestCase::setUp()`](https://github.com/sebastianbergmann/phpunit/blob/4.7/src/Framework/TestCase.php#L1803-L1809).
