### PR TITLE
Allow to segregate middleware on host

### DIFF
--- a/doc/book/features/application.md
+++ b/doc/book/features/application.md
@@ -145,19 +145,19 @@ and, more specifically, its `MiddlewarePipe` definition, you can also pipe
 should execute on each request, defining error handlers, and/or segregating
 applications by subpath.
 
-The signature of `pipe()` is:
+`pipe()` can be called with up to three arguments:
 
 ```php
-public function pipe($pathOrMiddleware, $middleware = null)
+public function pipe($middleware)
+public function pipe(string $path, $middleware)
+public function pipe(string $path, string $host, $middleware)
 ```
 
 where:
 
-- `$pathOrMiddleware` is either a string URI path (for path segregation), a
-  callable middleware, or the service name for a middleware to fetch from the
-  composed container.
-- `$middleware` is required if `$pathOrMiddleware` is a string URI path. It can
-  be one of:
+- `$path` is a string URI path (for path segregation) 
+- `$host` is a string URI host (for host segregation), 
+- `$middleware` can be one of
   - a callable;
   - a service name that resolves to valid middleware in the container;
   - a fully qualified class name of a constructor-less class;
@@ -170,10 +170,12 @@ middleware only when it is invoked. Internally, it wraps the call to fetch and
 dispatch the middleware inside a closure.
 
 Additionally, we define a new method, `pipeErrorHandler()`, with the following
-signature:
+signatures:
 
 ```php
-public function pipeErrorHandler($pathOrMiddleware, $middleware = null)
+public function pipeErrorHandler($middleware)
+public function pipeErrorHandler($path, $middleware)
+public function pipeErrorHandler($path, $host, $middleware)
 ```
 
 It acts just like `pipe()` except when the middleware specified is a service

--- a/doc/book/reference/usage-examples.md
+++ b/doc/book/reference/usage-examples.md
@@ -468,6 +468,7 @@ Each middleware specified must be in the following form:
     'middleware' => 'Name of middleware service, or a callable',
     // optional:
     'path'  => '/path/to/match',
+    'host'  => 'host.to.match.example.com',
     'error' => true,
     'priority' => 1, // Integer
 ]
@@ -609,13 +610,13 @@ this is done to ensure that lazy-loading of error middleware works as expected.
 > This also means that if the service specified is not valid middleware, you
 > will not find out until the application attempts to invoke it.
 
-## Segregating your application to a subpath
+## Segregating your application to a subpath or host
 
 One benefit of a middleware-based application is the ability to compose
-middleware and segregate them by paths. `Zend\Expressive\Application` is itself
+middleware and segregate them by paths and/or hosts. `Zend\Expressive\Application` is itself
 middleware, allowing you to do exactly that if desired.
 
-In the following example, we'll assume that `$api` and `$blog` are
+In the following example, we'll assume that `$api`, `$blog` and `$support` are
 `Zend\Expressive\Application` instances, and compose them into a
 `Zend\Stratigility\MiddlewarePipe`.
 
@@ -629,6 +630,7 @@ require __DIR__ . '/../vendor/autoload.php';
 $app = new MiddlewarePipe();
 $app->pipe('/blog', $blog);
 $app->pipe('/api', $api);
+$app->pipe('/', 'support.example.com', $support);
 
 $server = Server::createServerFromRequest(
     $app,
@@ -643,6 +645,7 @@ You could also compose them in an `Application` instance, and utilize `run()`:
 $app = AppFactory::create();
 $app->pipe('/blog', $blog);
 $app->pipe('/api', $api);
+$app->pipe('/', 'support.example.com', $support);
 
 $app->run();
 ```

--- a/src/Application.php
+++ b/src/Application.php
@@ -258,14 +258,21 @@ class Application extends MiddlewarePipe implements Router\RouteResultSubjectInt
      * once.
      *
      * @param string|array|callable $path Either a URI path prefix, or middleware.
+     * @param null|string|array|callable $host Either a URI host, or middleware.
      * @param null|string|array|callable $middleware Middleware
      * @return self
      */
-    public function pipe($path, $middleware = null)
+    public function pipe($path, $host = null, $middleware = null)
     {
-        if (null === $middleware) {
+        if (null === $middleware && null === $host) {
             $middleware = $this->prepareMiddleware($path, $this->container);
             $path = '/';
+            $host = null;
+        }
+
+        if($path && $host && null === $middleware) {
+            $middleware = $this->prepareMiddleware($host, $this->container);
+            $host = null;
         }
 
         if (! is_callable($middleware)
@@ -282,7 +289,7 @@ class Application extends MiddlewarePipe implements Router\RouteResultSubjectInt
             return $this;
         }
 
-        parent::pipe($path, $middleware);
+        parent::pipe($path, $host, $middleware);
 
         if ($middleware === [$this, 'routeMiddleware']) {
             $this->routeMiddlewareIsRegistered = true;

--- a/src/Application.php
+++ b/src/Application.php
@@ -330,14 +330,21 @@ class Application extends MiddlewarePipe implements Router\RouteResultSubjectInt
      * proxies to pipe().
      *
      * @param string|callable $path Either a URI path prefix, or middleware.
+     * @param null|string|array|callable $host Either a URI host, or middleware.
      * @param null|string|callable $middleware Middleware
      * @return self
      */
-    public function pipeErrorHandler($path, $middleware = null)
+    public function pipeErrorHandler($path, $host = null, $middleware = null)
     {
-        if (null === $middleware) {
+        if (null === $middleware && null === $host) {
             $middleware = $this->prepareMiddleware($path, $this->container, $forError = true);
             $path = '/';
+            $host = null;
+        }
+
+        if($path && $host && null === $middleware) {
+            $middleware = $this->prepareMiddleware($host, $this->container, $forError = true);
+            $host = null;
         }
 
         if (! is_callable($middleware)
@@ -346,7 +353,7 @@ class Application extends MiddlewarePipe implements Router\RouteResultSubjectInt
             $middleware = $this->prepareMiddleware($middleware, $this->container, $forError = true);
         }
 
-        parent::pipe($path, $middleware);
+        parent::pipe($path, $host, $middleware);
 
         return $this;
     }

--- a/src/Application.php
+++ b/src/Application.php
@@ -270,7 +270,7 @@ class Application extends MiddlewarePipe implements Router\RouteResultSubjectInt
             $host = null;
         }
 
-        if($path && $host && null === $middleware) {
+        if ($path && $host && null === $middleware) {
             $middleware = $this->prepareMiddleware($host, $this->container);
             $host = null;
         }
@@ -342,7 +342,7 @@ class Application extends MiddlewarePipe implements Router\RouteResultSubjectInt
             $host = null;
         }
 
-        if($path && $host && null === $middleware) {
+        if ($path && $host && null === $middleware) {
             $middleware = $this->prepareMiddleware($host, $this->container, $forError = true);
             $host = null;
         }

--- a/src/Container/ApplicationFactory.php
+++ b/src/Container/ApplicationFactory.php
@@ -345,10 +345,11 @@ class ApplicationFactory
 
         foreach ($queue as $spec) {
             $path  = isset($spec['path']) ? $spec['path'] : '/';
+            $host  = isset($spec['host']) ? $spec['host'] : null;
             $error = array_key_exists('error', $spec) ? (bool) $spec['error'] : false;
             $pipe  = $error ? 'pipeErrorHandler' : 'pipe';
 
-            $app->{$pipe}($path, $spec['middleware']);
+            $app->{$pipe}($path, $host, $spec['middleware']);
         }
 
         return $injections;

--- a/test/Container/ApplicationFactoryTest.php
+++ b/test/Container/ApplicationFactoryTest.php
@@ -222,6 +222,8 @@ class ApplicationFactoryTest extends TestCase
                 'pre_routing' => [
                     [ 'middleware' => $middleware ],
                     [ 'path' => '/foo', 'middleware' => $middleware ],
+                    [ 'host' => 'foo.example.com', 'middleware' => $middleware ],
+                    [ 'host' => 'foo.example.com', 'path' => '/foo', 'middleware' => $middleware ],
                 ],
                 'post_routing' => [ ],
             ],
@@ -242,7 +244,7 @@ class ApplicationFactoryTest extends TestCase
         $r->setAccessible(true);
         $pipeline = $r->getValue($app);
 
-        $this->assertCount(5, $pipeline);
+        $this->assertCount(7, $pipeline);
 
         $route = $pipeline->dequeue();
         $this->assertInstanceOf(StratigilityRoute::class, $route);
@@ -253,6 +255,18 @@ class ApplicationFactoryTest extends TestCase
         $this->assertInstanceOf(StratigilityRoute::class, $route);
         $this->assertSame($middleware, $route->handler);
         $this->assertEquals('/foo', $route->path);
+
+        $route = $pipeline->dequeue();
+        $this->assertInstanceOf(StratigilityRoute::class, $route);
+        $this->assertSame($middleware, $route->handler);
+        $this->assertEquals('/', $route->path);
+        $this->assertEquals('foo.example.com', $route->host);
+
+        $route = $pipeline->dequeue();
+        $this->assertInstanceOf(StratigilityRoute::class, $route);
+        $this->assertSame($middleware, $route->handler);
+        $this->assertEquals('/foo', $route->path);
+        $this->assertEquals('foo.example.com', $route->host);
 
         $route = $pipeline->dequeue();
         $this->assertInstanceOf(StratigilityRoute::class, $route);
@@ -293,6 +307,8 @@ class ApplicationFactoryTest extends TestCase
                 'post_routing' => [
                     [ 'middleware' => $middleware ],
                     [ 'path' => '/foo', 'middleware' => $middleware ],
+                    [ 'host' => 'foo.example.com', 'middleware' => $middleware ],
+                    [ 'host' => 'foo.example.com', 'path' => '/foo', 'middleware' => $middleware ],
                 ],
             ],
         ];
@@ -312,7 +328,7 @@ class ApplicationFactoryTest extends TestCase
         $r->setAccessible(true);
         $pipeline = $r->getValue($app);
 
-        $this->assertCount(5, $pipeline);
+        $this->assertCount(7, $pipeline);
 
         $route = $pipeline->dequeue();
         $this->assertInstanceOf(StratigilityRoute::class, $route);
@@ -340,6 +356,18 @@ class ApplicationFactoryTest extends TestCase
         $this->assertInstanceOf(Closure::class, $route->handler);
         $this->assertTrue(call_user_func($route->handler, 'req', 'res'));
         $this->assertEquals('/foo', $route->path);
+
+        $route = $pipeline->dequeue();
+        $this->assertInstanceOf(StratigilityRoute::class, $route);
+        $this->assertSame($middleware, $route->handler);
+        $this->assertEquals('/', $route->path);
+        $this->assertEquals('foo.example.com', $route->host);
+
+        $route = $pipeline->dequeue();
+        $this->assertInstanceOf(StratigilityRoute::class, $route);
+        $this->assertSame($middleware, $route->handler);
+        $this->assertEquals('/foo', $route->path);
+        $this->assertEquals('foo.example.com', $route->host);
     }
 
     /**
@@ -355,6 +383,8 @@ class ApplicationFactoryTest extends TestCase
             'middleware_pipeline' => [
                 [ 'middleware' => 'Middleware' ],
                 [ 'path' => '/foo', 'middleware' => 'Middleware' ],
+                [ 'host' => 'foo.example.com', 'middleware' => 'Middleware' ],
+                [ 'host' => 'foo.example.com', 'path' => '/foo', 'middleware' => 'Middleware' ],
             ],
         ];
 
@@ -367,7 +397,7 @@ class ApplicationFactoryTest extends TestCase
         $r->setAccessible(true);
         $pipeline = $r->getValue($app);
 
-        $this->assertCount(2, $pipeline);
+        $this->assertCount(4, $pipeline);
 
         $route = $pipeline->dequeue();
         $this->assertInstanceOf(StratigilityRoute::class, $route);
@@ -380,6 +410,20 @@ class ApplicationFactoryTest extends TestCase
         $this->assertInstanceOf(Closure::class, $route->handler);
         $this->assertTrue(call_user_func($route->handler, 'req', 'res'));
         $this->assertEquals('/foo', $route->path);
+
+        $route = $pipeline->dequeue();
+        $this->assertInstanceOf(StratigilityRoute::class, $route);
+        $this->assertInstanceOf(Closure::class, $route->handler);
+        $this->assertTrue(call_user_func($route->handler, 'req', 'res'));
+        $this->assertEquals('/', $route->path);
+        $this->assertEquals('foo.example.com', $route->host);
+
+        $route = $pipeline->dequeue();
+        $this->assertInstanceOf(StratigilityRoute::class, $route);
+        $this->assertInstanceOf(Closure::class, $route->handler);
+        $this->assertTrue(call_user_func($route->handler, 'req', 'res'));
+        $this->assertEquals('/foo', $route->path);
+        $this->assertEquals('foo.example.com', $route->host);
     }
 
     /**
@@ -519,6 +563,8 @@ class ApplicationFactoryTest extends TestCase
             'middleware_pipeline' => [
                 [ 'middleware' => 'Middleware' ],
                 [ 'path' => '/foo', 'middleware' => 'Middleware' ],
+                [ 'host' => 'foo.example.com', 'middleware' => 'Middleware' ],
+                [ 'host' => 'foo.example.com', 'path' => '/foo', 'middleware' => 'Middleware' ],
             ],
         ];
 
@@ -533,12 +579,14 @@ class ApplicationFactoryTest extends TestCase
      */
     public function testRaisesExceptionOnInvocationOfUninvokableServiceSpecifiedMiddlewarePulledFromContainer()
     {
-        $middleware = (object) [];
+        $middleware = (object)[];
 
         $config = [
             'middleware_pipeline' => [
-                [ 'middleware' => 'Middleware' ],
-                [ 'path' => '/foo', 'middleware' => 'Middleware' ],
+                ['middleware' => 'Middleware'],
+                ['path' => '/foo', 'middleware' => 'Middleware'],
+                ['host' => 'foo.example.com', 'middleware' => 'Middleware'],
+                ['host' => 'foo.example.com', 'path' => '/foo', 'middleware' => 'Middleware'],
             ],
         ];
 
@@ -551,7 +599,7 @@ class ApplicationFactoryTest extends TestCase
         $r->setAccessible(true);
         $pipeline = $r->getValue($app);
 
-        $this->assertCount(2, $pipeline);
+        $this->assertCount(4, $pipeline);
 
         $first = $pipeline->dequeue();
         $this->assertInstanceOf(StratigilityRoute::class, $first);
@@ -563,7 +611,24 @@ class ApplicationFactoryTest extends TestCase
         $this->assertInstanceOf(Closure::class, $second->handler);
         $this->assertEquals('/foo', $second->path);
 
-        foreach (['first' => $first->handler, 'second' => $second->handler] as $index => $handler) {
+        $third = $pipeline->dequeue();
+        $this->assertInstanceOf(StratigilityRoute::class, $third);
+        $this->assertInstanceOf(Closure::class, $third->handler);
+        $this->assertEquals('/', $third->path);
+        $this->assertEquals('foo.example.com', $third->host);
+
+        $fourth = $pipeline->dequeue();
+        $this->assertInstanceOf(StratigilityRoute::class, $fourth);
+        $this->assertInstanceOf(Closure::class, $fourth->handler);
+        $this->assertEquals('/foo', $fourth->path);
+        $this->assertEquals('foo.example.com', $fourth->host);
+
+        foreach ([
+                     'first' => $first->handler,
+                     'second' => $second->handler,
+                     'third' => $third->handler,
+                     'fourth' => $fourth->handler
+                 ] as $index => $handler) {
             try {
                 $handler('req', 'res');
                 $this->fail(sprintf('%s handler succeed, but should have raised an exception', $index));
@@ -648,6 +713,8 @@ class ApplicationFactoryTest extends TestCase
                 'pre_routing' => [
                     [ 'middleware' => $middleware ],
                     [ 'path' => '/foo', 'middleware' => $middleware ],
+                    [ 'host' => 'foo.example.com', 'middleware' => $middleware ],
+                    [ 'host' => 'foo.example.com', 'path' => '/foo', 'middleware' => $middleware ],
                 ],
                 'post_routing' => [ ],
             ],
@@ -668,7 +735,7 @@ class ApplicationFactoryTest extends TestCase
         $r->setAccessible(true);
         $pipeline = $r->getValue($app);
 
-        $this->assertCount(5, $pipeline);
+        $this->assertCount(7, $pipeline);
 
         $route = $pipeline->dequeue();
         $this->assertInstanceOf(StratigilityRoute::class, $route);
@@ -679,6 +746,18 @@ class ApplicationFactoryTest extends TestCase
         $this->assertInstanceOf(StratigilityRoute::class, $route);
         $this->assertSame($middleware, $route->handler);
         $this->assertEquals('/foo', $route->path);
+
+        $route = $pipeline->dequeue();
+        $this->assertInstanceOf(StratigilityRoute::class, $route);
+        $this->assertSame($middleware, $route->handler);
+        $this->assertEquals('/', $route->path);
+        $this->assertEquals('foo.example.com', $route->host);
+
+        $route = $pipeline->dequeue();
+        $this->assertInstanceOf(StratigilityRoute::class, $route);
+        $this->assertSame($middleware, $route->handler);
+        $this->assertEquals('/foo', $route->path);
+        $this->assertEquals('foo.example.com', $route->host);
 
         $route = $pipeline->dequeue();
         $this->assertInstanceOf(StratigilityRoute::class, $route);
@@ -862,6 +941,8 @@ class ApplicationFactoryTest extends TestCase
         $pipelineFirst = clone $api;
         $hello = clone $api;
         $pipelineLast = clone $api;
+        $hostWithNoPath = clone $api;
+        $hostWithPath = clone $api;
 
         $this->injectServiceInContainer($this->container, 'DynamicPath', $dynamicPath);
         $this->injectServiceInContainer($this->container, 'Goodbye', $goodbye);
@@ -870,6 +951,8 @@ class ApplicationFactoryTest extends TestCase
         $pipeline = [
             [ 'path' => '/api', 'middleware' => $api ],
             [ 'path' => '/dynamic-path', 'middleware' => 'DynamicPath' ],
+            [ 'host' => 'foo.example.com', 'middleware' => $hostWithNoPath ],
+            [ 'host' => 'foo.example.com', 'path' => '/foo', 'middleware' => $hostWithPath ],
             ['middleware' => $noPath],
             ['middleware' => 'Goodbye'],
             ['middleware' => [
@@ -902,25 +985,39 @@ class ApplicationFactoryTest extends TestCase
         $r->setAccessible(true);
         $pipeline = $r->getValue($app);
 
-        $this->assertCount(5, $pipeline, 'Did not get expected pipeline count!');
+        $this->assertCount(7, $pipeline, 'Did not get expected pipeline count!');
 
         $test = $pipeline->dequeue();
         $this->assertEquals('/api', $test->path);
+        $this->assertEquals(null, $test->host);
         $this->assertSame($api, $test->handler);
 
         // Lazy middleware is not marshaled until invocation
         $test = $pipeline->dequeue();
         $this->assertEquals('/dynamic-path', $test->path);
+        $this->assertEquals(null, $test->host);
         $this->assertNotSame($dynamicPath, $test->handler);
         $this->assertInstanceOf(Closure::class, $test->handler);
 
         $test = $pipeline->dequeue();
         $this->assertEquals('/', $test->path);
+        $this->assertEquals('foo.example.com', $test->host);
+        $this->assertSame($hostWithNoPath, $test->handler);
+
+        $test = $pipeline->dequeue();
+        $this->assertEquals('/foo', $test->path);
+        $this->assertEquals('foo.example.com', $test->host);
+        $this->assertSame($hostWithPath, $test->handler);
+
+        $test = $pipeline->dequeue();
+        $this->assertEquals('/', $test->path);
+        $this->assertEquals(null, $test->host);
         $this->assertSame($noPath, $test->handler);
 
         // Lazy middleware is not marshaled until invocation
         $test = $pipeline->dequeue();
         $this->assertEquals('/', $test->path);
+        $this->assertEquals(null, $test->host);
         $this->assertNotSame($goodbye, $test->handler);
         $this->assertInstanceOf(Closure::class, $test->handler);
 


### PR DESCRIPTION
This PR adds segregating middlewares by host in Application's middleware pipe, implements https://github.com/zendframework/zend-expressive/issues/235

``` php
// in middleware-pipeline.global.php

'api' => [
    'path' => '/',
    'host' => 'api.example.com',
    'middleware' => [
        ...
    ],
],
```

Disclaimer: it depends on my PR for Stratigility https://github.com/zendframework/zend-stratigility/pull/62
Feedback would be very welcome.
