### PR TITLE
Correct the documentation for configuring a container-driven container

### DIFF
--- a/doc/book/reference/usage-examples.md
+++ b/doc/book/reference/usage-examples.md
@@ -317,11 +317,13 @@ In `config/autoload/dependencies.global.php`, place the following:
 ```php
 <?php
 
+use Zend\ServiceManager\Factory\InvokableFactory;
+
 return [
     'dependencies' => [
         'invokables' => [
-            \Application\HelloWorldAction::class => \Application\HelloWorldAction::class,
-            \Application\PingAction::class => \Application\PingAction::class,
+            \Application\HelloWorldAction::class => InvokableFactory::class,
+            \Application\PingAction::class => InvokableFactory::class,
         ],
         'factories' => [
             \Zend\Expressive\Application::class => \Zend\Expressive\Container\ApplicationFactory::class,
@@ -355,7 +357,7 @@ In `src/Application/HelloWorld.php`, place the following:
 
 ```php
 <?php
-namespace App;
+namespace Application;
 
 class HelloWorld
 {
@@ -371,7 +373,7 @@ In `src/Application/Ping.php`, place the following:
 
 ```php
 <?php
-namespace App;
+namespace Application;
 
 use Zend\Diactoros\Response\JsonResponse;
 
@@ -384,7 +386,13 @@ class Ping
 }
 ```
 
-After that’s done run `composer dump-autoload` from the command-line, in the root directory of your project. Finally, in `public/index.php`, place the following:
+After that’s done run:
+
+```
+composer dump-autoload
+```
+
+Finally, in `public/index.php`, place the following:
 
 ```php
 <?php


### PR DESCRIPTION
I'm not sure if the documentation was correct previously, but whenever
I've tried to follow it, to the letter, it's resulted in segmentation
faults and the routes never being loaded. Given that, after some further
research, I believe that the previous recommendation was never going to
work. So, I've migrated some of the configuration from a setup using the
skeleton installer and updated the docs to reflect that.

I don't mean what I've said in any kind of mean or uncharitable way. 
Perhaps the configuration worked up until a particular revision, but was
not updated to reflect subsequent changes. Or, perhaps the fault lies with
me, and I wasn't as thorough as I thought I was. Either way, I offer this for 
consideration and review.