### PR TITLE
Reference zend-router instead of ZF2 MVC in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ features:
 - Routing. Choose your own router; we support:
     - [Aura.Router](https://github.com/auraphp/Aura.Router)
     - [FastRoute](https://github.com/nikic/FastRoute)
-    - [ZF2's MVC router](https://github.com/zendframework/zend-mvc)
+    - [zend-router](https://github.com/zendframework/zend-expressive-router)
 - DI Containers, via [container-interop](https://github.com/container-interop/container-interop).
   Middleware matched via routing is retrieved from the composed container.
 - Optionally, templating. We support:
@@ -63,7 +63,7 @@ We currently support and provide the following routing integrations:
   `composer require zendframework/zend-expressive-aurarouter`
 - [FastRoute](https://github.com/nikic/FastRoute):
   `composer require zendframework/zend-expressive-fastroute`
-- [ZF2 MVC Router](https://github.com/zendframework/zend-mvc):
+- [zend-router](https://github.com/zendframework/zend-expressive-router):
   `composer require zendframework/zend-expressive-zendrouter`
 
 We recommend using a dependency injection container, and typehint against

--- a/doc/book/getting-started/standalone.md
+++ b/doc/book/getting-started/standalone.md
@@ -26,7 +26,7 @@ $ composer require zendframework/zend-expressive zendframework/zend-expressive-f
 >
 > Expressive needs a routing implementation in order to create routed
 > middleware. We suggest FastRoute in the quick start, but you can also
-> currently choose from Aura.Router and the ZF2 MVC router.
+> currently choose from Aura.Router and zend-router.
 
 > ### Containers
 >

--- a/doc/book/index.md
+++ b/doc/book/index.md
@@ -7,7 +7,7 @@ framework for PHP, with the following features:
 - Routing. Choose your own router; we support:
     - [Aura.Router](https://github.com/auraphp/Aura.Router)
     - [FastRoute](https://github.com/nikic/FastRoute)
-    - [ZF2's MVC router](https://github.com/zendframework/zend-mvc)
+    - [zend-router](https://github.com/zendframework/zend-expressive-router)
 - DI Containers, via [container-interop](https://github.com/container-interop/container-interop).
   All middleware composed in Expressive may be retrieved from the composed
   container.


### PR DESCRIPTION
Updating per [zend-expressive-router@#14](https://github.com/zendframework/zend-expressive-router/pull/14)