### PR TITLE
Make PHP error handler operate in a stack

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -129,9 +129,8 @@ class Application extends MiddlewarePipe implements Router\RouteResultSubjectInt
      *
      * If $out is not provided, uses the result of `getFinalHandler()`.
      *
-     * @todo Remove logic for creating final handler for version 2.0.
-     * @todo Remove error handler for deprecation notice due to triggering
-     *     error middleware for version 2.0.0.
+     * @todo Remove logic for creating final handler for version 2.0.0.
+     * @todo Remove swallowDeprecationNotices() invocation for version 2.0.0.
      * @param ServerRequestInterface $request
      * @param ResponseInterface $response
      * @param callable|null $out
@@ -673,6 +672,7 @@ class Application extends MiddlewarePipe implements Router\RouteResultSubjectInt
     /**
      * Register an error handler to swallow deprecation notices due to error middleware usage.
      *
+     * @todo Remove method for version 2.0.0.
      * @return void
      */
     private function swallowDeprecationNotices()
@@ -689,13 +689,12 @@ class Application extends MiddlewarePipe implements Router\RouteResultSubjectInt
             return;
         }
 
-        $composite = function ($errno, $errstr, $errfile, $errline, $errcontext) use ($handler, $previous) {
+        set_error_handler(function ($errno, $errstr, $errfile, $errline, $errcontext) use ($handler, $previous) {
             if ($handler($errno, $errstr)) {
                 return true;
             }
 
             return $previous($errno, $errstr, $errfile, $errline, $errcontext);
-        };
-        set_error_handler($composite);
+        });
     }
 }


### PR DESCRIPTION
Per #400, when we register a new error handler to swallow deprecation notices in `Application::__invoke()`, if any global error handlers were registered previously, they now disappear.

This patch adds a test covering that scenario, and updates the `Application` class as follows:

- The `set_error_handler()` call in `Application::__invoke()` has been replaced with a call to a new method, `swallowDeprecationNotices()`.
- `swallowDeprecationNotices()` now captures the return value of calling `set_error_handler()`; if that value is non-empty, it creates a new error handler closing over its own error handler and the previous which invokes the previous if our own returns false.

This serves as an alternate solution to #401.