### PR TITLE
Register only one error handler in `swallowDeprecationNotices()`

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -677,24 +677,16 @@ class Application extends MiddlewarePipe implements Router\RouteResultSubjectInt
      */
     private function swallowDeprecationNotices()
     {
-        $handler = function ($errno, $errstr) {
-            if ($errno !== E_USER_DEPRECATED) {
-                return false;
+        $handler = function ($errno, $errstr, $errfile, $errline, $errcontext) use (&$previous) {
+            $swallow = $errno === E_USER_DEPRECATED && false !== strstr($errstr, 'error middleware is deprecated');
+
+            if ($swallow || $previous === null) {
+                return $swallow;
             }
-            return false !== strstr($errstr, 'error middleware is deprecated');
+
+            $previous($errno, $errstr, $errfile, $errline, $errcontext);
         };
 
         $previous = set_error_handler($handler);
-        if (! $previous) {
-            return;
-        }
-
-        set_error_handler(function ($errno, $errstr, $errfile, $errline, $errcontext) use ($handler, $previous) {
-            if ($handler($errno, $errstr)) {
-                return true;
-            }
-
-            return $previous($errno, $errstr, $errfile, $errline, $errcontext);
-        });
     }
 }

--- a/test/IntegrationTest.php
+++ b/test/IntegrationTest.php
@@ -84,9 +84,9 @@ class IntegrationTest extends TestCase
      */
     public function testErrorMiddlewareDeprecationErrorHandlerWillNotOverridePreviouslyRegisteredErrorHandler()
     {
-        $triggered = false;
+        $triggered = 0;
         $this->errorHandler = set_error_handler(function ($errno, $errstr) use (&$triggered) {
-            $triggered = true;
+            $triggered++;
             return true;
         });
 
@@ -104,6 +104,10 @@ class IntegrationTest extends TestCase
 
         $app->run($request, $response);
 
-        $this->assertTrue($triggered);
+        trigger_error('Triggered', E_USER_NOTICE);
+
+        restore_error_handler();
+
+        $this->assertSame(2, $triggered);
     }
 }


### PR DESCRIPTION
Handlers are not popped correctly in `__invoke()`:

`$handler` from `swallowDeprecationNotices()` is still active after running the application which again swallows all errors after `Zend\Expressive\Application` finished execution.

The modified test passes for this commit, but it does not in the previous (but it should).

Edit: Would it be desired to also open a corresponding issue?