### PR TITLE
Change visibility of "injectRoutesAndPipeline" method to protected

### DIFF
--- a/src/Container/ApplicationFactory.php
+++ b/src/Container/ApplicationFactory.php
@@ -163,7 +163,7 @@ class ApplicationFactory
      * @param Application $app
      * @param ContainerInterface $container
      */
-    private function injectRoutesAndPipeline(Application $app, ContainerInterface $container)
+    protected function injectRoutesAndPipeline(Application $app, ContainerInterface $container)
     {
         $config = $container->has('config') ? $container->get('config') : [];
         $pipelineCreated = false;


### PR DESCRIPTION
Use case: my application is made of a few API endpoints, all of them share the same configuration. In order for them to work together, I need to customize `middleware_pipeline` and `routes` config keys. Easiest way to achieve this is to extend `ApplicationFactory` class, overriding `injectRoutesAndPipeline` method.