### PR TITLE
HEAD and OPTIONS requests

### DIFF
--- a/test/RouteMiddlewareTest.php
+++ b/test/RouteMiddlewareTest.php
@@ -522,6 +522,126 @@ class RouteMiddlewareTest extends TestCase
         $this->assertEquals('Middleware', (string) $result->getBody());
     }
 
+    public function allowedMethod()
+    {
+        return [
+            'aura-head'          => [AuraRouter::class, 'HEAD'],
+            'aura-options'       => [AuraRouter::class, 'OPTIONS'],
+            'fast-route-head'    => [FastRouteRouter::class, 'HEAD'],
+            'fast-route-options' => [FastRouteRouter::class, 'OPTIONS'],
+            'fast-route-get'     => [FastRouteRouter::class, 'GET'],
+            'zf2-head'           => [ZendRouter::class, 'HEAD'],
+            'zf2-options'        => [ZendRouter::class, 'OPTIONS'],
+        ];
+    }
+
+    public function notAllowedMethod()
+    {
+        return [
+            'aura-get'          => [AuraRouter::class, 'GET'],
+            'aura-post'         => [AuraRouter::class, 'POST'],
+            'aura-put'          => [AuraRouter::class, 'PUT'],
+            'aura-delete'       => [AuraRouter::class, 'DELETE'],
+            'aura-patch'        => [AuraRouter::class, 'PATCH'],
+            'fast-route-post'   => [FastRouteRouter::class, 'POST'],
+            'fast-route-put'    => [FastRouteRouter::class, 'PUT'],
+            'fast-route-delete' => [FastRouteRouter::class, 'DELETE'],
+            'fast-route-patch'  => [FastRouteRouter::class, 'PATCH'],
+            'zf2-get'           => [ZendRouter::class, 'GET'],
+            'zf2-post'          => [ZendRouter::class, 'POST'],
+            'zf2-put'           => [ZendRouter::class, 'PUT'],
+            'zf2-delete'        => [ZendRouter::class, 'DELETE'],
+            'zf2-patch'         => [ZendRouter::class, 'PATCH'],
+        ];
+    }
+
+    /**
+     * @dataProvider allowedMethod
+     *
+     * @param string $adapter
+     * @param string $method
+     */
+    public function testAllowedMethodsWhenOnlyPutMethodSet($adapter, $method)
+    {
+        $app = new Application(new $adapter);
+
+        // Add a PUT route
+        $app->put('/foo', function ($req, $res, $next) {
+            $res->getBody()->write('Middleware');
+            return $res;
+        });
+
+        $next = function ($req, $res) {
+            return $res;
+        };
+
+        $request  = new ServerRequest(['REQUEST_METHOD' => $method], [], '/foo', $method);
+        $response = new Response();
+        $result   = $app->routeMiddleware($request, $response, function ($request, $response) use ($app, $next) {
+            return $app->dispatchMiddleware($request, $response, $next);
+        });
+        $this->assertEquals(200, $result->getStatusCode());
+        $this->assertEquals('Middleware', (string) $result->getBody());
+    }
+
+    /**
+     * @dataProvider allowedMethod
+     *
+     * @param string $adapter
+     * @param string $method
+     */
+    public function testAllowedMethodsWhenNoHttpMethodsSet($adapter, $method)
+    {
+        $app = new Application(new $adapter);
+
+        // Add a route with empty array - NO HTTP methods
+        $app->route('/foo', function ($req, $res, $next) {
+            $res->getBody()->write('Middleware');
+            return $res;
+        }, []);
+
+        $next = function ($req, $res) {
+            return $res;
+        };
+
+        $request  = new ServerRequest(['REQUEST_METHOD' => $method], [], '/foo', $method);
+        $response = new Response();
+        $result   = $app->routeMiddleware($request, $response, function ($request, $response) use ($app, $next) {
+            return $app->dispatchMiddleware($request, $response, $next);
+        });
+        $this->assertEquals(200, $result->getStatusCode());
+        $this->assertEquals('Middleware', (string) $result->getBody());
+    }
+
+    /**
+     * @dataProvider notAllowedMethod
+     *
+     * @param string $adapter
+     * @param string $method
+     */
+    public function testNotAllowedMethodWhenNoHttpMethodsSet($adapter, $method)
+    {
+        $app = new Application(new $adapter);
+
+        // Add a route with empty array - NO HTTP methods
+        $app->route('/foo', function ($req, $res, $next) {
+            $res->getBody()->write('Middleware');
+            return $res;
+        }, []);
+
+        $next = function ($req, $res) {
+            return $res;
+        };
+
+        $request  = new ServerRequest(['REQUEST_METHOD' => $method], [], '/foo', $method);
+        $response = new Response();
+        $result   = $app->routeMiddleware($request, $response, function ($request, $response) use ($app, $next) {
+            return $app->dispatchMiddleware($request, $response, $next);
+        });
+        $this->assertEquals(405, $result->getStatusCode());
+        $this->assertNotContains('Middleware', (string) $result->getBody());
+    }
+
     /**
      * @dataProvider routerAdapters
      * @group 74


### PR DESCRIPTION
Documentation says:

> // Matching NO HTTP methods
> // Pass an empty array to the HTTP methods. HEAD and OPTIONS will still be
> // honored. (In FastRoute, GET is also honored.)
> $app->route('/post', 'WillThisHandlePost', []);
> https://github.com/zendframework/zend-expressive/blob/master/doc/book/reference/usage-examples.md

As I understand `HEAD` and `OPTIONS` requests should be available when "no http" methods are set (an empty array), and also `GET` request when using FastRoute.
I've added test that shows it's not working correctly.

Also added two other tests:
- check if HEAD/OPTIONS requests are __allowed__ when list of allowed methods is set,
- check if GET*/POST/PUT/DELETE/PATCH request are __not allowed__ when "no http" methods is set.

GET* - as docs says in FastRoute GET method is honored (as we can see in my tests it's not working as well).

We can discuss what is the correct way and what should contain body for HEAD and OPTIONS requests (probably we need more tests for it). My tests shows that for different route providers it works different way. IMHO, it should be consistent, doesn't matter what router is used.