### PR TITLE
Eliminate deprecation notices due to request/response decorator usage

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -558,8 +558,9 @@ class Application extends MiddlewarePipe implements Router\RouteResultSubjectInt
      */
     public function run(ServerRequestInterface $request = null, ResponseInterface $response = null)
     {
-        $request  = $request ?: ServerRequestFactory::fromGlobals();
         $response = $response ?: new Response();
+        $request  = $request ?: ServerRequestFactory::fromGlobals();
+        $request  = $request->withAttribute('originalResponse', $response);
 
         $response = $this($request, $response);
 

--- a/src/TemplatedErrorHandler.php
+++ b/src/TemplatedErrorHandler.php
@@ -191,9 +191,7 @@ class TemplatedErrorHandler
         }
 
         $originalResponse  = $this->originalResponse;
-        $decoratedResponse = $response instanceof StratigilityResponse
-            ? $response->getOriginalResponse()
-            : $response;
+        $decoratedResponse = $request->getAttribute('originalResponse', $response);
 
         if ($originalResponse !== $response
             && $originalResponse !== $decoratedResponse

--- a/src/TemplatedErrorHandler.php
+++ b/src/TemplatedErrorHandler.php
@@ -9,7 +9,6 @@ namespace Zend\Expressive;
 
 use Psr\Http\Message\RequestInterface as Request;
 use Psr\Http\Message\ResponseInterface as Response;
-use Zend\Stratigility\Http\Response as StratigilityResponse;
 use Zend\Stratigility\Utils;
 
 /**

--- a/src/WhoopsErrorHandler.php
+++ b/src/WhoopsErrorHandler.php
@@ -11,7 +11,6 @@ use Psr\Http\Message\RequestInterface as Request;
 use Psr\Http\Message\ResponseInterface as Response;
 use Whoops\Handler\PrettyPageHandler;
 use Whoops\Run as Whoops;
-use Zend\Stratigility\Http\Request as StratigilityRequest;
 
 /**
  * Final handler with templated page capabilities plus Whoops exception reporting.

--- a/src/WhoopsErrorHandler.php
+++ b/src/WhoopsErrorHandler.php
@@ -102,11 +102,9 @@ class WhoopsErrorHandler extends TemplatedErrorHandler
      */
     private function prepareWhoopsHandler(Request $request, PrettyPageHandler $handler)
     {
-        if ($request instanceof StratigilityRequest) {
-            $request = $request->getOriginalRequest();
-        }
+        $uri = $request->getAttribute('originalUri', false) ?: $request->getUri();
+        $request = $request->getAttribute('originalRequest', false) ?: $request;
 
-        $uri = $request->getUri();
         $handler->addDataTable('Expressive Application Request', [
             'HTTP Method'            => $request->getMethod(),
             'URI'                    => (string) $uri,

--- a/test/IntegrationTest.php
+++ b/test/IntegrationTest.php
@@ -49,13 +49,7 @@ class IntegrationTest extends TestCase
         $request  = new ServerRequest([], [], 'https://example.com/foo', 'GET');
         $response = new Response();
 
-        set_error_handler(function ($errno, $errstr) {
-            return false !== strstr($errstr, 'OriginalMessages');
-        }, E_USER_DEPRECATED);
-
         $app->run($request, $response);
-
-        restore_error_handler();
 
         $this->assertInstanceOf(ResponseInterface::class, $this->response);
         $this->assertEquals(404, $this->response->getStatusCode());
@@ -68,13 +62,7 @@ class IntegrationTest extends TestCase
         $request      = new ServerRequest([], [], 'https://example.com/foo', 'GET');
         $response     = new Response();
 
-        set_error_handler(function ($errno, $errstr) {
-            return false !== strstr($errstr, 'OriginalMessages');
-        }, E_USER_DEPRECATED);
-
         $app->run($request, $response);
-
-        restore_error_handler();
 
         $this->assertInstanceOf(ResponseInterface::class, $this->response);
         $this->assertEquals(404, $this->response->getStatusCode());

--- a/test/TemplatedErrorHandlerTest.php
+++ b/test/TemplatedErrorHandlerTest.php
@@ -12,7 +12,7 @@ namespace ZendTest\Expressive;
 use Exception;
 use PHPUnit_Framework_TestCase as TestCase;
 use Prophecy\Argument;
-use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 use Zend\Expressive\Template\TemplateRendererInterface;
@@ -30,7 +30,7 @@ class TemplatedErrorHandlerTest extends TestCase
 
     public function getRequest($stream)
     {
-        $request = $this->prophesize(RequestInterface::class);
+        $request = $this->prophesize(ServerRequestInterface::class);
         $request->getBody()->will(function () use ($stream) {
             return $stream->reveal();
         });
@@ -130,6 +130,9 @@ class TemplatedErrorHandlerTest extends TestCase
         $handler->setOriginalResponse($response->reveal());
 
         $request = $this->getRequest($this->getStream());
+        $request
+            ->getAttribute('originalResponse', Argument::that([$response, 'reveal']))
+            ->will([$response, 'reveal']);
 
         $result = $handler($request->reveal(), $response->reveal());
         $this->assertSame($expected->reveal(), $result);
@@ -151,6 +154,9 @@ class TemplatedErrorHandlerTest extends TestCase
         $handler->setOriginalResponse($response->reveal());
 
         $request = $this->getRequest($this->getStream());
+        $request
+            ->getAttribute('originalResponse', Argument::that([$response, 'reveal']))
+            ->will([$response, 'reveal']);
 
         $result = $handler($request->reveal(), $response->reveal());
         $this->assertSame($response->reveal(), $result);
@@ -167,6 +173,9 @@ class TemplatedErrorHandlerTest extends TestCase
 
         $response = $this->getResponse($this->getStream());
         $request  = $this->getRequest($this->getStream());
+        $request
+            ->getAttribute('originalResponse', Argument::that([$response, 'reveal']))
+            ->will([$response, 'reveal']);
 
         $result = $handler($request->reveal(), $response->reveal());
         $this->assertSame($response->reveal(), $result);
@@ -243,6 +252,9 @@ class TemplatedErrorHandlerTest extends TestCase
 
         $request = $this->getRequest($this->getStream());
         $request->getUri()->shouldBeCalled();
+        $request
+            ->getAttribute('originalResponse', Argument::that([$response, 'reveal']))
+            ->will([$response, 'reveal']);
 
         $result = $handler($request->reveal(), $response->reveal());
         $this->assertSame($expected->reveal(), $result);

--- a/test/WhoopsErrorHandlerTest.php
+++ b/test/WhoopsErrorHandlerTest.php
@@ -82,6 +82,8 @@ class WhoopsErrorHandlerTest extends TestCase
         $request->getAttributes()->shouldBeCalled();
         $request->getQueryParams()->shouldBeCalled();
         $request->getParsedBody()->shouldBeCalled();
+        $request->getAttribute('originalUri', false)->willReturn(false);
+        $request->getAttribute('originalRequest', false)->willReturn(false);
 
         $result = $handler($request->reveal(), $response->reveal(), $exception);
         $this->assertSame($expected->reveal(), $result);
@@ -119,7 +121,8 @@ class WhoopsErrorHandlerTest extends TestCase
 
         $request           = new ServerRequest(['SCRIPT_NAME' => __FILE__]);
         $decoratingRequest = $this->prophesize(StratigilityRequest::class);
-        $decoratingRequest->getOriginalRequest()->willReturn($request);
+        $decoratingRequest->getAttribute('originalRequest', false)->willReturn($request);
+        $decoratingRequest->getAttribute('originalUri', false)->willReturn($request->getUri());
 
         $result = $handler($decoratingRequest->reveal(), $response->reveal(), $exception);
         $this->assertSame($expected->reveal(), $result);


### PR DESCRIPTION
This patch does the following:

- Updates the `TemplatedErrorHandler` and `WhoopsErrorHandler` to no longer use Stratigility request/response decorator-specific methods. Instead, they now pull values via the `original*` request attributes, using default values.
- Updates the `Application::run()` method to set the `originalResponse` request attribute; this allows the above changes to be used with Stratigility versions prior to 1.3 (which is the first release in which that attribute was introduced).
- Updates the integration test to remove error handling for deprecation notices based on usage of Stratigility request/response decorators, as they are no longer invoked.

Other than the error handling deprecations, this now allows Expressive to run without deprecation notices.