### PR TITLE
Updated to zend-expressive-router 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "filp/whoops": "^1.1 || ^2.0",
         "malukenho/docheader": "^0.1.5",
         "mockery/mockery": "^0.9.5",
-        "phpunit/phpunit": "^5.7",
+        "phpunit/phpunit": "^5.7.1",
         "zendframework/zend-coding-standard": "~1.0.0",
         "zendframework/zend-expressive-aurarouter": "^2.0",
         "zendframework/zend-expressive-fastroute": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         "container-interop/container-interop": "^1.1",
         "psr/http-message": "^1.0",
         "zendframework/zend-diactoros": "^1.1",
-        "zendframework/zend-expressive-router": "^1.3.2",
-        "zendframework/zend-expressive-template": "^1.0.1",
+        "zendframework/zend-expressive-router": "^2.0",
+        "zendframework/zend-expressive-template": "^1.0.4",
         "zendframework/zend-stratigility": "^1.3.1",
         "fig/http-message-util": "^1.1"
     },
@@ -29,11 +29,11 @@
         "filp/whoops": "^1.1 || ^2.0",
         "malukenho/docheader": "^0.1.5",
         "mockery/mockery": "^0.9.5",
-        "phpunit/phpunit": "^5.0",
+        "phpunit/phpunit": "^5.7",
         "zendframework/zend-coding-standard": "~1.0.0",
-        "zendframework/zend-expressive-aurarouter": "^1.1.3",
-        "zendframework/zend-expressive-fastroute": "^1.3",
-        "zendframework/zend-expressive-zendrouter": "^1.3",
+        "zendframework/zend-expressive-aurarouter": "^2.0",
+        "zendframework/zend-expressive-fastroute": "^2.0",
+        "zendframework/zend-expressive-zendrouter": "^2.0",
         "zendframework/zend-servicemanager": "^2.6 || ^3.1.1"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "a533a5ab40513caedd7766fef7caf2b9",
-    "content-hash": "3c3ba352fa6b6dc9acef6d1e18e167e6",
+    "hash": "7eeba75086c5e78fef14e4f6e3b0ce74",
+    "content-hash": "b8a27a40f96f3e5f794353fbc591aab5",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -188,16 +188,16 @@
         },
         {
             "name": "zendframework/zend-diactoros",
-            "version": "1.3.7",
+            "version": "1.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-diactoros.git",
-                "reference": "969ff423d3f201da3ff718a5831bb999bb0669b0"
+                "reference": "d9c1fd7c4b024179d49faf367da544b4eef7cfe8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-diactoros/zipball/969ff423d3f201da3ff718a5831bb999bb0669b0",
-                "reference": "969ff423d3f201da3ff718a5831bb999bb0669b0",
+                "url": "https://api.github.com/repos/zendframework/zend-diactoros/zipball/d9c1fd7c4b024179d49faf367da544b4eef7cfe8",
+                "reference": "d9c1fd7c4b024179d49faf367da544b4eef7cfe8",
                 "shasum": ""
             },
             "require": {
@@ -209,7 +209,7 @@
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.6 || ^5.5",
-                "squizlabs/php_codesniffer": "^2.3.1"
+                "zendframework/zend-coding-standard": "~1.0.0"
             },
             "type": "library",
             "extra": {
@@ -234,7 +234,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2016-10-11 13:25:21"
+            "time": "2017-01-05 21:44:28"
         },
         {
             "name": "zendframework/zend-escaper",
@@ -282,16 +282,16 @@
         },
         {
             "name": "zendframework/zend-expressive-router",
-            "version": "1.3.2",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-expressive-router.git",
-                "reference": "50c9e4dff0cf65d9937c56b597c530e1bf5f8ef0"
+                "reference": "14f8e8e1ca6a0469779d9df2c569f420fc41bd01"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/50c9e4dff0cf65d9937c56b597c530e1bf5f8ef0",
-                "reference": "50c9e4dff0cf65d9937c56b597c530e1bf5f8ef0",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/14f8e8e1ca6a0469779d9df2c569f420fc41bd01",
+                "reference": "14f8e8e1ca6a0469779d9df2c569f420fc41bd01",
                 "shasum": ""
             },
             "require": {
@@ -312,8 +312,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev",
-                    "dev-develop": "2.0.x-dev"
+                    "dev-master": "2.0-dev",
+                    "dev-develop": "2.1-dev"
                 }
             },
             "autoload": {
@@ -333,20 +333,20 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2016-12-14 13:49:15"
+            "time": "2017-01-07 02:17:28"
         },
         {
             "name": "zendframework/zend-expressive-template",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-expressive-template.git",
-                "reference": "2aac4050ebcf9a2c883dc23cf74671da02a66a7b"
+                "reference": "23922f96b32ab6e64fc551ec06b81fd047828765"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-template/zipball/2aac4050ebcf9a2c883dc23cf74671da02a66a7b",
-                "reference": "2aac4050ebcf9a2c883dc23cf74671da02a66a7b",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-template/zipball/23922f96b32ab6e64fc551ec06b81fd047828765",
+                "reference": "23922f96b32ab6e64fc551ec06b81fd047828765",
                 "shasum": ""
             },
             "require": {
@@ -354,7 +354,7 @@
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.7",
-                "squizlabs/php_codesniffer": "^2.3"
+                "zendframework/zend-coding-standard": "~1.0.0"
             },
             "suggest": {
                 "zendframework/zend-expressive-platesrenderer": "^0.1 to use the Plates template renderer",
@@ -382,20 +382,20 @@
                 "expressive",
                 "template"
             ],
-            "time": "2016-01-28 15:44:23"
+            "time": "2017-01-11 18:42:34"
         },
         {
             "name": "zendframework/zend-stratigility",
-            "version": "1.3.1",
+            "version": "1.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-stratigility.git",
-                "reference": "c410d367bb85f0a3cca44f112957d0ee28895d19"
+                "reference": "ffbf29ceb92a9223b8383ea2b021b242591141d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-stratigility/zipball/c410d367bb85f0a3cca44f112957d0ee28895d19",
-                "reference": "c410d367bb85f0a3cca44f112957d0ee28895d19",
+                "url": "https://api.github.com/repos/zendframework/zend-stratigility/zipball/ffbf29ceb92a9223b8383ea2b021b242591141d2",
+                "reference": "ffbf29ceb92a9223b8383ea2b021b242591141d2",
                 "shasum": ""
             },
             "require": {
@@ -405,8 +405,8 @@
                 "zendframework/zend-escaper": "^2.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.7 || ^5.5",
-                "squizlabs/php_codesniffer": "^2.6.2",
+                "phpunit/phpunit": "^5.6",
+                "zendframework/zend-coding-standard": "~1.0.0",
                 "zendframework/zend-diactoros": "^1.0"
             },
             "suggest": {
@@ -435,7 +435,7 @@
                 "middleware",
                 "psr-7"
             ],
-            "time": "2016-11-11 00:16:05"
+            "time": "2017-01-05 22:22:10"
         }
     ],
     "packages-dev": [
@@ -543,16 +543,16 @@
         },
         {
             "name": "filp/whoops",
-            "version": "2.1.4",
+            "version": "2.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filp/whoops.git",
-                "reference": "3f5cbd0e6a2fc17bc40b0238025ef1ff4c8c3efa"
+                "reference": "2abce9d956589122c6443d6265f01cf7e9388e3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filp/whoops/zipball/3f5cbd0e6a2fc17bc40b0238025ef1ff4c8c3efa",
-                "reference": "3f5cbd0e6a2fc17bc40b0238025ef1ff4c8c3efa",
+                "url": "https://api.github.com/repos/filp/whoops/zipball/2abce9d956589122c6443d6265f01cf7e9388e3c",
+                "reference": "2abce9d956589122c6443d6265f01cf7e9388e3c",
                 "shasum": ""
             },
             "require": {
@@ -599,7 +599,7 @@
                 "whoops",
                 "zf2"
             ],
-            "time": "2016-10-11 15:32:23"
+            "time": "2016-12-26 16:13:31"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -698,16 +698,16 @@
         },
         {
             "name": "mockery/mockery",
-            "version": "0.9.6",
+            "version": "0.9.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/padraic/mockery.git",
-                "reference": "65d4ca18e15cb02eeb1e5336f884e46b9b905be0"
+                "reference": "4de7969f4664da3cef1ccd83866c9f59378c3371"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/padraic/mockery/zipball/65d4ca18e15cb02eeb1e5336f884e46b9b905be0",
-                "reference": "65d4ca18e15cb02eeb1e5336f884e46b9b905be0",
+                "url": "https://api.github.com/repos/padraic/mockery/zipball/4de7969f4664da3cef1ccd83866c9f59378c3371",
+                "reference": "4de7969f4664da3cef1ccd83866c9f59378c3371",
                 "shasum": ""
             },
             "require": {
@@ -759,7 +759,7 @@
                 "test double",
                 "testing"
             ],
-            "time": "2016-09-30 12:09:40"
+            "time": "2016-12-19 14:50:55"
         },
         {
             "name": "myclabs/deep-copy",
@@ -805,16 +805,16 @@
         },
         {
             "name": "nikic/fast-route",
-            "version": "v1.0.1",
+            "version": "v1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/FastRoute.git",
-                "reference": "8ea928195fa9b907f0d6e48312d323c1a13cc2af"
+                "reference": "f3dcf5130e634b6123d40727d612ec6aa4f61fb3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/FastRoute/zipball/8ea928195fa9b907f0d6e48312d323c1a13cc2af",
-                "reference": "8ea928195fa9b907f0d6e48312d323c1a13cc2af",
+                "url": "https://api.github.com/repos/nikic/FastRoute/zipball/f3dcf5130e634b6123d40727d612ec6aa4f61fb3",
+                "reference": "f3dcf5130e634b6123d40727d612ec6aa4f61fb3",
                 "shasum": ""
             },
             "require": {
@@ -844,7 +844,7 @@
                 "router",
                 "routing"
             ],
-            "time": "2016-06-12 19:08:51"
+            "time": "2016-10-20 17:36:47"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -1057,16 +1057,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "4.0.3",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "903fd6318d0a90b4770a009ff73e4a4e9c437929"
+                "reference": "c14196e64a78570034afd0b7a9f3757ba71c2a0a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/903fd6318d0a90b4770a009ff73e4a4e9c437929",
-                "reference": "903fd6318d0a90b4770a009ff73e4a4e9c437929",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c14196e64a78570034afd0b7a9f3757ba71c2a0a",
+                "reference": "c14196e64a78570034afd0b7a9f3757ba71c2a0a",
                 "shasum": ""
             },
             "require": {
@@ -1116,7 +1116,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-11-28 16:00:31"
+            "time": "2016-12-20 15:22:42"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1301,16 +1301,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.7.4",
+            "version": "5.7.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "af91da3f2671006ff5d0628023de3b7ac4d1ef09"
+                "reference": "50fd2be8f3e23e91da825f36f08e5f9633076ffe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/af91da3f2671006ff5d0628023de3b7ac4d1ef09",
-                "reference": "af91da3f2671006ff5d0628023de3b7ac4d1ef09",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/50fd2be8f3e23e91da825f36f08e5f9633076ffe",
+                "reference": "50fd2be8f3e23e91da825f36f08e5f9633076ffe",
                 "shasum": ""
             },
             "require": {
@@ -1379,7 +1379,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-12-13 16:19:44"
+            "time": "2016-12-28 07:18:51"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -2442,16 +2442,16 @@
         },
         {
             "name": "zendframework/zend-expressive-aurarouter",
-            "version": "1.1.3",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-expressive-aurarouter.git",
-                "reference": "e97009e4fd0f2d91d02c719bc94e60ea4fe461f2"
+                "reference": "f076b045481a931086d3b11eb7ebc3f0f66c041d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-aurarouter/zipball/e97009e4fd0f2d91d02c719bc94e60ea4fe461f2",
-                "reference": "e97009e4fd0f2d91d02c719bc94e60ea4fe461f2",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-aurarouter/zipball/f076b045481a931086d3b11eb7ebc3f0f66c041d",
+                "reference": "f076b045481a931086d3b11eb7ebc3f0f66c041d",
                 "shasum": ""
             },
             "require": {
@@ -2459,7 +2459,7 @@
                 "fig/http-message-util": "^1.1",
                 "php": "^5.6 || ^7.0",
                 "psr/http-message": "^1.0",
-                "zendframework/zend-expressive-router": "^1.3.2"
+                "zendframework/zend-expressive-router": "^2.0"
             },
             "require-dev": {
                 "malukenho/docheader": "^0.1.5",
@@ -2469,8 +2469,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1-dev",
-                    "dev-develop": "1.2-dev"
+                    "dev-master": "2.0-dev",
+                    "dev-develop": "2.1-dev"
                 }
             },
             "autoload": {
@@ -2491,20 +2491,20 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2016-12-15 23:09:06"
+            "time": "2017-01-11 21:59:35"
         },
         {
             "name": "zendframework/zend-expressive-fastroute",
-            "version": "1.3.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-expressive-fastroute.git",
-                "reference": "825c93ff72c0f629bb427a6da8ebfe9d4735c296"
+                "reference": "646ca5818f4a887f9111c1d815434155383fd508"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-fastroute/zipball/825c93ff72c0f629bb427a6da8ebfe9d4735c296",
-                "reference": "825c93ff72c0f629bb427a6da8ebfe9d4735c296",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-fastroute/zipball/646ca5818f4a887f9111c1d815434155383fd508",
+                "reference": "646ca5818f4a887f9111c1d815434155383fd508",
                 "shasum": ""
             },
             "require": {
@@ -2512,7 +2512,8 @@
                 "nikic/fast-route": "^1.0.0",
                 "php": "^5.6 || ^7.0",
                 "psr/http-message": "^1.0",
-                "zendframework/zend-expressive-router": "^1.3.2"
+                "zendframework/zend-expressive-router": "^2.0",
+                "zendframework/zend-stdlib": "^3.1"
             },
             "require-dev": {
                 "malukenho/docheader": "^0.1.5",
@@ -2522,8 +2523,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3-dev",
-                    "dev-develop": "1.4-dev"
+                    "dev-master": "2.0-dev",
+                    "dev-develop": "2.1-dev"
                 }
             },
             "autoload": {
@@ -2544,40 +2545,41 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2016-12-14 19:47:05"
+            "time": "2017-01-11 22:05:53"
         },
         {
             "name": "zendframework/zend-expressive-zendrouter",
-            "version": "1.3.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-expressive-zendrouter.git",
-                "reference": "b00ef3a314bbe92da0a33e42ef0c575ddd4a4ba9"
+                "reference": "4c0f356cb187120ce9c9f34e5863dad54bdf6050"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-zendrouter/zipball/b00ef3a314bbe92da0a33e42ef0c575ddd4a4ba9",
-                "reference": "b00ef3a314bbe92da0a33e42ef0c575ddd4a4ba9",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-zendrouter/zipball/4c0f356cb187120ce9c9f34e5863dad54bdf6050",
+                "reference": "4c0f356cb187120ce9c9f34e5863dad54bdf6050",
                 "shasum": ""
             },
             "require": {
                 "fig/http-message-util": "^1.1",
                 "php": "^5.6 || ^7.0",
                 "psr/http-message": "^1.0",
-                "zendframework/zend-expressive-router": "^1.3.2",
+                "zendframework/zend-expressive-router": "^2.0",
                 "zendframework/zend-psr7bridge": "^0.2.2",
                 "zendframework/zend-router": "^3.0"
             },
             "require-dev": {
                 "malukenho/docheader": "^0.1.5",
                 "phpunit/phpunit": "^4.8 || ^5.6",
-                "zendframework/zend-coding-standard": "~1.0.0"
+                "zendframework/zend-coding-standard": "~1.0.0",
+                "zendframework/zend-i18n": "^2.7"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3-dev",
-                    "dev-develop": "1.4-dev"
+                    "dev-master": "2.0-dev",
+                    "dev-develop": "2.1-dev"
                 }
             },
             "autoload": {
@@ -2598,7 +2600,7 @@
                 "psr-7",
                 "zf2"
             ],
-            "time": "2016-12-14 20:46:12"
+            "time": "2017-01-11 21:51:59"
         },
         {
             "name": "zendframework/zend-http",
@@ -2806,40 +2808,46 @@
         },
         {
             "name": "zendframework/zend-servicemanager",
-            "version": "3.1.1",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-servicemanager.git",
-                "reference": "f701b0d322741b0c8d8ca1288f249a49438029cd"
+                "reference": "596a2cde85a92c3366514ae0f55ea32ef59536ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-servicemanager/zipball/f701b0d322741b0c8d8ca1288f249a49438029cd",
-                "reference": "f701b0d322741b0c8d8ca1288f249a49438029cd",
+                "url": "https://api.github.com/repos/zendframework/zend-servicemanager/zipball/596a2cde85a92c3366514ae0f55ea32ef59536ac",
+                "reference": "596a2cde85a92c3366514ae0f55ea32ef59536ac",
                 "shasum": ""
             },
             "require": {
                 "container-interop/container-interop": "~1.0",
-                "php": "^5.5 || ^7.0"
+                "php": "^5.6 || ^7.0",
+                "zendframework/zend-stdlib": "^3.1"
             },
             "provide": {
                 "container-interop/container-interop-implementation": "^1.1"
             },
             "require-dev": {
+                "mikey179/vfsstream": "^1.6",
                 "ocramius/proxy-manager": "^1.0 || ^2.0",
                 "phpbench/phpbench": "^0.10.0",
                 "phpunit/phpunit": "^4.6 || ^5.2.10",
-                "squizlabs/php_codesniffer": "^2.5.1"
+                "zendframework/zend-coding-standard": "~1.0.0"
             },
             "suggest": {
                 "ocramius/proxy-manager": "ProxyManager 1.* to handle lazy initialization of services",
                 "zendframework/zend-stdlib": "zend-stdlib ^2.5 if you wish to use the MergeReplaceKey or MergeRemoveKey features in Config instances"
             },
+            "bin": [
+                "bin/generate-deps-for-config-factory",
+                "bin/generate-factory-for-class"
+            ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev",
-                    "dev-develop": "3.2-dev"
+                    "dev-master": "3.2-dev",
+                    "dev-develop": "3.3-dev"
                 }
             },
             "autoload": {
@@ -2857,7 +2865,7 @@
                 "servicemanager",
                 "zf"
             ],
-            "time": "2016-07-15 14:59:51"
+            "time": "2016-12-19 20:04:51"
         },
         {
             "name": "zendframework/zend-stdlib",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "7eeba75086c5e78fef14e4f6e3b0ce74",
-    "content-hash": "b8a27a40f96f3e5f794353fbc591aab5",
+    "hash": "beb6a1d3b9cc913871bed9099d18220c",
+    "content-hash": "680648c708daf301b46aae8f6bec8dee",
     "packages": [
         {
             "name": "container-interop/container-interop",

--- a/src/Application.php
+++ b/src/Application.php
@@ -429,15 +429,11 @@ class Application extends MiddlewarePipe
             return $next($request, $response);
         }
 
-        $middleware = $routeResult->getMatchedMiddleware();
-        if (! $middleware) {
-            throw new Exception\InvalidMiddlewareException(sprintf(
-                'The route %s does not have a middleware to dispatch',
-                $routeResult->getMatchedRouteName()
-            ));
-        }
+        $middleware = $this->prepareMiddleware(
+            $routeResult->getMatchedMiddleware(),
+            $this->container
+        );
 
-        $middleware = $this->prepareMiddleware($middleware, $this->container);
         return $middleware($request, $response, $next);
     }
 

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -1,9 +1,7 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
@@ -29,8 +27,8 @@ use Zend\Diactoros\ServerRequestFactory;
 use Zend\Expressive\Application;
 use Zend\Expressive\Emitter\EmitterStack;
 use Zend\Expressive\Exception;
-use Zend\Expressive\Router\Exception as RouterException;
 use Zend\Expressive\Exception\InvalidMiddlewareException;
+use Zend\Expressive\Router\Exception as RouterException;
 use Zend\Expressive\Router\Route;
 use Zend\Expressive\Router\RouteResult;
 use Zend\Expressive\Router\RouterInterface;
@@ -238,7 +236,7 @@ class ApplicationTest extends TestCase
         ];
 
         $request = new ServerRequest([], [], '/', 'GET');
-        $routeResult = RouteResult::fromRouteMatch(__METHOD__, $middleware, []);
+        $routeResult = RouteResult::fromRoute(new Route('/', $middleware, [], __METHOD__));
         $request = $request->withAttribute(RouteResult::class, $routeResult);
 
         $container = $this->mockContainerInterface();
@@ -265,7 +263,7 @@ class ApplicationTest extends TestCase
     public function testThrowsExceptionWhenDispatchingUncallableMiddleware($middleware)
     {
         $request = new ServerRequest([], [], '/', 'GET');
-        $routeResult = RouteResult::fromRouteMatch(__METHOD__, $middleware, []);
+        $routeResult = RouteResult::fromRoute(new Route('/', $middleware, [], __METHOD__));
         $request = $request->withAttribute(RouteResult::class, $routeResult);
 
         $this->getApp()->dispatchMiddleware($request, new Response(), function () {

--- a/test/RouteMiddlewareTest.php
+++ b/test/RouteMiddlewareTest.php
@@ -21,6 +21,7 @@ use Zend\Expressive\Exception\InvalidMiddlewareException;
 use Zend\Expressive\Middleware;
 use Zend\Expressive\Router\AuraRouter;
 use Zend\Expressive\Router\FastRouteRouter;
+use Zend\Expressive\Router\Route as ExpressiveRoute;
 use Zend\Expressive\Router\RouteResult;
 use Zend\Expressive\Router\RouteResultObserverInterface;
 use Zend\Expressive\Router\RouterInterface;
@@ -105,11 +106,10 @@ class RouteMiddlewareTest extends TestCase
             return $finalResponse;
         };
 
-        $result = RouteResult::fromRouteMatch(
+        $result = RouteResult::fromRoute(new ExpressiveRoute(
             '/foo',
-            $middleware,
-            []
-        );
+            $middleware
+        ));
 
         $this->router->match($request)->willReturn($result);
         $request = $request->withAttribute(RouteResult::class, $result);
@@ -123,56 +123,6 @@ class RouteMiddlewareTest extends TestCase
         $this->assertSame($finalResponse, $test);
     }
 
-    public function testRoutingSuccessWithoutMiddlewareRaisesExceptionInDispatch()
-    {
-        $request  = new ServerRequest();
-        $response = new Response();
-
-        $middleware = (object) [];
-
-        $result = RouteResult::fromRouteMatch(
-            '/foo',
-            false,
-            []
-        );
-
-        $this->router->match($request)->willReturn($result);
-        $request = $request->withAttribute(RouteResult::class, $result);
-
-        $next = function ($request, $response) {
-            $this->fail('Should not enter $next');
-        };
-
-        $app = $this->getApplication();
-        $this->setExpectedException(InvalidMiddlewareException::class, 'does not have');
-        $app->dispatchMiddleware($request, $response, $next);
-    }
-
-    public function testRoutingSuccessResolvingToNonCallableNonStringMiddlewareRaisesExceptionAtDispatch()
-    {
-        $request  = new ServerRequest();
-        $response = new Response();
-
-        $middleware = (object) [];
-
-        $result = RouteResult::fromRouteMatch(
-            '/foo',
-            $middleware,
-            []
-        );
-
-        $this->router->match($request)->willReturn($result);
-        $request = $request->withAttribute(RouteResult::class, $result);
-
-        $next = function ($request, $response) {
-            $this->fail('Should not enter $next');
-        };
-
-        $app = $this->getApplication();
-        $this->setExpectedException(InvalidMiddlewareException::class, 'callable');
-        $app->dispatchMiddleware($request, $response, $next);
-    }
-
     public function testRoutingSuccessResolvingToUninvokableMiddlewareRaisesExceptionAtDispatch()
     {
         $request  = new ServerRequest();
@@ -180,11 +130,10 @@ class RouteMiddlewareTest extends TestCase
 
         $middleware = (object) [];
 
-        $result = RouteResult::fromRouteMatch(
+        $result = RouteResult::fromRoute(new ExpressiveRoute(
             '/foo',
-            'not a class',
-            []
-        );
+            'not a class'
+        ));
 
         $this->router->match($request)->willReturn($result);
         $request = $request->withAttribute(RouteResult::class, $result);
@@ -204,11 +153,10 @@ class RouteMiddlewareTest extends TestCase
     {
         $request  = new ServerRequest();
         $response = new Response();
-        $result   = RouteResult::fromRouteMatch(
+        $result   = RouteResult::fromRoute(new ExpressiveRoute(
             '/foo',
-            __NAMESPACE__ . '\TestAsset\InvokableMiddleware',
-            []
-        );
+            __NAMESPACE__ . '\TestAsset\InvokableMiddleware'
+        ));
 
         $this->router->match($request)->willReturn($result);
         $request = $request->withAttribute(RouteResult::class, $result);
@@ -234,11 +182,10 @@ class RouteMiddlewareTest extends TestCase
             return $res->withHeader('X-Middleware', 'Invoked');
         };
 
-        $result = RouteResult::fromRouteMatch(
+        $result = RouteResult::fromRoute(new ExpressiveRoute(
             '/foo',
-            'TestAsset\Middleware',
-            []
-        );
+            'TestAsset\Middleware'
+        ));
 
         $this->router->match($request)->willReturn($result);
         $request = $request->withAttribute(RouteResult::class, $result);
@@ -708,7 +655,7 @@ class RouteMiddlewareTest extends TestCase
 
         $request  = new ServerRequest();
         $response = new Response();
-        $result   = RouteResult::fromRouteMatch('resource', $middleware, $matches);
+        $result   = RouteResult::fromRoute(new ExpressiveRoute('resource', $middleware), $matches);
 
         $this->router->match($request)->willReturn($result);
 


### PR DESCRIPTION
Updated the depedency on zend-expressive-router to `^2.0`, and, in development, each router implementation to that same constraint.

Doing so has an intersting side-effect: the route result is guaranteed to have valid middleware composed, as the result is created from a `Route` instance, which will raise an exception much earlier in cases of invalid middleware being passed during its own instantiation. This allowed removing two unit tests, as well as a conditional within `dispatchMiddleware()` for verifying we have callable middleware.