### PR TITLE
Ensure `Application::__invoke()` does not trigger deprecations

### DIFF
--- a/test/IntegrationTest.php
+++ b/test/IntegrationTest.php
@@ -50,9 +50,7 @@ class IntegrationTest extends TestCase
         $response = new Response();
 
         set_error_handler(function ($errno, $errstr) {
-            return (false !== strstr($errstr, 'OriginalMessages')
-                || false !== strstr($errstr, '$out')
-            );
+            return false !== strstr($errstr, 'OriginalMessages');
         }, E_USER_DEPRECATED);
 
         $app->run($request, $response);


### PR DESCRIPTION
Stratigility 1.3 deprecates having an optional `$out` argument to `__invoke()`. However, `Application::run()` was calling without the argument, to allow lazy-creation of a final handler if none was injected at instantiation.

In order to mimic the behavior of `MiddlewarePipe`, this meant testing:

- For a null `$out` argument
- A null return value from `getFinalHandler()`
- Decorating a PSR response with a Stratigility response
- Seeding a Stratigility `FinalHandler` with the decorated response

I removed a condition from an error handler that was checking for deprecations in order to ensure that deprecation notices *were* being emitted previously, and after changes, were not. Interestingly, these were not triggering failures for me locally; I was only seeing the deprecation notices within the PHPUnit progress output. As such, verification of this patch will involve checking the Travis logs.