### PR TITLE
Fix: Docblock

### DIFF
--- a/src/ErrorMiddlewarePipe.php
+++ b/src/ErrorMiddlewarePipe.php
@@ -39,7 +39,7 @@ class ErrorMiddlewarePipe
     private $pipeline;
 
     /**
-     * @param MiddlewarePipe $pipe
+     * @param MiddlewarePipe $pipeline
      */
     public function __construct(MiddlewarePipe $pipeline)
     {


### PR DESCRIPTION
This PR
- [x] fixes a docblock where the argument is actually named `$pipeline` instead of `$pipe`
