### PR TITLE
[docs] Use locale request attribute in favor of the static global locale

### DIFF
--- a/doc/book/cookbook/setting-locale-depending-routing-parameter.md
+++ b/doc/book/cookbook/setting-locale-depending-routing-parameter.md
@@ -125,7 +125,7 @@ class LocalizationMiddleware
         // Get locale from route, fallback to the user's browser preference
         $locale = $request->getAttribute(
             'locale',
-            Locale::acceptFromHttp($request->getServerParams()['HTTP_ACCEPT_LANGUAGE'])
+            Locale::acceptFromHttp($request->getServerParams()['HTTP_ACCEPT_LANGUAGE'] ?? 'en_US')
         );
 
         // Store the locale as a request attribute

--- a/doc/book/cookbook/setting-locale-depending-routing-parameter.md
+++ b/doc/book/cookbook/setting-locale-depending-routing-parameter.md
@@ -125,7 +125,9 @@ class LocalizationMiddleware
         // Get locale from route, fallback to the user's browser preference
         $locale = $request->getAttribute(
             'locale',
-            Locale::acceptFromHttp($request->getServerParams()['HTTP_ACCEPT_LANGUAGE'] ?? 'en_US')
+            Locale::acceptFromHttp(
+                isset($request->getServerParams()['HTTP_ACCEPT_LANGUAGE']) ? $request->getServerParams()['HTTP_ACCEPT_LANGUAGE'] : 'en_US'
+            )
         );
 
         // Store the locale as a request attribute


### PR DESCRIPTION
As discussed on IRC and in #350.

This changes how the locale is stored in the cookbook example. Since it's not reliable to use the global static `Locale::setDefault()`, it's better to store it as a request attribute.
