### PR TITLE
Prevent deprecation notice based on triggering error middleware

### DIFF
--- a/test/Container/ApplicationFactoryIntegrationTest.php
+++ b/test/Container/ApplicationFactoryIntegrationTest.php
@@ -128,13 +128,7 @@ class ApplicationFactoryIntegrationTest extends TestCase
         $request = new ServerRequest([], [], 'http://example.com/needs/authentication', 'GET');
         $response = new Response();
 
-        set_error_handler(function ($errno, $errstr) {
-            return false !== strstr($errstr, 'error middleware is deprecated');
-        }, E_USER_DEPRECATED);
-
         $response = $app($request, $response);
-
-        restore_error_handler();
 
         $this->assertInstanceOf(ResponseInterface::class, $response);
         $this->assertEquals(401, $response->getStatusCode(), 'Unexpected response');
@@ -222,13 +216,7 @@ class ApplicationFactoryIntegrationTest extends TestCase
         $request = new ServerRequest([], [], 'http://example.com/needs/authentication', 'GET');
         $response = new Response();
 
-        set_error_handler(function ($errno, $errstr) {
-            return false !== strstr($errstr, 'error middleware is deprecated');
-        }, E_USER_DEPRECATED);
-
         $response = $app($request, $response);
-
-        restore_error_handler();
 
         $this->assertInstanceOf(ResponseInterface::class, $response);
         $this->assertEquals(401, $response->getStatusCode(), 'Unexpected response');


### PR DESCRIPTION
Users cannot yet set the raiseThrowables flag, as there are not shipped facilities for handling errors using templates or whoops. As such, currently, if the queue is exhausted or an exception is thrown, error middleware is triggered. This patch adds an error handler to `Application::__invoke()` to swallow deprecation notices due to invocation of error middleware.