### PR TITLE
Improve compatible with PHP7 Errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "zendframework/zend-stratigility": "^1.1"
     },
     "require-dev": {
-        "filp/whoops": "^1.1",
+        "filp/whoops": "^2.0",
         "phpunit/phpunit": "^4.7",
         "squizlabs/php_codesniffer": "^2.3",
         "zendframework/zend-expressive-aurarouter": "^1.0",


### PR DESCRIPTION
expressive itself was fixed #295 in 1.0, but until whoops 2 whoops couldn't handle it either.
