### PR TITLE
[Proposal] make Application::run() return a ResponseInterface

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -493,7 +493,9 @@ class Application extends MiddlewarePipe
      * the returned response using the composed emitter.
      *
      * @param null|ServerRequestInterface $request
-     * @param null|ResponseInterface $response
+     * @param null|ResponseInterface      $response
+     *
+     * @return ResponseInterface
      */
     public function run(ServerRequestInterface $request = null, ResponseInterface $response = null)
     {
@@ -501,12 +503,10 @@ class Application extends MiddlewarePipe
             $request  = $request ?: ServerRequestFactory::fromGlobals();
         } catch (InvalidArgumentException $e) {
             // Unable to parse uploaded files
-            $this->emitMarshalServerRequestException($e);
-            return;
+            return $this->emitMarshalServerRequestException($e);
         } catch (UnexpectedValueException $e) {
             // Invalid request method
-            $this->emitMarshalServerRequestException($e);
-            return;
+            return $this->emitMarshalServerRequestException($e);
         }
 
         $response = $response ?: new Response();
@@ -516,6 +516,8 @@ class Application extends MiddlewarePipe
 
         $emitter = $this->getEmitter();
         $emitter->emit($response);
+
+        return $response;
     }
 
     /**
@@ -625,7 +627,7 @@ class Application extends MiddlewarePipe
 
     /**
      * @var \Exception|\Throwable $exception
-     * @return void
+     * @return ResponseInterface
      */
     private function emitMarshalServerRequestException($exception)
     {
@@ -635,6 +637,8 @@ class Application extends MiddlewarePipe
         $response = $finalHandler(new ServerRequest(), $response, $exception);
         $emitter = $this->getEmitter();
         $emitter->emit($response);
+
+        return $response;
     }
 
     /**

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -730,4 +730,39 @@ class ApplicationTest extends TestCase
             $this->fail($e->getMessage());
         }
     }
+
+    /**
+     * @dataProvider superGlobalSetupProvider
+     *
+     * @param callable $setupSuperGlobals
+     */
+    public function testRunReturnsResponse(callable $setupSuperGlobals)
+    {
+        $setupSuperGlobals();
+
+        $finalHandler = function () {
+            return $this->prophesize(ResponseInterface::class)->reveal();
+        };
+
+        $emitter = $this->prophesize(EmitterInterface::class);
+        $app = new Application($this->router->reveal(), null, $finalHandler, $emitter->reveal());
+
+        $response = $app->run();
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    public function superGlobalSetupProvider()
+    {
+        return [
+            'all good' => [ function () {
+            } ],
+            'invalid files' => [ function () {
+                $_FILES = [ 'foobar' ];
+            } ],
+            'invalid protocol' => [ function () {
+                $_SERVER['SERVER_PROTOCOL'] = 'foobar';
+            } ],
+        ];
+    }
 }


### PR DESCRIPTION
Ok, I know some folks won't like it, but hey, proposals don't hurt.

I'd like to change `Zend\Expressive\Application` api so that `run()` **returns a Response**.

The main argument for it is so that functional testing is made easier, as it doesn't require stubbing the `EmitterInterface` and then inspect the response passed to it. The way I see it, the emitter is just an internal detail of `run()`, and as such I should be able to ignore it.

Also, there are other frameworks that do this (e.g. Slim), and some don't even output the response right away but do that during an entirely different method call.

Ultimately, I'd very much like if any test of any web application could be as simple as this:

```php
// setup
$app     = new App(/* etc */);
$request = new Request(/* etc */);

// exec
$response = $app->run($request); 

// assert
assertThat($response, /* etc */); 
```

Is there any compelling reason why `run()` should be void?