### PR TITLE
Do not emit deprecation notices for 405 errors

### DIFF
--- a/.docheader
+++ b/.docheader
@@ -1,5 +1,5 @@
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) %regexp:(20\d{2}-)?%%year% Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) %regexp:(20\d{2}-)20\d{2}% Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */

--- a/src/Application.php
+++ b/src/Application.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -423,6 +423,10 @@ class Application extends MiddlewarePipe implements Router\RouteResultSubjectInt
             if ($result->isMethodFailure()) {
                 $response = $response->withStatus(405)
                     ->withHeader('Allow', implode(',', $result->getAllowedMethods()));
+
+                // Need to swallow deprecation notices, as this is how 405 errors
+                // are reported in the 1.0 series.
+                $this->swallowDeprecationNotices();
                 return $next($request, $response, 405);
             }
             return $next($request, $response);

--- a/src/Exception/MissingDependencyException.php
+++ b/src/Exception/MissingDependencyException.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/RouteMiddlewareTest.php
+++ b/test/RouteMiddlewareTest.php
@@ -1,9 +1,7 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/RouteMiddlewareTest.php
+++ b/test/RouteMiddlewareTest.php
@@ -13,6 +13,7 @@ use PHPUnit_Framework_TestCase as TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\ResponseInterface;
+use SplQueue;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequest;
 use Zend\Expressive\Application;
@@ -23,6 +24,8 @@ use Zend\Expressive\Router\RouteResult;
 use Zend\Expressive\Router\RouteResultObserverInterface;
 use Zend\Expressive\Router\RouterInterface;
 use Zend\Expressive\Router\ZendRouter;
+use Zend\Stratigility\Next;
+use Zend\Stratigility\Route;
 
 class RouteMiddlewareTest extends TestCase
 {
@@ -58,6 +61,44 @@ class RouteMiddlewareTest extends TestCase
             $this->assertEquals(405, $response->getStatusCode());
             return $response;
         };
+
+        $app  = $this->getApplication();
+        $test = $app->routeMiddleware($request, $response, $next);
+        $this->assertInstanceOf(ResponseInterface::class, $test);
+        $this->assertEquals(405, $test->getStatusCode());
+        $allow = $test->getHeaderLine('Allow');
+        $this->assertContains('GET', $allow);
+        $this->assertContains('POST', $allow);
+    }
+
+    /**
+     * @todo Remove for 1.1.0. In that version, you either raise throwables, or
+     *     you opt in to the legacy error handling, and understand you will receive
+     *     deprecation notices.
+     * @group 419
+     */
+    public function testRoutingFailureDueToHttpMethodCallsNextWithoutEmittingDeprecationNotice()
+    {
+        $request  = new ServerRequest();
+        $response = new Response();
+        $result   = RouteResult::fromRouteFailure(['GET', 'POST']);
+
+        $this->router->match($request)->willReturn($result);
+
+        $route = new Route('/', function ($error, $request, $response, $next) {
+            $this->assertEquals(405, $error);
+            $this->assertEquals(405, $response->getStatusCode());
+            return $response;
+        });
+
+        $queue = new SplQueue();
+        $queue->enqueue($route);
+
+        $done = function ($request, $response, $error = false) {
+            $this->fail('Should not reach final handler, but did');
+        };
+
+        $next = new Next($queue, $done);
 
         $app  = $this->getApplication();
         $test = $app->routeMiddleware($request, $response, $next);

--- a/test/RouteMiddlewareTest.php
+++ b/test/RouteMiddlewareTest.php
@@ -22,6 +22,8 @@ use Zend\Expressive\Router\RouteResult;
 use Zend\Expressive\Router\RouteResultObserverInterface;
 use Zend\Expressive\Router\RouterInterface;
 use Zend\Expressive\Router\ZendRouter;
+use Zend\Stratigility\Http\Request as StratigilityRequest;
+use Zend\Stratigility\Http\Response as StratigilityResponse;
 use Zend\Stratigility\Next;
 use Zend\Stratigility\Route;
 
@@ -77,8 +79,9 @@ class RouteMiddlewareTest extends TestCase
      */
     public function testRoutingFailureDueToHttpMethodCallsNextWithoutEmittingDeprecationNotice()
     {
-        $request  = new ServerRequest();
-        $response = new Response();
+        // Stratigility request/response required for this test, due to usage of Next instance.
+        $request  = new StratigilityRequest(new ServerRequest());
+        $response = new StratigilityResponse(new Response());
         $result   = RouteResult::fromRouteFailure(['GET', 'POST']);
 
         $this->router->match($request)->willReturn($result);

--- a/test/WhoopsErrorHandlerTest.php
+++ b/test/WhoopsErrorHandlerTest.php
@@ -15,6 +15,7 @@ use Prophecy\Argument;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
+use ReflectionClass;
 use Whoops\Handler\Handler;
 use Whoops\Handler\PrettyPageHandler;
 use Whoops\Run as Whoops;
@@ -29,7 +30,17 @@ class WhoopsErrorHandlerTest extends TestCase
 {
     public function getPrettyPageHandler()
     {
-        return $this->prophesize(PrettyPageHandler::class);
+        $handler = $this->prophesize(PrettyPageHandler::class);
+
+        // whoops 2.1.5 introduced a new method, which the runner calls when
+        // invoked; as such, we need to test if this method is present and mock
+        // a request to it if present.
+        $r = new ReflectionClass(PrettyPageHandler::class);
+        if ($r->hasMethod('contentType')) {
+            $handler->contentType()->willReturn('text/html');
+        }
+
+        return $handler;
     }
 
     public function testInstantiationRequiresWhoopsAndPageHandler()

--- a/test/WhoopsErrorHandlerTest.php
+++ b/test/WhoopsErrorHandlerTest.php
@@ -1,9 +1,7 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
  * @see       http://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 


### PR DESCRIPTION
As reported in #419, when using zend-stratigility 1.3 with Expressive 1.0, 405 errors are also now accompanied by deprecation notices. Since this is default functionality, we need to swallow those deprecation notices for now.