### PR TITLE
[docs] Update HelperPluginManagerFactory example

### DIFF
--- a/doc/book/cookbook/using-zend-form-view-helpers.md
+++ b/doc/book/cookbook/using-zend-form-view-helpers.md
@@ -35,25 +35,21 @@ zend-form component (or whichever other components you wish to use).
 namespace Your\Application;
 
 use Interop\Container\ContainerInterface;
-use Zend\Form\View\HelperConfig as FormHelperConfig;
 use Zend\ServiceManager\Config;
 use Zend\View\HelperPluginManager;
 
 class HelperPluginManagerFactory
 {
     public function __invoke(ContainerInterface $container)
-    {   
-        $config = $container->has('config') ? $container->get('config') : []; 
-        $config = isset($config['view_helpers']) ? $config['view_helpers'] : []; 
-        $manager = new HelperPluginManager(new Config($config));
-        $manager->setServiceLocator($container);
+    {
+        $manager = new HelperPluginManager($container);
 
-        // Add zend-form view helper configuration:
-        $formConfig = new FormHelperConfig();
-        $formConfig->configureServiceManager($manager);
+        $config = $container->has('config') ? $container->get('config') : [];
+        $config = isset($config['view_helpers']) ? $config['view_helpers'] : [];
+        (new Config($config))->configureServiceManager($manager);
 
-        return $manager;                                                                                                                                                                                                                                                        
-    }   
+        return $manager;
+    }
 }
 ```
 

--- a/doc/book/cookbook/using-zend-form-view-helpers.md
+++ b/doc/book/cookbook/using-zend-form-view-helpers.md
@@ -10,6 +10,19 @@ want to use the various view helpers available in other components, such as:
 By default, only the view helpers directly available in zend-view are available;
 how can you add the others?
 
+To add the zend-form view helpers create a file `config/autoload/zend-form.global.php`
+with the contents:
+
+```php
+<?php
+use Zend\Form\ConfigProvider;
+
+$provider = new ConfigProvider();
+return $provider();
+```
+
+and that will essentially do everything needed.
+
 If you installed Expressive via the skeleton, the service
 `Zend\View\HelperPluginManager` is registered for you, and represents the helper
 plugin manager injected into the `PhpRenderer` instance. As such, you only need


### PR DESCRIPTION
Updates zend form plugin helper example and removes the deprecated `Zend\Form\View\HelperConfig`.
- [x] Update HelperPluginManagerFactory
- [x] Add Zend\Form\ConfigProvider (#335)
- [ ] Update delegator factories/service extension
