### PR TITLE
Intercept exceptions from the ServerRequest factory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "zendframework/zend-expressive-aurarouter": "^1.0",
         "zendframework/zend-expressive-fastroute": "^1.0",
         "zendframework/zend-expressive-zendrouter": "^1.0",
-        "zendframework/zend-servicemanager": "^2.6"
+        "zendframework/zend-servicemanager": "^2.6",
+        "mockery/mockery": "^0.9.5"
     },
     "autoload": {
       "psr-4": {

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -12,17 +12,21 @@ namespace ZendTest\Expressive;
 use BadMethodCallException;
 use DomainException;
 use Interop\Container\ContainerInterface;
+use InvalidArgumentException;
+use Mockery;
 use PHPUnit_Framework_TestCase as TestCase;
 use Prophecy\Argument;
 use Psr\Http\Message\ResponseInterface;
 use ReflectionProperty;
 use RuntimeException;
 use SplQueue;
+use UnexpectedValueException;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\Response\EmitterInterface;
 use Zend\Diactoros\Response\SapiEmitter;
 use Zend\Diactoros\ServerRequest as Request;
 use Zend\Diactoros\ServerRequest;
+use Zend\Diactoros\ServerRequestFactory;
 use Zend\Expressive\Application;
 use Zend\Expressive\Emitter\EmitterStack;
 use Zend\Expressive\Exception;
@@ -621,5 +625,65 @@ class ApplicationTest extends TestCase
 
         $this->setExpectedException(InvalidMiddlewareException::class);
         $handler('foo', 'bar', 'baz', 'bat');
+    }
+
+    public function invalidRequestExceptions()
+    {
+        return [
+            'invalid file'             => [
+                InvalidArgumentException::class,
+                'Invalid value in files specification',
+            ],
+            'invalid protocol version' => [
+                UnexpectedValueException::class,
+                'Unrecognized protocol version (foo-bar)',
+            ],
+        ];
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     * @dataProvider invalidRequestExceptions
+     */
+    public function testRunInvokesFinalHandlerWhenServerRequestFactoryRaisesException(
+        $expectedException,
+        $message
+    ) {
+        // try/catch is necessary in the case that the test fails.
+        // Assertion exceptions raised inside prophecy expectations normally
+        // are fine, but in the context of runInSeparateProcess, these
+        // lead to closure serialization errors. try/catch allows us to
+        // catch those and provide failure assertions.
+        try {
+            $requestFactory = Mockery::mock('alias:' . ServerRequestFactory::class)
+                ->shouldReceive('fromGlobals')
+                ->withNoArgs()
+                ->andThrow($expectedException, $message)
+                ->once()
+                ->getMock();
+
+            $finalHandler = function ($request, $response, $err = null) use ($expectedException, $message) {
+                $this->assertEquals(400, $response->getStatusCode());
+                $this->assertInstanceOf($expectedException, $err);
+                $this->assertEquals($message, $err->getMessage());
+                return $response;
+            };
+
+            $emitter = $this->prophesize(EmitterInterface::class);
+            $emitter->emit(Argument::that(function ($response) {
+                $this->assertInstanceOf(ResponseInterface::class, $response, 'Emitter did not receive a response');
+                $this->assertEquals(400, $response->getStatusCode());
+                return true;
+            }))->shouldBeCalled();
+
+            $app = new Application($this->router->reveal(), null, $finalHandler, $emitter->reveal());
+
+            $app->run();
+        } catch (\Throwable $e) {
+            $this->fail($e->getMessage());
+        } catch (\Exception $e) {
+            $this->fail($e->getMessage());
+        }
     }
 }


### PR DESCRIPTION
As noted in zendframework/zend-diactoros#171, the `ServerRequestFactory::fromGlobals()` method raises exceptions on malformed information, such as:

- malformed file upload data
- invalid HTTP protocol versions

At the application level, we should catch these, and invoke the final handler with a 400 response when caught.

I've opened this against master, as I consider the current behavior a "bug"; however, in a way, it's technically a new feature. I'd appreciate comments as to the preferred release. :smile: