### PR TITLE
Added handling for missing container/router in AppFactory

### DIFF
--- a/.docheader
+++ b/.docheader
@@ -1,5 +1,5 @@
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2015-%year% Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) %regexp:(20\d{2}-)?%%year% Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "zendframework/zend-expressive-fastroute": "^1.0",
         "zendframework/zend-expressive-zendrouter": "^1.0",
         "zendframework/zend-servicemanager": "^2.6",
-        "malukenho/docheader": "^0.1.0"
+        "malukenho/docheader": "^0.1.5"
     },
     "autoload": {
       "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "bfe38efe126728318092ad61f0c56de6",
-    "content-hash": "36ae45df1f447559f5a7e11cfa725cea",
+    "hash": "8e99a5ef4f9f8500dc14587de32a162e",
+    "content-hash": "1de54fe5d6df880378b1fe7e6951da6a",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -557,16 +557,16 @@
         },
         {
             "name": "malukenho/docheader",
-            "version": "0.1.4",
+            "version": "0.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/malukenho/docheader.git",
-                "reference": "64137b8fd198163fa69fbc1affe0c900aaf8d257"
+                "reference": "f35ada934d1de3f5ba09970a6541009a41347658"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/malukenho/docheader/zipball/64137b8fd198163fa69fbc1affe0c900aaf8d257",
-                "reference": "64137b8fd198163fa69fbc1affe0c900aaf8d257",
+                "url": "https://api.github.com/repos/malukenho/docheader/zipball/f35ada934d1de3f5ba09970a6541009a41347658",
+                "reference": "f35ada934d1de3f5ba09970a6541009a41347658",
                 "shasum": ""
             },
             "require": {
@@ -603,7 +603,7 @@
                 "code standard",
                 "license"
             ],
-            "time": "2016-10-04 16:06:27"
+            "time": "2016-11-17 16:46:05"
         },
         {
             "name": "nikic/fast-route",

--- a/src/AppFactory.php
+++ b/src/AppFactory.php
@@ -40,11 +40,31 @@ final class AppFactory
      * @param null|Router\RouterInterface $router Router implementation to use;
      *     defaults to the FastRoute router bridge.
      * @return Application
+     * @throws Exception\MissingDependencyException if the container was not
+     *     provided and the ServiceManager class is not present.
+     * @throws Exception\MissingDependencyException if the router was not
+     *     provided and the Router\FastRouteRouter class is not present.
      */
     public static function create(
         ContainerInterface $container = null,
         Router\RouterInterface $router = null
     ) {
+        if (! $container && ! class_exists(ServiceManager::class)) {
+            throw new Exception\MissingDependencyException(sprintf(
+                '%s requires a container, but none was provided and %s is not installed',
+                __CLASS__,
+                ServiceManager::class
+            ));
+        }
+
+        if (! $router && ! class_exists(Router\FastRouteRouter::class)) {
+            throw new Exception\MissingDependencyException(sprintf(
+                '%s requires a router, but none was provided and %s is not installed',
+                __CLASS__,
+                Router\FastRouteRouter::class
+            ));
+        }
+
         $container = $container ?: new ServiceManager();
         $router    = $router    ?: new Router\FastRouteRouter();
         $emitter   = new Emitter\EmitterStack();

--- a/src/Exception/MissingDependencyException.php
+++ b/src/Exception/MissingDependencyException.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Exception;
+
+use RuntimeException;
+
+class MissingDependencyException extends RuntimeException implements ExceptionInterface
+{
+}


### PR DESCRIPTION
`AppFactory::create` now raises a new `MissingDependencyException` in either of
the two following scenarios:

- `$container` absence, and lack of `ServiceManager`
- `$router` absence, and lack of `Router\FastRouteRouter`

Note: I was unable to write tests, because both classes are always present in our test suite!

Fixes #352