### PR TITLE
Fix: Use class keyword where possible

### DIFF
--- a/src/Container/TemplatedErrorHandlerFactory.php
+++ b/src/Container/TemplatedErrorHandlerFactory.php
@@ -10,6 +10,7 @@
 namespace Zend\Expressive\Container;
 
 use Interop\Container\ContainerInterface;
+use Zend\Expressive\Template\TemplateRendererInterface;
 use Zend\Expressive\TemplatedErrorHandler;
 
 /**
@@ -44,8 +45,8 @@ class TemplatedErrorHandlerFactory
 {
     public function __invoke(ContainerInterface $container)
     {
-        $template = $container->has('Zend\Expressive\Template\TemplateRendererInterface')
-            ? $container->get('Zend\Expressive\Template\TemplateRendererInterface')
+        $template = $container->has(TemplateRendererInterface::class)
+            ? $container->get(TemplateRendererInterface::class)
             : null;
 
         $config = $container->has('config')

--- a/src/Container/WhoopsErrorHandlerFactory.php
+++ b/src/Container/WhoopsErrorHandlerFactory.php
@@ -10,6 +10,7 @@
 namespace Zend\Expressive\Container;
 
 use Interop\Container\ContainerInterface;
+use Zend\Expressive\Template\TemplateRendererInterface;
 use Zend\Expressive\WhoopsErrorHandler;
 
 /**
@@ -50,8 +51,8 @@ class WhoopsErrorHandlerFactory
 {
     public function __invoke(ContainerInterface $container)
     {
-        $template = $container->has('Zend\Expressive\Template\TemplateRendererInterface')
-            ? $container->get('Zend\Expressive\Template\TemplateRendererInterface')
+        $template = $container->has(TemplateRendererInterface::class)
+            ? $container->get(TemplateRendererInterface::class)
             : null;
 
         $config = $container->has('config')


### PR DESCRIPTION
This PR
- [x] makes use of the `class` keyword where possible
