### PR TITLE
Add support for Whoops 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "zendframework/zend-stratigility": "^1.1"
     },
     "require-dev": {
-        "filp/whoops": "^1.1",
+        "filp/whoops": "^2.0",
         "phpunit/phpunit": "^4.7",
         "squizlabs/php_codesniffer": "^2.3",
         "zendframework/zend-expressive-aurarouter": "^1.0",
@@ -44,7 +44,7 @@
       }
     },
     "suggest": {
-        "filp/whoops": "^1.1 to use the Whoops error handler",
+        "filp/whoops": "^2.0 to use the Whoops error handler",
         "zendframework/zend-expressive-helpers": "^1.0 for its UrlHelper, ServerUrlHelper, and BodyParseMiddleware",
         "zendframework/zend-expressive-aurarouter": "^1.0 to use the Aura.Router routing adapter",
         "zendframework/zend-expressive-fastroute": "^1.0 to use the FastRoute routing adapter",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "zendframework/zend-stratigility": "^1.1"
     },
     "require-dev": {
-        "filp/whoops": "^2.0",
+        "filp/whoops": "^1.1 || ^2.0",
         "phpunit/phpunit": "^4.7",
         "squizlabs/php_codesniffer": "^2.3",
         "zendframework/zend-expressive-aurarouter": "^1.0",

--- a/src/Container/WhoopsErrorHandlerFactory.php
+++ b/src/Container/WhoopsErrorHandlerFactory.php
@@ -10,7 +10,9 @@
 namespace Zend\Expressive\Container;
 
 use Interop\Container\ContainerInterface;
+use Whoops\Handler\JsonResponseHandler;
 use Zend\Expressive\WhoopsErrorHandler;
+use Whoops\Run as Whoops;
 
 /**
  * Create and return an instance of the whoops error handler.
@@ -45,6 +47,20 @@ use Zend\Expressive\WhoopsErrorHandler;
  * </code>
  *
  * If any of the keys are missing, default values will be used.
+ *
+ * The whoops configuration can contain:
+ *
+ * <code>
+ * 'whoops' => [
+ *     'json_exceptions' => [
+ *         'display'    => true,
+ *         'show_trace' => true,
+ *         'ajax_only'  => true,
+ *     ]
+ * ]
+ * </code>
+ *
+ * All values are booleans; omission of any implies boolean false.
  */
 class WhoopsErrorHandlerFactory
 {
@@ -58,16 +74,59 @@ class WhoopsErrorHandlerFactory
             ? $container->get('config')
             : [];
 
-        $config = isset($config['zend-expressive']['error_handler'])
+        $expressiveConfig = isset($config['zend-expressive']['error_handler'])
             ? $config['zend-expressive']['error_handler']
             : [];
 
+        $whoopsConfig = isset($config['whoops'])
+            ? $config['whoops']
+            : [];
+
+        $whoops = $container->get('Zend\Expressive\Whoops');
+        $whoops->pushHandler($container->get('Zend\Expressive\WhoopsPageHandler'));
+        $this->registerJsonHandler($whoops, $whoopsConfig);
+
         return new WhoopsErrorHandler(
-            $container->get('Zend\Expressive\Whoops'),
-            $container->get('Zend\Expressive\WhoopsPageHandler'),
+            $whoops,
+            null,
             $template,
-            (isset($config['template_404']) ? $config['template_404'] : 'error/404'),
-            (isset($config['template_error']) ? $config['template_error'] : 'error/error')
+            (isset($expressiveConfig['template_404']) ? $expressiveConfig['template_404'] : 'error/404'),
+            (isset($expressiveConfig['template_error']) ? $expressiveConfig['template_error'] : 'error/error')
         );
+    }
+
+    /**
+     * If configuration indicates a JsonResponseHandler, configure and register it.
+     *
+     * @param Whoops $whoops
+     * @param array|\ArrayAccess $config
+     */
+    private function registerJsonHandler(Whoops $whoops, $config)
+    {
+        if (! isset($config['json_exceptions']['display'])
+            || empty($config['json_exceptions']['display'])
+        ) {
+            return;
+        }
+
+        $handler = new JsonResponseHandler();
+
+        if (isset($config['json_exceptions']['ajax_only'])) {
+            if (method_exists(\Whoops\Util\Misc::class, 'isAjaxRequest')) {
+                // Whoops 2.x
+                if (! \Whoops\Util\Misc::isAjaxRequest()) {
+                    return;
+                }
+            } elseif (method_exists($handler, 'onlyForAjaxRequests')) {
+                // Whoops 1.x
+                $handler->onlyForAjaxRequests(true);
+            }
+        }
+
+        if (isset($config['json_exceptions']['show_trace'])) {
+            $handler->addTraceToOutput(true);
+        }
+
+        $whoops->pushHandler($handler);
     }
 }

--- a/src/Container/WhoopsFactory.php
+++ b/src/Container/WhoopsFactory.php
@@ -82,7 +82,15 @@ class WhoopsFactory
         }
 
         if (isset($config['json_exceptions']['ajax_only'])) {
-            $handler->onlyForAjaxRequests(true);
+            if (method_exists(\Whoops\Util\Misc::class, 'isAjaxRequest')) {
+                // Whoops 2.x
+                if (! \Whoops\Util\Misc::isAjaxRequest()) {
+                    return;
+                }
+            } elseif (method_exists($handler, 'onlyForAjaxRequests')) {
+                // Whoops 1.x
+                $handler->onlyForAjaxRequests(true);
+            }
         }
 
         $whoops->pushHandler($handler);

--- a/src/WhoopsErrorHandler.php
+++ b/src/WhoopsErrorHandler.php
@@ -77,7 +77,7 @@ class WhoopsErrorHandler extends TemplatedErrorHandler
     protected function handleException($exception, Request $request, Response $response)
     {
         // Push the whoops handler if any
-        if (null !== $this->whoopsHandler) {
+        if ($this->whoopsHandler !== null) {
             $this->whoops->pushHandler($this->whoopsHandler);
         }
 

--- a/test/Container/WhoopsErrorHandlerFactoryTest.php
+++ b/test/Container/WhoopsErrorHandlerFactoryTest.php
@@ -30,13 +30,13 @@ class WhoopsErrorHandlerFactoryTest extends TestCase
 
     public function setUp()
     {
-        $whoops      = $this->prophesize(Whoops::class);
-        $pageHandler = $this->prophesize(PrettyPageHandler::class);
+        $whoops          = new Whoops();
+        $pageHandler     = $this->prophesize(PrettyPageHandler::class);
         $this->container = $this->mockContainerInterface();
         $this->injectServiceInContainer($this->container, 'Zend\Expressive\WhoopsPageHandler', $pageHandler->reveal());
-        $this->injectServiceInContainer($this->container, 'Zend\Expressive\Whoops', $whoops->reveal());
+        $this->injectServiceInContainer($this->container, 'Zend\Expressive\Whoops', $whoops);
 
-        $this->factory   = new WhoopsErrorHandlerFactory();
+        $this->factory = new WhoopsErrorHandlerFactory();
     }
 
     public function testReturnsAWhoopsErrorHandler()
@@ -59,10 +59,14 @@ class WhoopsErrorHandlerFactoryTest extends TestCase
 
     public function testWillInjectTemplateNamesFromConfigurationWhenPresent()
     {
-        $config = ['zend-expressive' => ['error_handler' => [
-            'template_404'   => 'error::404',
-            'template_error' => 'error::500',
-        ]]];
+        $config = [
+            'zend-expressive' => [
+                'error_handler' => [
+                    'template_404'   => 'error::404',
+                    'template_error' => 'error::500',
+                ],
+            ],
+        ];
         $this->injectServiceInContainer($this->container, 'config', $config);
 
         $factory = $this->factory;

--- a/test/Container/WhoopsFactoryTest.php
+++ b/test/Container/WhoopsFactoryTest.php
@@ -11,7 +11,6 @@ namespace ZendTest\Expressive\Container;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
-use ReflectionFunction;
 use ReflectionProperty;
 use Whoops\Handler\JsonResponseHandler;
 use Whoops\Handler\PrettyPageHandler;
@@ -31,17 +30,17 @@ class WhoopsFactoryTest extends TestCase
 
     public function setUp()
     {
-        $pageHandler = $this->prophesize(PrettyPageHandler::class);
+        $pageHandler     = $this->prophesize(PrettyPageHandler::class);
         $this->container = $this->mockContainerInterface();
         $this->injectServiceInContainer($this->container, 'Zend\Expressive\WhoopsPageHandler', $pageHandler->reveal());
 
-        $this->factory   = new WhoopsFactory();
+        $this->factory = new WhoopsFactory();
     }
 
     public function assertWhoopsContainsHandler($type, Whoops $whoops, $message = null)
     {
         $message = $message ?: sprintf("Failed to assert whoops runtime composed handler of type %s", $type);
-        $r = new ReflectionProperty($whoops, 'handlerStack');
+        $r       = new ReflectionProperty($whoops, 'handlerStack');
         $r->setAccessible(true);
         $stack = $r->getValue($whoops);
 
@@ -81,11 +80,18 @@ class WhoopsFactoryTest extends TestCase
      */
     public function testJsonResponseHandlerCanBeConfigured()
     {
-        $config = ['whoops' => ['json_exceptions' => [
-            'display'    => true,
-            'show_trace' => true,
-            'ajax_only'  => true,
-        ]]];
+        // Set for Whoops 2.x json handler detection
+        $_SERVER['HTTP_X_REQUESTED_WITH'] = 'xmlhttprequest';
+
+        $config = [
+            'whoops' => [
+                'json_exceptions' => [
+                    'display'    => true,
+                    'show_trace' => true,
+                    'ajax_only'  => true,
+                ],
+            ],
+        ];
         $this->injectServiceInContainer($this->container, 'config', $config);
 
         $factory = $this->factory;
@@ -94,6 +100,9 @@ class WhoopsFactoryTest extends TestCase
         $jsonHandler = $whoops->popHandler();
         $this->assertInstanceOf(JsonResponseHandler::class, $jsonHandler);
         $this->assertAttributeSame(true, 'returnFrames', $jsonHandler);
-        $this->assertAttributeSame(true, 'onlyForAjaxRequests', $jsonHandler);
+
+        if (method_exists($jsonHandler, 'onlyForAjaxRequests')) {
+            $this->assertAttributeSame(true, 'onlyForAjaxRequests', $jsonHandler);
+        }
     }
 }

--- a/test/Container/WhoopsPageHandlerFactoryTest.php
+++ b/test/Container/WhoopsPageHandlerFactoryTest.php
@@ -11,8 +11,6 @@ namespace ZendTest\Expressive\Container;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
-use ReflectionFunction;
-use ReflectionProperty;
 use Whoops\Handler\PrettyPageHandler;
 use Zend\Expressive\Container\Exception\InvalidServiceException;
 use Zend\Expressive\Container\WhoopsPageHandlerFactory;
@@ -48,15 +46,19 @@ class WhoopsPageHandlerFactoryTest extends TestCase
         $this->injectServiceInContainer($this->container, 'config', $config);
 
         $factory = $this->factory;
-        $result = $factory($this->container->reveal());
+        $result  = $factory($this->container->reveal());
         $this->assertInstanceOf(PrettyPageHandler::class, $result);
         $this->assertAttributeEquals($config['whoops']['editor'], 'editor', $result);
     }
 
     public function testWillInjectCallableEditor()
     {
-        $config = ['whoops' => ['editor' => function () {
-        }]];
+        $config = [
+            'whoops' => [
+                'editor' => function () {
+                },
+            ],
+        ];
         $this->injectServiceInContainer($this->container, 'config', $config);
         $factory = $this->factory;
 
@@ -74,7 +76,7 @@ class WhoopsPageHandlerFactoryTest extends TestCase
         $this->injectServiceInContainer($this->container, 'custom', $editor);
 
         $factory = $this->factory;
-        $result = $factory($this->container->reveal());
+        $result  = $factory($this->container->reveal());
         $this->assertInstanceOf(PrettyPageHandler::class, $result);
         $this->assertAttributeSame($editor, 'editor', $result);
     }


### PR DESCRIPTION
This PR adds support for Whoops 2.0 as discussed in zendframework/zend-expressive-skeleton#115 and #383.

Falling back to 1.1 is no option since it doesn't support PHP 7.

It's not optimal but it adds support fro 2.0 while maintaining BC.
- [x] Add whoops 2.0 support
- [x] Suggest whoops 2.0
- [x] Fix whoops tests
