### PR TITLE
fixes FastRouteRouter typo

### DIFF
--- a/doc/book/features/router/fast-route.md
+++ b/doc/book/features/router/fast-route.md
@@ -36,9 +36,9 @@ with no arguments; it will create the underlying FastRoute objects required
 and compose them for you:
 
 ```php
-use Zend\Expressive\Router\FastRoute;
+use Zend\Expressive\Router\FastRouteRouter;
 
-$router = new FastRoute();
+$router = new FastRouteRouter();
 ```
 
 ## Programmatic Creation


### PR DESCRIPTION
Tiny Typo, it's [`FastRouteRouter`](https://github.com/zendframework/zend-expressive-fastroute/blob/master/src/FastRouteRouter.php), not `FastRoute`…