### PR TITLE
Allow HEAD and OPTIONS requests for any matched route

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "container-interop/container-interop": "^1.1",
         "psr/http-message": "^1.0",
         "zendframework/zend-diactoros": "^1.1",
-        "zendframework/zend-expressive-router": "^1.1",
+        "zendframework/zend-expressive-router": "^1.3.2",
         "zendframework/zend-expressive-template": "^1.0.1",
         "zendframework/zend-stratigility": "^1.3.1",
         "fig/http-message-util": "^1.1"
@@ -31,9 +31,9 @@
         "mockery/mockery": "^0.9.5",
         "phpunit/phpunit": "^5.0",
         "zendframework/zend-coding-standard": "~1.0.0",
-        "zendframework/zend-expressive-aurarouter": "^1.0",
-        "zendframework/zend-expressive-fastroute": "^1.0",
-        "zendframework/zend-expressive-zendrouter": "^1.0",
+        "zendframework/zend-expressive-aurarouter": "^1.1.3",
+        "zendframework/zend-expressive-fastroute": "^1.3",
+        "zendframework/zend-expressive-zendrouter": "^1.3",
         "zendframework/zend-servicemanager": "^2.6 || ^3.1.1"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "2e11eb95789d5517899ac838b21a8c5f",
-    "content-hash": "a0695dc01e069a81f607c8fb328c1ad6",
+    "hash": "0fec3ecce54339948cc650a8fcf00846",
+    "content-hash": "3c3ba352fa6b6dc9acef6d1e18e167e6",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -282,36 +282,38 @@
         },
         {
             "name": "zendframework/zend-expressive-router",
-            "version": "1.2.0",
+            "version": "1.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-expressive-router.git",
-                "reference": "ec11c758e067c3eef579cb51dcabfcbf5de2ec03"
+                "reference": "50c9e4dff0cf65d9937c56b597c530e1bf5f8ef0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/ec11c758e067c3eef579cb51dcabfcbf5de2ec03",
-                "reference": "ec11c758e067c3eef579cb51dcabfcbf5de2ec03",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/50c9e4dff0cf65d9937c56b597c530e1bf5f8ef0",
+                "reference": "50c9e4dff0cf65d9937c56b597c530e1bf5f8ef0",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5 || ^7.0",
+                "fig/http-message-util": "^1.1",
+                "php": "^5.6 || ^7.0",
                 "psr/http-message": "^1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.7",
-                "squizlabs/php_codesniffer": "^2.3"
+                "malukenho/docheader": "^0.1.5",
+                "phpunit/phpunit": "^4.7 || ^5.6",
+                "zendframework/zend-coding-standard": "~1.0.0"
             },
             "suggest": {
-                "zendframework/zend-expressive-aurarouter": "^0.1 to use the Aura.Router routing adapter",
-                "zendframework/zend-expressive-fastroute": "^0.1 to use the FastRoute routing adapter",
-                "zendframework/zend-expressive-zendrouter": "^0.1 to use the zend-mvc routing adapter"
+                "zendframework/zend-expressive-aurarouter": "^1.0 to use the Aura.Router routing adapter",
+                "zendframework/zend-expressive-fastroute": "^1.2 to use the FastRoute routing adapter",
+                "zendframework/zend-expressive-zendrouter": "^1.2 to use the zend-router routing adapter"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev",
-                    "dev-develop": "1.3-dev"
+                    "dev-master": "1.3.x-dev",
+                    "dev-develop": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -331,7 +333,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2016-01-18 20:10:33"
+            "time": "2016-12-14 13:49:15"
         },
         {
             "name": "zendframework/zend-expressive-template",
@@ -439,42 +441,35 @@
     "packages-dev": [
         {
             "name": "aura/router",
-            "version": "2.3.1",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/auraphp/Aura.Router.git",
-                "reference": "d8cb21b7fa8d2b2ae874093d5440688b3356f9c4"
+                "reference": "6daebc9747e26a6fdd545d1ed5982b276f17b7a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/auraphp/Aura.Router/zipball/d8cb21b7fa8d2b2ae874093d5440688b3356f9c4",
-                "reference": "d8cb21b7fa8d2b2ae874093d5440688b3356f9c4",
+                "url": "https://api.github.com/repos/auraphp/Aura.Router/zipball/6daebc9747e26a6fdd545d1ed5982b276f17b7a2",
+                "reference": "6daebc9747e26a6fdd545d1ed5982b276f17b7a2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=5.5.0",
+                "psr/http-message": "~1.0",
+                "psr/log": "~1.0"
             },
             "require-dev": {
-                "aura/di": "~2.0"
+                "zendframework/zend-diactoros": "~1.0"
             },
             "type": "library",
-            "extra": {
-                "aura": {
-                    "type": "library",
-                    "config": {
-                        "common": "Aura\\Router\\_Config\\Common"
-                    }
-                }
-            },
             "autoload": {
                 "psr-4": {
-                    "Aura\\Router\\": "src/",
-                    "Aura\\Router\\_Config\\": "config/"
+                    "Aura\\Router\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD-2-Clause"
+                "MIT"
             ],
             "authors": [
                 {
@@ -482,14 +477,15 @@
                     "homepage": "https://github.com/auraphp/Aura.Router/contributors"
                 }
             ],
-            "description": "A web router implementation; given a URI path and a copy of $_SERVER, it will extract path-info parameter values for a specific route.",
+            "description": "Powerful, flexible web routing for PSR-7 requests.",
             "homepage": "https://github.com/auraphp/Aura.Router",
             "keywords": [
+                "psr-7",
                 "route",
                 "router",
                 "routing"
             ],
-            "time": "2016-10-03 20:00:15"
+            "time": "2016-10-03 21:48:40"
         },
         {
             "name": "doctrine/instantiator",
@@ -1305,16 +1301,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.7.2",
+            "version": "5.7.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "336aff0ac52e306c98e7455bc3e8d7b0bf777a5e"
+                "reference": "af91da3f2671006ff5d0628023de3b7ac4d1ef09"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/336aff0ac52e306c98e7455bc3e8d7b0bf777a5e",
-                "reference": "336aff0ac52e306c98e7455bc3e8d7b0bf777a5e",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/af91da3f2671006ff5d0628023de3b7ac4d1ef09",
+                "reference": "af91da3f2671006ff5d0628023de3b7ac4d1ef09",
                 "shasum": ""
             },
             "require": {
@@ -1325,7 +1321,7 @@
                 "ext-xml": "*",
                 "myclabs/deep-copy": "~1.3",
                 "php": "^5.6 || ^7.0",
-                "phpspec/prophecy": "^1.3.1",
+                "phpspec/prophecy": "^1.6.2",
                 "phpunit/php-code-coverage": "^4.0.3",
                 "phpunit/php-file-iterator": "~1.4",
                 "phpunit/php-text-template": "~1.2",
@@ -1335,7 +1331,7 @@
                 "sebastian/diff": "~1.2",
                 "sebastian/environment": "^1.3.4 || ^2.0",
                 "sebastian/exporter": "~2.0",
-                "sebastian/global-state": "~1.0",
+                "sebastian/global-state": "^1.0 || ^2.0",
                 "sebastian/object-enumerator": "~2.0",
                 "sebastian/resource-operations": "~1.0",
                 "sebastian/version": "~1.0|~2.0",
@@ -1383,20 +1379,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-12-03 08:33:00"
+            "time": "2016-12-13 16:19:44"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "3.4.2",
+            "version": "3.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "90a08f5deed5f7ac35463c161f2e8fa0e5652faf"
+                "reference": "3ab72b65b39b491e0c011e2e09bb2206c2aa8e24"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/90a08f5deed5f7ac35463c161f2e8fa0e5652faf",
-                "reference": "90a08f5deed5f7ac35463c161f2e8fa0e5652faf",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/3ab72b65b39b491e0c011e2e09bb2206c2aa8e24",
+                "reference": "3ab72b65b39b491e0c011e2e09bb2206c2aa8e24",
                 "shasum": ""
             },
             "require": {
@@ -1442,7 +1438,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2016-11-27 07:52:03"
+            "time": "2016-12-08 20:27:08"
         },
         {
             "name": "psr/log",
@@ -2084,16 +2080,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.2.0",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "09d0fd33560e3573185a2ea17614e37ba38716c5"
+                "reference": "d12aa9ca20f4db83ec58410978dab6afcb9d6aaa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/09d0fd33560e3573185a2ea17614e37ba38716c5",
-                "reference": "09d0fd33560e3573185a2ea17614e37ba38716c5",
+                "url": "https://api.github.com/repos/symfony/console/zipball/d12aa9ca20f4db83ec58410978dab6afcb9d6aaa",
+                "reference": "d12aa9ca20f4db83ec58410978dab6afcb9d6aaa",
                 "shasum": ""
             },
             "require": {
@@ -2143,11 +2139,11 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-16 22:18:16"
+            "time": "2016-12-11 14:34:22"
         },
         {
             "name": "symfony/debug",
-            "version": "v3.2.0",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
@@ -2204,16 +2200,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v3.2.0",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "4263e35a1e342a0f195c9349c0dee38148f8a14f"
+                "reference": "a69cb5d455b4885ca376dc5bb3e1155cc8c08c4b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/4263e35a1e342a0f195c9349c0dee38148f8a14f",
-                "reference": "4263e35a1e342a0f195c9349c0dee38148f8a14f",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/a69cb5d455b4885ca376dc5bb3e1155cc8c08c4b",
+                "reference": "a69cb5d455b4885ca376dc5bb3e1155cc8c08c4b",
                 "shasum": ""
             },
             "require": {
@@ -2249,7 +2245,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-03 08:11:03"
+            "time": "2016-12-13 09:39:43"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -2312,16 +2308,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.2.0",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "f2300ba8fbb002c028710b92e1906e7457410693"
+                "reference": "a7095af4b97a0955f85c8989106c249fa649011f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/f2300ba8fbb002c028710b92e1906e7457410693",
-                "reference": "f2300ba8fbb002c028710b92e1906e7457410693",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/a7095af4b97a0955f85c8989106c249fa649011f",
+                "reference": "a7095af4b97a0955f85c8989106c249fa649011f",
                 "shasum": ""
             },
             "require": {
@@ -2363,7 +2359,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-18 21:17:59"
+            "time": "2016-12-10 10:07:06"
         },
         {
             "name": "webmozart/assert",
@@ -2446,33 +2442,35 @@
         },
         {
             "name": "zendframework/zend-expressive-aurarouter",
-            "version": "1.0.0",
+            "version": "1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-expressive-aurarouter.git",
-                "reference": "cfca5afe885dc7db3358ab0eb8fae38a20d619c2"
+                "reference": "e97009e4fd0f2d91d02c719bc94e60ea4fe461f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-aurarouter/zipball/cfca5afe885dc7db3358ab0eb8fae38a20d619c2",
-                "reference": "cfca5afe885dc7db3358ab0eb8fae38a20d619c2",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-aurarouter/zipball/e97009e4fd0f2d91d02c719bc94e60ea4fe461f2",
+                "reference": "e97009e4fd0f2d91d02c719bc94e60ea4fe461f2",
                 "shasum": ""
             },
             "require": {
-                "aura/router": "^2.3",
-                "php": "^5.5 || ^7.0",
+                "aura/router": "^3.0",
+                "fig/http-message-util": "^1.1",
+                "php": "^5.6 || ^7.0",
                 "psr/http-message": "^1.0",
-                "zendframework/zend-expressive-router": "^1.0"
+                "zendframework/zend-expressive-router": "^1.3.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.7",
-                "squizlabs/php_codesniffer": "^2.3"
+                "malukenho/docheader": "^0.1.5",
+                "phpunit/phpunit": "^4.7 || ^5.6",
+                "zendframework/zend-coding-standard": "~1.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev",
-                    "dev-develop": "1.1-dev"
+                    "dev-master": "1.1-dev",
+                    "dev-develop": "1.2-dev"
                 }
             },
             "autoload": {
@@ -2493,37 +2491,39 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2015-12-07 15:34:25"
+            "time": "2016-12-15 23:09:06"
         },
         {
             "name": "zendframework/zend-expressive-fastroute",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-expressive-fastroute.git",
-                "reference": "2d08527ee8b4ac8709a9dae626f868eaaa1d84e6"
+                "reference": "825c93ff72c0f629bb427a6da8ebfe9d4735c296"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-fastroute/zipball/2d08527ee8b4ac8709a9dae626f868eaaa1d84e6",
-                "reference": "2d08527ee8b4ac8709a9dae626f868eaaa1d84e6",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-fastroute/zipball/825c93ff72c0f629bb427a6da8ebfe9d4735c296",
+                "reference": "825c93ff72c0f629bb427a6da8ebfe9d4735c296",
                 "shasum": ""
             },
             "require": {
+                "fig/http-message-util": "^1.1",
                 "nikic/fast-route": "^1.0.0",
-                "php": "^5.5 || ^7.0",
+                "php": "^5.6 || ^7.0",
                 "psr/http-message": "^1.0",
-                "zendframework/zend-expressive-router": "^1.0"
+                "zendframework/zend-expressive-router": "^1.3.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.7",
-                "squizlabs/php_codesniffer": "^2.3"
+                "malukenho/docheader": "^0.1.5",
+                "phpunit/phpunit": "^4.7 || ^5.6",
+                "zendframework/zend-coding-standard": "~1.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1-dev",
-                    "dev-develop": "1.2-dev"
+                    "dev-master": "1.3-dev",
+                    "dev-develop": "1.4-dev"
                 }
             },
             "autoload": {
@@ -2544,38 +2544,40 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2016-06-16 13:37:19"
+            "time": "2016-12-14 19:47:05"
         },
         {
             "name": "zendframework/zend-expressive-zendrouter",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-expressive-zendrouter.git",
-                "reference": "bbd3cc499f3dcaeb0ce483e7975c238719b0104f"
+                "reference": "b00ef3a314bbe92da0a33e42ef0c575ddd4a4ba9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-zendrouter/zipball/bbd3cc499f3dcaeb0ce483e7975c238719b0104f",
-                "reference": "bbd3cc499f3dcaeb0ce483e7975c238719b0104f",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-zendrouter/zipball/b00ef3a314bbe92da0a33e42ef0c575ddd4a4ba9",
+                "reference": "b00ef3a314bbe92da0a33e42ef0c575ddd4a4ba9",
                 "shasum": ""
             },
             "require": {
+                "fig/http-message-util": "^1.1",
                 "php": "^5.6 || ^7.0",
                 "psr/http-message": "^1.0",
-                "zendframework/zend-expressive-router": "^1.2",
+                "zendframework/zend-expressive-router": "^1.3.2",
                 "zendframework/zend-psr7bridge": "^0.2.2",
                 "zendframework/zend-router": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8",
-                "squizlabs/php_codesniffer": "^2.6.2"
+                "malukenho/docheader": "^0.1.5",
+                "phpunit/phpunit": "^4.8 || ^5.6",
+                "zendframework/zend-coding-standard": "~1.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev",
-                    "dev-develop": "1.3-dev"
+                    "dev-master": "1.3-dev",
+                    "dev-develop": "1.4-dev"
                 }
             },
             "autoload": {
@@ -2596,7 +2598,7 @@
                 "psr-7",
                 "zf2"
             ],
-            "time": "2016-08-11 14:14:46"
+            "time": "2016-12-14 20:46:12"
         },
         {
             "name": "zendframework/zend-http",

--- a/doc/book/features/middleware/implicit-methods-middleware.md
+++ b/doc/book/features/middleware/implicit-methods-middleware.md
@@ -1,0 +1,133 @@
+# ImplicitHeadMiddleware and ImplicitOptionsMiddleware
+
+Starting with version 1.1, Expressive offers middleware for implicitly
+supporting `HEAD` and `OPTIONS` requests. The HTTP/1.1 specifications indicate
+that all server implementations _must_ support `HEAD` requests for any given
+URI, and that they _should_ support `OPTIONS` requests. To make this possible,
+we have added features to our routing layer, and middleware that can detect
+_implicit_  support for these methods (i.e., the route was not registered
+_explicitly_ with the method).
+
+## ImplicitHeadMiddleware
+
+`Zend\Expressive\Middleware\ImplicitHeadMiddleware` provides support for
+handling `HEAD` requests to routed middleware when the route does not expliclity
+allow for the method. It should be registered _between_ the routing and dispatch
+middleware.
+
+By default, it can be instantiated with no extra arguments. However, you _may_
+provide a response instance to use by default to the constructor if you need to
+craft special headers, status code, etc.
+
+Register the dependency via `dependencies` configuration:
+
+```php
+use Zend\Expressive\Middleware\ImplicitHeadMiddleware;
+
+return [
+    'dependencies' => [
+        'invokables' => [
+            ImplicitHeadMiddleware::class => ImplicitHeadMiddleware::class,
+        ],
+
+        // or, if you have defined a factory to inject a response:
+        'factories' => [
+            ImplicitHeadMiddleware::class => \Your\ImplicitHeadMiddlewareFactory::class,
+        ],
+    ],
+];
+```
+
+Within your application pipeline, add the middleware between the routing and
+dispatch middleware:
+
+```php
+$app->pipeRoutingMiddleware();
+$app->pipe(ImplicitHeadMiddleware::class);
+// ...
+$app->pipeDispatchMiddleware();
+```
+
+(Note: if you used the `expressive-pipeline-from-config` tool to create your
+programmatic pipeline, or if you used the Expressive 1.1 skeleton or later, this
+middleware is likely already in your pipeline, as is a dependency entry.)
+
+When in place, it will do the following:
+
+- If the request method is `HEAD`, AND
+- the request composes a `RouteResult` attribute, AND
+- the route result composes a `Route` instance, AND
+- the route returns true for the `implicitHead()` method, THEN
+- the middleware will return a response.
+
+In all other cases, it returns the result of delegating to the next middleware
+layer.
+
+When `implicitHead()` is matched, one of two things may occur. First, if the
+route does not support the `GET` method, then the middleware returns the
+composed response (either the one injected at instantiation, or an empty
+instance). However, if `GET` is supported, it will dispatch the next layer, but
+with a `GET` request instead of `HEAD`; additionally, it will inject the
+returned response with an empty response body before returning it.
+
+## ImplicitOptionsMiddleware
+
+`Zend\Expressive\Middleware\ImplicitOptionsMiddleware` provides support for
+handling `OPTIONS` requests to routed middleware when the route does not
+expliclity allow for the method. Like the `ImplicitHeadMiddleware`, it should be
+registered _between_ the routing and dispatch middleware.
+
+By default, it can be instantiated with no extra arguments. However, you _may_
+provide a response prototype instance to use by default to the constructor if
+you need to craft special headers, status code, etc.
+
+Register the dependency via `dependencies` configuration:
+
+```php
+use Zend\Expressive\Middleware\ImplicitOptionsMiddleware;
+
+return [
+    'dependencies' => [
+        'invokables' => [
+            ImplicitOptionsMiddleware::class => ImplicitOptionsMiddleware::class,
+        ],
+
+        // or, if you have defined a factory to inject a response:
+        'factories' => [
+            ImplicitOptionsMiddleware::class => \Your\ImplicitOptionsMiddlewareFactory::class,
+        ],
+    ],
+];
+```
+
+Within your application pipeline, add the middleware between the routing and
+dispatch middleware:
+
+```php
+$app->pipeRoutingMiddleware();
+$app->pipe(ImplicitOptionsMiddleware::class);
+// ...
+$app->pipeDispatchMiddleware();
+```
+
+(Note: if you used the `expressive-pipeline-from-config` tool to create your
+programmatic pipeline, or if you used the Expressive 1.1 skeleton or later, this
+middleware is likely already in your pipeline, as is a dependency entry.)
+
+When in place, it will do the following:
+
+- If the request method is `OPTIONS`, AND
+- the request composes a `RouteResult` attribute, AND
+- the route result composes a `Route` instance, AND
+- the route returns true for the `implicitOptions()` method, THEN
+- the middleware will return a response with an `Allow` header indicating
+  methods the route allows.
+
+In all other cases, it returns the result of delegating to the next middleware
+layer.
+
+One thing to note: the allowed methods reported by the route and/or route
+result, and returned via the `Allow` header,  may vary based on router
+implementation. In most cases, it should be an aggregate of all routes using the
+same path specification; however, it *could* be only the methods supported
+explicitly by the matched route. 

--- a/doc/book/reference/migration/to-v1-1.md
+++ b/doc/book/reference/migration/to-v1-1.md
@@ -200,8 +200,8 @@ handling needs should you decide to opt in to this functionality:
     - `$template = 'error::error'`: the template to render, with a default value
       if none is provided.
 
-  `Zend\Expressive\Container\ErrorResponseGeneratorFactory` can create an
-  instance, using the following:
+- `Zend\Expressive\Container\ErrorResponseGeneratorFactory` can create an
+  instance of the `ErrorResponseGenerator` using the following:
 
     - The `debug` top-level configuration value is used to set the
       `$isDevelopmentMode` flag.
@@ -216,8 +216,7 @@ handling needs should you decide to opt in to this functionality:
   generate the error response. Its constructor takes a single argument, a
   `Whoops\Run` instance. If a `Whoops\Handler\PrettyPageHandler` is registered
   with the instance, it will add a data table with request details derived from
-  the `ServerRequestInterface` instance.
-
+  the `ServerRequestInterface` instance.<br/><br/>
   `Zend\Expressive\Container\WhoopsErrorResponseGeneratorFactory` can create an
   instance, and will use the `Zend\Expressive\Whoops` service to seed the
   `Whoops\Run` argument.
@@ -227,8 +226,7 @@ handling needs should you decide to opt in to this functionality:
   get to the innermost layer, no middleware was able to handle the request,
   indicating a 404.) By default, it will produce a canned plaintext response.
   However, you can also provide an optional `TemplateRendererInterface` instance
-  and `$template` in order to provided templated content.
-
+  and `$template` in order to provided templated content.<br/><br/>
   The constructor arguments are:
 
     - `ResponseInterface $responsePrototype`: this is an empty response on which
@@ -240,8 +238,8 @@ handling needs should you decide to opt in to this functionality:
     -  $template = 'error::404'`: optionally, you may provide a
       template to render; if none is provided, a sane default is used.
 
-  `Zend\Expressive\Container\NotFoundHandlerFactory` can create an instance for
-  you, and will use the following to do so:
+- `Zend\Expressive\Container\NotFoundHandlerFactory` can create an instance of
+  the `NotFoundHandler` for you, and will use the following to do so:
 
     - The `Zend\Expressive\Template\TemplateRendererInterface` service, if
       available.
@@ -251,8 +249,8 @@ handling needs should you decide to opt in to this functionality:
 
 - `Zend\Expressive\Container\ErrorHandlerFactory` will create an instance of
   `Zend\Stratigility\Middleware\ErrorHandler`, and use the
-  `Zend\Stratigility\Middleware\ErrorResponseGenerator` service to seed it.
-
+  `Zend\Stratigility\Middleware\ErrorResponseGenerator` service to seed
+  it.<br/><br/>
   As such, register one of the following as a factory for the
   `Zend\Stratigility\Middleware\ErrorResponseGenerator` service:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,8 @@ pages:
             - 'Using Twig': features/template/twig.md
             - 'Using zend-view': features/template/zend-view.md
         - 'Error Handling': features/error-handling.md
+        - Middleware:
+            - 'Implicit HEAD and OPTIONS Middleware': features/middleware/implicit-methods-middleware.md
         - Helpers:
             - Introduction: features/helpers/intro.md
             - UrlHelper: features/helpers/url-helper.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,7 +57,7 @@ pages:
         - 'Expressive Projects': reference/expressive-projects.md
         - Migration:
             - 'From RC5 and Earlier': reference/migration/rc-to-v1.md
-            - 'From the 1.0 series to 1.1+': reference/migration/to-v1.1.md
+            - 'From the 1.0 series to 1.1+': reference/migration/to-v1-1.md
 site_name: Expressive
 site_description: 'zend-expressive: PSR-7 Middleware Microframework'
 repo_url: 'https://github.com/zendframework/zend-expressive'

--- a/src/Middleware/ImplicitHeadMiddleware.php
+++ b/src/Middleware/ImplicitHeadMiddleware.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Middleware;
+
+use Fig\Http\Message\RequestMethodInterface as RequestMethod;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Zend\Diactoros\Response;
+use Zend\Diactoros\Stream;
+use Zend\Expressive\Router\RouteResult;
+
+/**
+ * Handle implicit HEAD requests.
+ *
+ * Place this middleware after the routing middleware so that it can handle
+ * implicit HEAD requests -- requests where HEAD is used, but the route does
+ * not explicitly handle that request method.
+ *
+ * When invoked, it will create an empty response with status code 200.
+ *
+ * You may optionally pass a response prototype to the constructor; when
+ * present, that instance will be returned instead.
+ *
+ * The middleware is only invoked in these specific conditions:
+ *
+ * - a HEAD request
+ * - with a `RouteResult` present
+ * - where the `RouteResult` contains a `Route` instance
+ * - and the `Route` instance defines implicit HEAD.
+ *
+ * In all other circumstances, it will return the result of the delegate.
+ *
+ * If the route instance supports GET requests, the middleware dispatches
+ * the next layer, but alters the request passed to use the GET method;
+ * it then provides an empty response body to the returned response.
+ */
+class ImplicitHeadMiddleware
+{
+    /**
+     * @var null|ResponseInterface
+     */
+    private $response;
+
+    /**
+     * @param null|ResponseInterface $response Response prototype to return
+     *     for implicit HEAD requests; if none provided, an empty zend-diactoros
+     *     instance will be created.
+     */
+    public function __construct(ResponseInterface $response = null)
+    {
+        $this->response = $response;
+    }
+
+    /**
+     * Handle an implicit HEAD request.
+     *
+     * If the route allows GET requests, dispatches as a GET request and
+     * resets the response body to be empty; otherwise, creates a new empty
+     * response.
+     *
+     * @param ServerRequestInterface $request
+     * @param ResponseInterface $response
+     * @param callable $next
+     * @return ResponseInterface
+     */
+    public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next)
+    {
+        if ($request->getMethod() !== RequestMethod::METHOD_HEAD) {
+            return $next($request, $response);
+        }
+
+        if (false === ($result = $request->getAttribute(RouteResult::class, false))) {
+            return $next($request, $response);
+        }
+
+        $route = $result->getMatchedRoute();
+        if (! $route || ! $route->implicitHead()) {
+            return $next($request, $response);
+        }
+
+        if (! $route->allowsMethod(RequestMethod::METHOD_GET)) {
+            return $this->getResponse();
+        }
+
+        $response = $next(
+            $request->withMethod(RequestMethod::METHOD_GET),
+            $response
+        );
+
+        return $response->withBody(new Stream('php://temp/', 'wb+'));
+    }
+
+    /**
+     * Return the response prototype to use for an implicit HEAD request.
+     *
+     * @return ResponseInterface
+     */
+    private function getResponse()
+    {
+        if ($this->response) {
+            return $this->response;
+        }
+
+        return new Response();
+    }
+}

--- a/src/Middleware/ImplicitOptionsMiddleware.php
+++ b/src/Middleware/ImplicitOptionsMiddleware.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Expressive\Middleware;
+
+use Fig\Http\Message\RequestMethodInterface as RequestMethod;
+use Fig\Http\Message\StatusCodeInterface as StatusCode;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Zend\Diactoros\Response;
+use Zend\Expressive\Router\RouteResult;
+
+/**
+ * Handle implicit OPTIONS requests.
+ *
+ * Place this middleware after the routing middleware so that it can handle
+ * implicit OPTIONS requests -- requests where OPTIONS is used, but the route
+ * does not explicitly handle that request method.
+ *
+ * When invoked, it will create a response with status code 200 and an Allow
+ * header that defines all accepted request methods.
+ *
+ * You may optionally pass a response prototype to the constructor; when
+ * present, that prototype will be used to create a new response with the
+ * Allow header.
+ *
+ * The middleware is only invoked in these specific conditions:
+ *
+ * - an OPTIONS request
+ * - with a `RouteResult` present
+ * - where the `RouteResult` contains a `Route` instance
+ * - and the `Route` instance defines implicit OPTIONS.
+ *
+ * In all other circumstances, it will return the result of the delegate.
+ */
+class ImplicitOptionsMiddleware
+{
+    /**
+     * @var null|ResponseInterface
+     */
+    private $response;
+
+    /**
+     * @param null|ResponseInterface $response Response prototype to use for
+     *     implicit OPTIONS requests; if not provided a zend-diactoros Response
+     *     instance will be created and used.
+     */
+    public function __construct(ResponseInterface $response = null)
+    {
+        $this->response = $response;
+    }
+
+    /**
+     * Handle an implicit OPTIONS request.
+     *
+     * @param ServerRequestInterface $request
+     * @param ResponseInterface $response
+     * @param callable $next
+     * @return ResponseInterface
+     */
+    public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next)
+    {
+        if ($request->getMethod() !== RequestMethod::METHOD_OPTIONS) {
+            return $next($request, $response);
+        }
+
+        if (false === ($result = $request->getAttribute(RouteResult::class, false))) {
+            return $next($request, $response);
+        }
+
+        $route = $result->getMatchedRoute();
+        if (! $route || ! $route->implicitOptions()) {
+            return $next($request, $response);
+        }
+
+        $methods = implode(',', $route->getAllowedMethods());
+        return $this->getResponse()->withHeader('Allow', $methods);
+    }
+
+    /**
+     * Return the response prototype to use for an implicit OPTIONS request.
+     *
+     * @return ResponseInterface
+     */
+    private function getResponse()
+    {
+        if ($this->response) {
+            return $this->response;
+        }
+
+        return new Response('php://temp', StatusCode::STATUS_OK);
+    }
+}

--- a/test/Middleware/ImplicitHeadMiddlewareTest.php
+++ b/test/Middleware/ImplicitHeadMiddlewareTest.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive\Middleware;
+
+use Fig\Http\Message\RequestMethodInterface as RequestMethod;
+use Fig\Http\Message\StatusCodeInterface as StatusCode;
+use PHPUnit_Framework_TestCase as TestCase;
+use Prophecy\Argument;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
+use Zend\Diactoros\Response;
+use Zend\Expressive\Middleware\ImplicitHeadMiddleware;
+use Zend\Expressive\Router\Route;
+use Zend\Expressive\Router\RouteResult;
+
+class ImplicitHeadMiddlewareTest extends TestCase
+{
+    public function testReturnsResultOfNextOnNonHeadRequests()
+    {
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn(RequestMethod::METHOD_GET);
+
+        $response = $this->prophesize(ResponseInterface::class)->reveal();
+
+        $next = function ($req, $res) use ($request, $response) {
+            $this->assertSame($request->reveal(), $req);
+            $this->assertSame($response, $res);
+            return $res;
+        };
+
+        $middleware = new ImplicitHeadMiddleware();
+        $result = $middleware($request->reveal(), $response, $next);
+
+        $this->assertSame($response, $result);
+    }
+
+    public function testReturnsResultOfNextWhenNoRouteResultPresentInRequest()
+    {
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn(RequestMethod::METHOD_HEAD);
+        $request->getAttribute(RouteResult::class, false)->willReturn(false);
+
+        $response = $this->prophesize(ResponseInterface::class)->reveal();
+
+        $next = function ($req, $res) use ($request, $response) {
+            $this->assertSame($request->reveal(), $req);
+            $this->assertSame($response, $res);
+            return $res;
+        };
+
+        $middleware = new ImplicitHeadMiddleware();
+        $result = $middleware($request->reveal(), $response, $next);
+
+        $this->assertSame($response, $result);
+    }
+
+    public function testReturnsResultOfNextWhenRouteResultDoesNotComposeRoute()
+    {
+        $result = $this->prophesize(RouteResult::class);
+        $result->getMatchedRoute()->willReturn(null);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn(RequestMethod::METHOD_HEAD);
+        $request->getAttribute(RouteResult::class, false)->will([$result, 'reveal']);
+
+        $response = $this->prophesize(ResponseInterface::class)->reveal();
+
+        $next = function ($req, $res) use ($request, $response) {
+            $this->assertSame($request->reveal(), $req);
+            $this->assertSame($response, $res);
+            return $res;
+        };
+
+        $middleware = new ImplicitHeadMiddleware();
+        $result = $middleware($request->reveal(), $response, $next);
+
+        $this->assertSame($response, $result);
+    }
+
+    public function testReturnsResultOfNextWhenRouteSupportsHeadExplicitly()
+    {
+        $route = $this->prophesize(Route::class);
+        $route->implicitHead()->willReturn(false);
+
+        $result = $this->prophesize(RouteResult::class);
+        $result->getMatchedRoute()->will([$route, 'reveal']);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn(RequestMethod::METHOD_HEAD);
+        $request->getAttribute(RouteResult::class, false)->will([$result, 'reveal']);
+
+        $response = $this->prophesize(ResponseInterface::class)->reveal();
+
+        $next = function ($req, $res) use ($request, $response) {
+            $this->assertSame($request->reveal(), $req);
+            $this->assertSame($response, $res);
+            return $res;
+        };
+
+        $middleware = new ImplicitHeadMiddleware();
+        $result = $middleware($request->reveal(), $response, $next);
+
+        $this->assertSame($response, $result);
+    }
+
+    public function testReturnsNewResponseWhenRouteImplicitlySupportsHeadAndDoesNotSupportGet()
+    {
+        $route = $this->prophesize(Route::class);
+        $route->implicitHead()->willReturn(true);
+        $route->allowsMethod(RequestMethod::METHOD_GET)->willReturn(false);
+
+        $result = $this->prophesize(RouteResult::class);
+        $result->getMatchedRoute()->will([$route, 'reveal']);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn(RequestMethod::METHOD_HEAD);
+        $request->getAttribute(RouteResult::class, false)->will([$result, 'reveal']);
+
+        $response = $this->prophesize(ResponseInterface::class)->reveal();
+
+        $next = function ($req, $res) {
+            $this->fail('Next invoked when it should not have been');
+        };
+
+        $middleware = new ImplicitHeadMiddleware();
+        $result = $middleware($request->reveal(), $response, $next);
+
+        $this->assertInstanceOf(Response::class, $result);
+        $this->assertEquals(StatusCode::STATUS_OK, $result->getStatusCode());
+        $this->assertEquals('', (string) $result->getBody());
+    }
+
+    public function testReturnsComposedResponseWhenPresentWhenRouteImplicitlySupportsHeadAndDoesNotSupportGet()
+    {
+        $route = $this->prophesize(Route::class);
+        $route->implicitHead()->willReturn(true);
+        $route->allowsMethod(RequestMethod::METHOD_GET)->willReturn(false);
+
+        $result = $this->prophesize(RouteResult::class);
+        $result->getMatchedRoute()->will([$route, 'reveal']);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn(RequestMethod::METHOD_HEAD);
+        $request->getAttribute(RouteResult::class, false)->will([$result, 'reveal']);
+
+        $response = $this->prophesize(ResponseInterface::class)->reveal();
+
+        $next = function ($req, $res) {
+            $this->fail('Next invoked when it should not have been');
+        };
+
+        $expected = new Response();
+        $middleware = new ImplicitHeadMiddleware($expected);
+        $result = $middleware($request->reveal(), $response, $next);
+
+        $this->assertSame($expected, $result);
+    }
+
+    public function testInvokesNextWhenRouteImplicitlySupportsHeadAndSupportsGet()
+    {
+        $route = $this->prophesize(Route::class);
+        $route->implicitHead()->willReturn(true);
+        $route->allowsMethod(RequestMethod::METHOD_GET)->willReturn(true);
+
+        $result = $this->prophesize(RouteResult::class);
+        $result->getMatchedRoute()->will([$route, 'reveal']);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn(RequestMethod::METHOD_HEAD);
+        $request->getAttribute(RouteResult::class, false)->will([$result, 'reveal']);
+        $request->withMethod(RequestMethod::METHOD_GET)->will([$request, 'reveal']);
+
+        $response = $this->prophesize(ResponseInterface::class);
+        $response
+            ->withBody(Argument::that(function ($body) {
+                $this->assertInstanceOf(StreamInterface::class, $body);
+                $this->assertEquals('', (string) $body);
+                return true;
+            }))
+            ->will([$response, 'reveal']);
+
+        $next = function ($req, $res) use ($request, $response) {
+            $this->assertSame($request->reveal(), $req);
+            $this->assertSame($response->reveal(), $res);
+            return $res;
+        };
+
+        $middleware = new ImplicitHeadMiddleware();
+        $result = $middleware($request->reveal(), $response->reveal(), $next);
+
+        $this->assertSame($response->reveal(), $result);
+    }
+}

--- a/test/Middleware/ImplicitOptionsMiddlewareTest.php
+++ b/test/Middleware/ImplicitOptionsMiddlewareTest.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive\Middleware;
+
+use Fig\Http\Message\RequestMethodInterface as RequestMethod;
+use Fig\Http\Message\StatusCodeInterface as StatusCode;
+use PHPUnit_Framework_TestCase as TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Zend\Diactoros\Response;
+use Zend\Expressive\Middleware\ImplicitOptionsMiddleware;
+use Zend\Expressive\Router\Route;
+use Zend\Expressive\Router\RouteResult;
+
+class ImplicitOptionsMiddlewareTest extends TestCase
+{
+    public function testNonOptionsRequestInvokesNext()
+    {
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn(RequestMethod::METHOD_GET);
+        $request->getAttribute(RouteResult::class, false)->shouldNotBeCalled();
+
+        $response = $this->prophesize(ResponseInterface::class)->reveal();
+
+        $next = function ($req, $res) use ($request, $response) {
+            $this->assertSame($request->reveal(), $req);
+            $this->assertSame($response, $res);
+            return $response;
+        };
+
+        $middleware = new ImplicitOptionsMiddleware();
+        $result = $middleware($request->reveal(), $response, $next);
+        $this->assertSame($response, $result);
+    }
+
+    public function testMissingRouteResultInvokesNext()
+    {
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn(RequestMethod::METHOD_OPTIONS);
+        $request->getAttribute(RouteResult::class, false)->willReturn(false);
+
+        $response = $this->prophesize(ResponseInterface::class)->reveal();
+
+        $next = function ($req, $res) use ($request, $response) {
+            $this->assertSame($request->reveal(), $req);
+            $this->assertSame($response, $res);
+            return $response;
+        };
+
+        $middleware = new ImplicitOptionsMiddleware();
+        $result = $middleware($request->reveal(), $response, $next);
+        $this->assertSame($response, $result);
+    }
+
+    public function testMissingRouteInRouteResultInvokesNext()
+    {
+        $result = $this->prophesize(RouteResult::class);
+        $result->getMatchedRoute()->willReturn(null);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn(RequestMethod::METHOD_OPTIONS);
+        $request->getAttribute(RouteResult::class, false)->will([$result, 'reveal']);
+
+        $response = $this->prophesize(ResponseInterface::class)->reveal();
+
+        $next = function ($req, $res) use ($request, $response) {
+            $this->assertSame($request->reveal(), $req);
+            $this->assertSame($response, $res);
+            return $response;
+        };
+
+        $middleware = new ImplicitOptionsMiddleware();
+        $result = $middleware($request->reveal(), $response, $next);
+        $this->assertSame($response, $result);
+    }
+
+    public function testOptionsRequestWhenRouteDefinesOptionsInvokesNext()
+    {
+        $route = $this->prophesize(Route::class);
+        $route->implicitOptions()->willReturn(false);
+
+        $result = $this->prophesize(RouteResult::class);
+        $result->getMatchedRoute()->will([$route, 'reveal']);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn(RequestMethod::METHOD_OPTIONS);
+        $request->getAttribute(RouteResult::class, false)->will([$result, 'reveal']);
+
+        $response = $this->prophesize(ResponseInterface::class)->reveal();
+
+        $next = function ($req, $res) use ($request, $response) {
+            $this->assertSame($request->reveal(), $req);
+            $this->assertSame($response, $res);
+            return $response;
+        };
+
+        $middleware = new ImplicitOptionsMiddleware();
+        $result = $middleware($request->reveal(), $response, $next);
+        $this->assertSame($response, $result);
+    }
+
+    public function testWhenNoResponseProvidedToConstructorImplicitOptionsRequestCreatesResponse()
+    {
+        $allowedMethods = ['GET', 'POST'];
+
+        $route = $this->prophesize(Route::class);
+        $route->implicitOptions()->willReturn(true);
+        $route->getAllowedMethods()->willReturn($allowedMethods);
+
+        $result = $this->prophesize(RouteResult::class);
+        $result->getMatchedRoute()->will([$route, 'reveal']);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn(RequestMethod::METHOD_OPTIONS);
+        $request->getAttribute(RouteResult::class, false)->will([$result, 'reveal']);
+
+        $response = $this->prophesize(ResponseInterface::class)->reveal();
+
+        $next = function ($req, $res) use ($request, $response) {
+            $this->fail('Next reached when it should not be');
+        };
+
+        $middleware = new ImplicitOptionsMiddleware();
+        $result = $middleware($request->reveal(), $response, $next);
+        $this->assertInstanceOf(Response::class, $result);
+        $this->assertEquals(StatusCode::STATUS_OK, $result->getStatusCode());
+        $this->assertEquals(implode(',', $allowedMethods), $result->getHeaderLine('Allow'));
+    }
+
+    public function testInjectsAllowHeaderInResponseProvidedToConstructorDuringOptionsRequest()
+    {
+        $allowedMethods = ['GET', 'POST'];
+
+        $route = $this->prophesize(Route::class);
+        $route->implicitOptions()->willReturn(true);
+        $route->getAllowedMethods()->willReturn($allowedMethods);
+
+        $result = $this->prophesize(RouteResult::class);
+        $result->getMatchedRoute()->will([$route, 'reveal']);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn(RequestMethod::METHOD_OPTIONS);
+        $request->getAttribute(RouteResult::class, false)->will([$result, 'reveal']);
+
+        $response = $this->prophesize(ResponseInterface::class)->reveal();
+
+        $next = function ($req, $res) use ($request, $response) {
+            $this->fail('Next reached when it should not be');
+        };
+
+        $expected = $this->prophesize(ResponseInterface::class);
+        $expected->withHeader('Allow', implode(',', $allowedMethods))->will([$expected, 'reveal']);
+
+        $middleware = new ImplicitOptionsMiddleware($expected->reveal());
+        $result = $middleware($request->reveal(), $response, $next);
+        $this->assertSame($expected->reveal(), $result);
+    }
+}

--- a/test/RouteMiddlewareTest.php
+++ b/test/RouteMiddlewareTest.php
@@ -9,6 +9,8 @@
 
 namespace ZendTest\Expressive;
 
+use Fig\Http\Message\RequestMethodInterface as RequestMethod;
+use Fig\Http\Message\StatusCodeInterface as StatusCode;
 use PHPUnit_Framework_TestCase as TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
@@ -17,6 +19,7 @@ use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequest;
 use Zend\Expressive\Application;
 use Zend\Expressive\Exception\InvalidMiddlewareException;
+use Zend\Expressive\Middleware;
 use Zend\Expressive\Router\AuraRouter;
 use Zend\Expressive\Router\FastRouteRouter;
 use Zend\Expressive\Router\RouteResult;
@@ -489,10 +492,20 @@ class RouteMiddlewareTest extends TestCase
 
     public function routerAdaptersForHttpMethods()
     {
-        foreach ($this->routerAdapters() as $adapter) {
+        $allMethods = [
+            RequestMethod::METHOD_GET,
+            RequestMethod::METHOD_POST,
+            RequestMethod::METHOD_PUT,
+            RequestMethod::METHOD_DELETE,
+            RequestMethod::METHOD_PATCH,
+            RequestMethod::METHOD_HEAD,
+            RequestMethod::METHOD_OPTIONS,
+        ];
+        foreach ($this->routerAdapters() as $adapterName => $adapter) {
             $adapter = array_pop($adapter);
-            foreach (['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS'] as $method) {
-                yield [$adapter, $method];
+            foreach ($allMethods as $method) {
+                $name = sprintf('%s-%s', $adapterName, $method);
+                yield $name => [$adapter, $method];
             }
         }
     }
@@ -520,6 +533,131 @@ class RouteMiddlewareTest extends TestCase
             return $app->dispatchMiddleware($request, $response, $next);
         });
         $this->assertEquals('Middleware', (string) $result->getBody());
+    }
+
+    public function allowedMethod()
+    {
+        return [
+            'aura-head'          => [AuraRouter::class, RequestMethod::METHOD_HEAD],
+            'aura-options'       => [AuraRouter::class, RequestMethod::METHOD_OPTIONS],
+            'fast-route-head'    => [FastRouteRouter::class, RequestMethod::METHOD_HEAD],
+            'fast-route-options' => [FastRouteRouter::class, RequestMethod::METHOD_OPTIONS],
+            'zf2-head'           => [ZendRouter::class, RequestMethod::METHOD_HEAD],
+            'zf2-options'        => [ZendRouter::class, RequestMethod::METHOD_OPTIONS],
+        ];
+    }
+
+    public function notAllowedMethod()
+    {
+        return [
+            'aura-get'          => [AuraRouter::class, RequestMethod::METHOD_GET],
+            'aura-post'         => [AuraRouter::class, RequestMethod::METHOD_POST],
+            'aura-put'          => [AuraRouter::class, RequestMethod::METHOD_PUT],
+            'aura-delete'       => [AuraRouter::class, RequestMethod::METHOD_DELETE],
+            'aura-patch'        => [AuraRouter::class, RequestMethod::METHOD_PATCH],
+            'fast-route-post'   => [FastRouteRouter::class, RequestMethod::METHOD_POST],
+            'fast-route-put'    => [FastRouteRouter::class, RequestMethod::METHOD_PUT],
+            'fast-route-delete' => [FastRouteRouter::class, RequestMethod::METHOD_DELETE],
+            'fast-route-patch'  => [FastRouteRouter::class, RequestMethod::METHOD_PATCH],
+            'zf2-get'           => [ZendRouter::class, RequestMethod::METHOD_GET],
+            'zf2-post'          => [ZendRouter::class, RequestMethod::METHOD_POST],
+            'zf2-put'           => [ZendRouter::class, RequestMethod::METHOD_PUT],
+            'zf2-delete'        => [ZendRouter::class, RequestMethod::METHOD_DELETE],
+            'zf2-patch'         => [ZendRouter::class, RequestMethod::METHOD_PATCH],
+        ];
+    }
+
+    /**
+     * @dataProvider allowedMethod
+     *
+     * @param string $adapter
+     * @param string $method
+     */
+    public function testAllowedMethodsWhenOnlyPutMethodSet($adapter, $method)
+    {
+        $app = new Application(new $adapter);
+        $app->pipeRoutingMiddleware();
+        $app->pipe(new Middleware\ImplicitHeadMiddleware());
+        $app->pipe(new Middleware\ImplicitOptionsMiddleware());
+        $app->pipeDispatchMiddleware();
+
+        // Add a PUT route
+        $app->put('/foo', function ($req, $res, $next) {
+            $res->getBody()->write('Middleware');
+            return $res;
+        });
+
+        $next = function ($req, $res) {
+            return $res;
+        };
+
+        $request  = new ServerRequest(['REQUEST_METHOD' => $method], [], '/foo', $method);
+        $response = new Response();
+        $result   = $app($request, $response, $next);
+
+        $this->assertEquals(StatusCode::STATUS_OK, $result->getStatusCode());
+        $this->assertEquals('', (string) $result->getBody());
+    }
+
+    /**
+     * @dataProvider allowedMethod
+     *
+     * @param string $adapter
+     * @param string $method
+     */
+    public function testAllowedMethodsWhenNoHttpMethodsSet($adapter, $method)
+    {
+        $app = new Application(new $adapter);
+        $app->pipeRoutingMiddleware();
+        $app->pipe(new Middleware\ImplicitHeadMiddleware());
+        $app->pipe(new Middleware\ImplicitOptionsMiddleware());
+        $app->pipeDispatchMiddleware();
+
+        // Add a route with empty array - NO HTTP methods
+        $app->route('/foo', function ($req, $res, $next) {
+            $res->getBody()->write('Middleware');
+            return $res;
+        }, []);
+
+        $next = function ($req, $res) {
+            return $res;
+        };
+
+        $request  = new ServerRequest(['REQUEST_METHOD' => $method], [], '/foo', $method);
+        $response = new Response();
+        $result   = $app($request, $response, $next);
+
+        $this->assertEquals(StatusCode::STATUS_OK, $result->getStatusCode());
+        $this->assertEquals('', (string) $result->getBody());
+    }
+
+    /**
+     * @dataProvider notAllowedMethod
+     *
+     * @param string $adapter
+     * @param string $method
+     */
+    public function testNotAllowedMethodWhenNoHttpMethodsSet($adapter, $method)
+    {
+        $app = new Application(new $adapter);
+
+        // Add a route with empty array - NO HTTP methods
+        $app->route('/foo', function ($req, $res, $next) {
+            $res->getBody()->write('Middleware');
+            return $res;
+        }, []);
+
+        $next = function ($req, $res) {
+            return $res;
+        };
+
+        $request  = new ServerRequest(['REQUEST_METHOD' => $method], [], '/foo', $method);
+        $response = new Response();
+        $result   = $app->routeMiddleware($request, $response, function ($request, $response) use ($app, $next) {
+            return $app->dispatchMiddleware($request, $response, $next);
+        });
+        $this->assertEquals(StatusCode::STATUS_METHOD_NOT_ALLOWED, $result->getStatusCode());
+        $this->assertNotContains('Middleware', (string) $result->getBody());
     }
 
     /**


### PR DESCRIPTION
Updates zend-expressive-router dependency to 1.3.2+, and related new versions of router implementations to those supporting that version.

This patch also introduces two new classes, `Zend\Expressive\Middleware\ImplicitHeadMiddleware` and `ImplicitOptionsMiddleware`. These can be placed after the routing middleware, but before the dispatch middleware, in order to handle HEAD and OPTIONS requests when the matched `Route` does not explicitly support them. In each case, they trigger only when:

- the method is the one they are specifically interested in;
- the request composes a `RouteResult` attribute;
- the `RouteResult` composes a `Route` instance (per the changes in zend-expressive-router and the various implementations);
- the `Route` instance indicates that the method is only supported implicitly.

Additionally, for routes supporting `GET` requests, the `ImplicitHeadMiddleware` will dispatch the next middleware in the layer, using `GET` as the request method, and ensure the returned response has an empty body.

This approach ensures that if a route _explicitly_ supports the given method, then the matched middleware is dispatched as normal.

Fixes #398