### PR TITLE
fast-route caching doc draft

### DIFF
--- a/doc/book/features/router/fast-route.md
+++ b/doc/book/features/router/fast-route.md
@@ -274,8 +274,8 @@ $container['Zend\Expressive\Router\RouterInterface'] = new RouterFactory();
 
 ### FastRoute caching support
 
-Starting from version 1.3.0 zend-expressive-fastroute supports fast-route 
-dispatch data caching.
+Starting from version 1.3.0 zend-expressive-fastroute comes with support 
+for fast-route native dispatch data caching.
 
 To enable this feature a couple of modifications are needed to be made in 
 the `routes.global.php` configuration file. 
@@ -289,14 +289,18 @@ will allow us to toggle caching support and to specify a custom cache file.
 
 As an example:
 ``` php
+// config file routes.global.php
+
+use Zend\Expressive\Router\RouterInterface;
+use Zend\Expressive\Router\FastRouteRouterFactory;
+
 return [
     'dependencies' => [
         //..
         'factories' => [
             //..
             // Notice that the factory is not the InvokableFactory anymore.
-            Zend\Expressive\Router\RouterInterface::class 
-                => Zend\Expressive\Router\FastRouteRouterFactory::class,
+            RouterInterface::class => FastRouteRouterFactory::class,
             //..
         ],
     ],

--- a/doc/book/features/router/fast-route.md
+++ b/doc/book/features/router/fast-route.md
@@ -283,7 +283,7 @@ configuration file.
 1. First we need to delegate the creation of the router instance to the new 
    provided factory.
 
-2. Then we need to add a new configuration entry (`$config['router']['fastroute']`) 
+2. Then we need to add a new configuration entry (`$config['router']['fastroute']`). 
    The options in this entry will be used by the factory to build the router 
    instance in order to toggle caching support and to specify a custom cache file.
 

--- a/doc/book/features/router/fast-route.md
+++ b/doc/book/features/router/fast-route.md
@@ -312,7 +312,8 @@ return [
     'router' => [
         'fastroute' => [
             'cache_enabled' => true, // bool 
-            'cache_file'    => 'data/cache/fastroute.php.cache', //optional path relative to the working directory
+             // optional (but recommended) cache file path
+            'cache_file'    => '/path/to/data/cache/fastroute.php.cache',
         ],
     ],
 
@@ -325,10 +326,12 @@ The new entry options are quite self-explanatory:
   environment. Commenting or omitting this option is equivalent to having it set 
   to `false`
 - `cache_file` (string) This is an optional parameter that represents the path of 
-  the dispatch data cache file relative to the zend-expressive working directory. 
-  The default is `data/cache/fastroute.php.cache`. `data/cache` is the
-  default zend-expressive cache directory created by the skeleton application.
-  An absolute file path is also supported.
+  the dispatch data cache file. It can be provided as an absolute file path or as a 
+  path relative to the zend-expressive working directory. 
+  It defaults to `data/cache/fastroute.php.cache`, where `data/cache` is the 
+  commonly defined zend-expressive cache directory created by the skeleton application.
+  An explicit absolute file path is recommended since the php `include` construct will 
+  skip searching in the `include_path`s and the current  directory.
   If you choose a custom path make sure that the containing directory exists 
   and is writable by the owner of the php process. As for other zend-expressive 
   cached configuaration, you need to purge this file in order to enable any newly 

--- a/doc/book/features/router/fast-route.md
+++ b/doc/book/features/router/fast-route.md
@@ -295,7 +295,8 @@ return [
         'factories' => [
             //..
             // Notice that the factory is not the InvokableFactory anymore.
-            Zend\Expressive\Router\RouterInterface::class => Zend\Expressive\Router\FastRouteRouterFactory::class,
+            Zend\Expressive\Router\RouterInterface::class 
+                => Zend\Expressive\Router\FastRouteRouterFactory::class,
             //..
         ],
     ],
@@ -304,7 +305,7 @@ return [
     'router' => [
         'fastroute' => [
             'cache_enabled' => true, // bool 
-            'cache_file'    => 'data/cache/fastroute.php.cachedata/cache/fastroute.cache', //optional path relative to the working directory
+            'cache_file'    => 'data/cache/fastroute.php.cache', //optional path relative to the working directory
         ],
     ],
 

--- a/doc/book/features/router/fast-route.md
+++ b/doc/book/features/router/fast-route.md
@@ -273,3 +273,55 @@ $container['Zend\Expressive\Router\RouterInterface'] = new RouterFactory();
 ```
 
 ### FastRoute caching support
+
+Starting from version 1.3.0 zend-expressive-fastroute supports fast-route 
+dispatch data caching.
+
+To enable this feature a couple of modifications are needed to be made in 
+the `routes.global.php` configuration file. 
+
+First we need to delegate the creation of the router instance to the new 
+provided factory.
+
+Then we need to add a new configuration entry. The options under this key 
+will be used by the factory to build the router instance. These options
+will allow us to toggle caching support and to specify a custom cache file.
+
+As an example:
+``` php
+return [
+    'dependencies' => [
+        //..
+        'factories' => [
+            //..
+            // Notice that the factory is not the InvokableFactory anymore.
+            Zend\Expressive\Router\RouterInterface::class => Zend\Expressive\Router\FastRouteRouterFactory::class,
+            //..
+        ],
+    ],
+    
+    // the new entry for caching support
+    'router' => [
+        'fastroute' => [
+            'cache_enabled' => true, // bool 
+            'cache_file'    => 'data/cache/fastroute.php.cachedata/cache/fastroute.cache', //optional path relative to the working directory
+        ],
+    ],
+
+    'routes' => [...],
+]
+```
+The new entry options are quite self-explanatory:
+- `cache_enabled` (bool) is used to toggle caching support. It's advisable to enable 
+  caching in a production environment and leave it disabled for the development 
+  environment. Commenting or omitting this option is equivalent to having it set 
+  to `false`
+- `cache_file` (string) This is an optional parameter that represents the relative 
+  path of the dispatch data cache file relative to the zend-expressive working
+  directory. The default is `data/cache/fastroute.php.cache`. `data/cache` is the
+  default zend-expressive cache directory created by the skeleton application. 
+  If you choose a custom path make sure that the containing directory exists 
+  and is writable by the owner of the php process. As for other zend-expressive 
+  cached configuaration, you need to purge this file in order to enable any newly 
+  added route if caching is enabled.
+  

--- a/doc/book/features/router/fast-route.md
+++ b/doc/book/features/router/fast-route.md
@@ -324,10 +324,11 @@ The new entry options are quite self-explanatory:
   caching in a production environment and leave it disabled for the development 
   environment. Commenting or omitting this option is equivalent to having it set 
   to `false`
-- `cache_file` (string) This is an optional parameter that represents the relative 
-  path of the dispatch data cache file relative to the zend-expressive working
-  directory. The default is `data/cache/fastroute.php.cache`. `data/cache` is the
-  default zend-expressive cache directory created by the skeleton application. 
+- `cache_file` (string) This is an optional parameter that represents the path of 
+  the dispatch data cache file relative to the zend-expressive working directory. 
+  The default is `data/cache/fastroute.php.cache`. `data/cache` is the
+  default zend-expressive cache directory created by the skeleton application.
+  An absolute file path is also supported.
   If you choose a custom path make sure that the containing directory exists 
   and is writable by the owner of the php process. As for other zend-expressive 
   cached configuaration, you need to purge this file in order to enable any newly 

--- a/doc/book/features/router/fast-route.md
+++ b/doc/book/features/router/fast-route.md
@@ -271,3 +271,5 @@ $container['FastRoute\RouteCollector'] = new FastRouteCollectorFactory();
 $container['FastRoute\RouteDispatcher'] = new FastRouteDispatcherFactory();
 $container['Zend\Expressive\Router\RouterInterface'] = new RouterFactory();
 ```
+
+### FastRoute caching support

--- a/doc/book/features/router/fast-route.md
+++ b/doc/book/features/router/fast-route.md
@@ -277,15 +277,15 @@ $container['Zend\Expressive\Router\RouterInterface'] = new RouterFactory();
 Starting from version 1.3.0 zend-expressive-fastroute comes with support 
 for fast-route native dispatch data caching.
 
-To enable this feature a couple of modifications are needed to be made in 
-the `routes.global.php` configuration file. 
+To enable this feature a couple of changes are needed in the `routes.global.php` 
+configuration file. 
 
-First we need to delegate the creation of the router instance to the new 
-provided factory.
+1. First we need to delegate the creation of the router instance to the new 
+   provided factory.
 
-Then we need to add a new configuration entry. The options under this key 
-will be used by the factory to build the router instance. These options
-will allow us to toggle caching support and to specify a custom cache file.
+2. Then we need to add a new configuration entry (`$config['router']['fastroute']`) 
+   The options in this entry will be used by the factory to build the router 
+   instance in order to toggle caching support and to specify a custom cache file.
 
 As an example:
 ``` php

--- a/doc/book/features/router/fast-route.md
+++ b/doc/book/features/router/fast-route.md
@@ -331,5 +331,5 @@ The new entry options are quite self-explanatory:
   If you choose a custom path make sure that the containing directory exists 
   and is writable by the owner of the php process. As for other zend-expressive 
   cached configuaration, you need to purge this file in order to enable any newly 
-  added route if caching is enabled.
+  added route when fast-route caching is enabled.
   

--- a/doc/book/features/router/fast-route.md
+++ b/doc/book/features/router/fast-route.md
@@ -291,16 +291,19 @@ As an example:
 ``` php
 // config file routes.global.php
 
-use Zend\Expressive\Router\RouterInterface;
-use Zend\Expressive\Router\FastRouteRouterFactory;
-
 return [
     'dependencies' => [
         //..
+        'invokables' => [
+            //..
+            // comment or remove the following line
+            // Zend\Expressive\Router\RouterInterface::class => Zend\Expressive\Router\FastRouteRouter::class,
+            //..
+        ],
         'factories' => [
             //..
-            // Notice that the factory is not the InvokableFactory anymore.
-            RouterInterface::class => FastRouteRouterFactory::class,
+            // Add this line (the router instance is now built in a factory)
+            Zend\Expressive\Router\RouterInterface::class => Zend\Expressive\Router\FastRouteRouterFactory::class,
             //..
         ],
     ],

--- a/doc/book/features/router/fast-route.md
+++ b/doc/book/features/router/fast-route.md
@@ -302,7 +302,7 @@ return [
         ],
         'factories' => [
             //..
-            // Add this line (the router instance is now built in a factory)
+            // Add this line (the router instance is now built "in the factory")
             Zend\Expressive\Router\RouterInterface::class => Zend\Expressive\Router\FastRouteRouterFactory::class,
             //..
         ],


### PR DESCRIPTION
Hello @weierophinney,

a few quick considerations that came to my mind (under the influence of the flu)

1. I am not a native english speaker....so please ... have mercy :-)...no, really, pls edit, edit....
   ...maybe I was over naive in some explainations.

2. Should we add a short intro about what fast-route dispatch data is, how fast.route caching works?

3. Would you prefer to have the class constant suggested by @Ocramius as the config keys?
  namely `FastRouteRouter::CONFIG_CACHE_ENABLED` and `FastRouteRouter::CONFIG_CACHE_FILE`

4. I used the default `cache_file` option value to be (both in the config file and in the router class)  `'data/cache/fastroute.php.cache'`. I use to prefix cache files with `php.cache` for php-array/serialized array, `json.cache` for json array/serialized data etc etc. If you prefer or think that can be a source of confusion we could just use `'data/cache/fastroute.cache'`.
(edited: or `'data/cache/fastroute.php'` to be aligned with the new `app_config.php` name)

5. in the `loadDispatchData()` method [src](https://github.com/zendframework/zend-expressive-fastroute/blob/develop/src/FastRouteRouter.php#L450): is there a way to have the error suppressor handler in one line pass the CS checker? I am quite sure i saw a one-line version somewhere in zend code.

kind regards
maks