### PR TITLE
Mark deprecated functionality

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "zendframework/zend-diactoros": "^1.1",
         "zendframework/zend-expressive-router": "^1.1",
         "zendframework/zend-expressive-template": "^1.0.1",
-        "zendframework/zend-stratigility": ">=1.1.0 < 1.3.0 || >=1.3.1 <2.0.0"
+        "zendframework/zend-stratigility": "^1.3.3"
     },
     "require-dev": {
         "filp/whoops": "^1.1 || ^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "8e99a5ef4f9f8500dc14587de32a162e",
-    "content-hash": "1de54fe5d6df880378b1fe7e6951da6a",
+    "hash": "69901c9ec74908e9e1f4214ff9f9035b",
+    "content-hash": "4946f1b59faeea05ccf815a612b44331",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -334,16 +334,16 @@
         },
         {
             "name": "zendframework/zend-stratigility",
-            "version": "1.3.1",
+            "version": "1.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-stratigility.git",
-                "reference": "c410d367bb85f0a3cca44f112957d0ee28895d19"
+                "reference": "2c4120d2af215c8261a36e0bc3aa8e179e05e148"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-stratigility/zipball/c410d367bb85f0a3cca44f112957d0ee28895d19",
-                "reference": "c410d367bb85f0a3cca44f112957d0ee28895d19",
+                "url": "https://api.github.com/repos/zendframework/zend-stratigility/zipball/2c4120d2af215c8261a36e0bc3aa8e179e05e148",
+                "reference": "2c4120d2af215c8261a36e0bc3aa8e179e05e148",
                 "shasum": ""
             },
             "require": {
@@ -353,8 +353,8 @@
                 "zendframework/zend-escaper": "^2.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.7 || ^5.5",
-                "squizlabs/php_codesniffer": "^2.6.2",
+                "phpunit/phpunit": "^5.6",
+                "zendframework/zend-coding-standard": "~1.0.0",
                 "zendframework/zend-diactoros": "^1.0"
             },
             "suggest": {
@@ -383,7 +383,7 @@
                 "middleware",
                 "psr-7"
             ],
-            "time": "2016-11-11 00:16:05"
+            "time": "2017-01-23 22:59:03"
         }
     ],
     "packages-dev": [

--- a/src/Application.php
+++ b/src/Application.php
@@ -335,6 +335,13 @@ class Application extends MiddlewarePipe implements Router\RouteResultSubjectInt
      * Once middleware detection and wrapping (if necessary) is complete,
      * proxies to pipe().
      *
+     * @deprecated since 1.1.0; to remove in 2.0.0. Stratigility v1-style
+     *     "error middleware" (middleware with four arguments, the first of which
+     *     being an error) was deprecated in Stratigility 1.3, and support
+     *     removed in Stratigility 2.0. You can start using standard middleware
+     *     for error handling by calling `raiseThrowables()` on the `Application`
+     *     instance, and piping such middleware in an outer layer of your application.
+     *     For an example, see `Zend\Stratigility\Middleware\ErrorHandler`.
      * @param string|callable $path Either a URI path prefix, or middleware.
      * @param null|string|callable $middleware Middleware
      * @return self
@@ -410,6 +417,11 @@ class Application extends MiddlewarePipe implements Router\RouteResultSubjectInt
      * Allow header, and `$next()` is called with its `$error` argument set
      * to the value `405` (invoking the next error middleware).
      *
+     * @deprecated since 1.1.0; to remove in 2.0.0. This method is extracted to
+     *     its own dedicated middleware class starting in 2.0.0. If you are
+     *     manually piping this method into your application or middleware
+     *     pipelines, or overriding the method, you will need to update your
+     *     code when migrating to 2.0.
      * @param  ServerRequestInterface $request
      * @param  ResponseInterface $response
      * @param  callable $next
@@ -453,6 +465,11 @@ class Application extends MiddlewarePipe implements Router\RouteResultSubjectInt
      * Finally, it attempts to marshal the middleware, and dispatches it when
      * complete, return the response.
      *
+     * @deprecated since 1.1.0; to remove in 2.0.0. This method is extracted to
+     *     its own dedicated middleware class starting in 2.0.0. If you are
+     *     manually piping this method into your application or middleware
+     *     pipelines, or overriding the method, you will need to update your
+     *     code when migrating to 2.0.
      * @param ServerRequestInterface $request
      * @param ResponseInterface $response
      * @param callable $next
@@ -598,6 +615,9 @@ class Application extends MiddlewarePipe implements Router\RouteResultSubjectInt
     /**
      * Return the final handler to use during `run()` if the stack is exhausted.
      *
+     * @deprecated since 1.1.0; renamed to `getDefaultDelegate()` in version
+     *     2.0.0. If you are consuming this method, please update your code to call
+     *     getDefaultDelegate() instead.
      * @param null|ResponseInterface $response Response instance with which to seed the
      *     FinalHandler; used to determine if the response passed to the handler
      *     represents the original or final response state.
@@ -616,6 +636,20 @@ class Application extends MiddlewarePipe implements Router\RouteResultSubjectInt
         }
 
         return $this->finalHandler;
+    }
+
+    /**
+     * Return the default delegate to use during `run()` when the stack is exhausted.
+     *
+     * Provided as a forwards compatibility measure with version 2, and proxies
+     * to getFinalHandler(); please note that it does not accept any arguments,
+     * nor pass them on to that method.
+     *
+     * @return callable|null
+     */
+    public function getDefaultDelegate()
+    {
+        return $this->getFinalHandler();
     }
 
     /**

--- a/src/Container/Exception/InvalidArgumentException.php
+++ b/src/Container/Exception/InvalidArgumentException.php
@@ -9,6 +9,12 @@ namespace Zend\Expressive\Container\Exception;
 
 use Interop\Container\Exception\ContainerException;
 
+/**
+ * @deprecated since 1.1.0; to remove in 2.0.0. This exception is currently
+ *     thrown by `Zend\Expressive\Container\ApplicationFactory`; starting
+ *     in 2.0.0, that factory will instead throw
+ *     `Zend\Expressive\Exception\InvalidArgumentException`.
+ */
 class InvalidArgumentException extends \InvalidArgumentException implements
     ContainerException,
     ExceptionInterface

--- a/src/Container/Exception/NotFoundException.php
+++ b/src/Container/Exception/NotFoundException.php
@@ -12,6 +12,9 @@ use RuntimeException;
 
 /**
  * Exception indicating a service was not found in the container.
+ *
+ * @deprecated since 1.1.0; to remove in 2.0.0. This exception is not thrown
+ *     by any classes within Expressive at this time.
  */
 class NotFoundException extends RuntimeException implements
     ExceptionInterface,

--- a/src/Container/TemplatedErrorHandlerFactory.php
+++ b/src/Container/TemplatedErrorHandlerFactory.php
@@ -38,6 +38,13 @@ use Zend\Expressive\TemplatedErrorHandler;
  * </code>
  *
  * If any of the keys are missing, default values will be used.
+ *
+ * @deprecated since 1.1.0, to be removed in 2.0.0. The "final handler" concept
+ *     will be replaced with a "default delegate", which will be an
+ *     implementation of Interop\Http\ServerMiddleware\DelegateInterface that
+ *     returns a canned response. Expressive will provide tools to migrate your
+ *     code to use default delegates for 2.0; you will only need to manually
+ *     change your code if you are extending this class.
  */
 class TemplatedErrorHandlerFactory
 {

--- a/src/Container/WhoopsErrorHandlerFactory.php
+++ b/src/Container/WhoopsErrorHandlerFactory.php
@@ -60,6 +60,13 @@ use Whoops\Run as Whoops;
  * </code>
  *
  * All values are booleans; omission of any implies boolean false.
+ *
+ * @deprecated since 1.1.0, to be removed in 2.0.0. The "final handler" concept
+ *     will be replaced with a "default delegate", which will be an
+ *     implementation of Interop\Http\ServerMiddleware\DelegateInterface that
+ *     returns a canned response. Expressive will provide tools to migrate your
+ *     code to use default delegates for 2.0; you will only need to manually
+ *     change your code if you are extending this class.
  */
 class WhoopsErrorHandlerFactory
 {

--- a/src/ErrorMiddlewarePipe.php
+++ b/src/ErrorMiddlewarePipe.php
@@ -28,6 +28,14 @@ use Zend\Stratigility\Next;
  * It is not implemented as an extension of MiddlewarePipe, as that class
  * implements the MiddlewareInterface, which prevents its use as error
  * middleware.
+ *
+ * @deprecated since 1.1.0; to remove in 2.0.0. Stratigility 1.3 deprecates the
+ *     concept of "error middleware" (middleware accepting exactly four arguments
+ *     the first of which being an error) in favor of using standard middleware
+ *     for error handling; you can use `Zend\Stratigility\ErrorHandler` either
+ *     directly or as an example of how to implement such middleware. If you are
+ *     using Stratigility 1.3, you can enable such error handling by calling
+ *     `raiseThrowables()` on your `Application` instance.
  */
 class ErrorMiddlewarePipe
 {

--- a/src/TemplatedErrorHandler.php
+++ b/src/TemplatedErrorHandler.php
@@ -18,6 +18,13 @@ use Zend\Stratigility\Utils;
  * Provides the optional ability to render a template for each of 404 and
  * general error conditions. If no template renderer is provided, returns
  * empty responses with appropriate status codes.
+ *
+ * @deprecated since 1.1.0, to be removed in 2.0.0. The "final handler" concept
+ *     will be replaced with a "default delegate", which will be an
+ *     implementation of Interop\Http\ServerMiddleware\DelegateInterface that
+ *     returns a canned response. Expressive will provide tools to migrate your
+ *     code to use default delegates for 2.0; you will only need to manually
+ *     change your code if you are extending this class.
  */
 class TemplatedErrorHandler
 {

--- a/src/WhoopsErrorHandler.php
+++ b/src/WhoopsErrorHandler.php
@@ -20,6 +20,12 @@ use Whoops\Run as Whoops;
  * interface for navigating an exception stack trace.
  *
  * @see http://filp.github.io/whoops/
+ * @deprecated since 1.1.0, to be removed in 2.0.0. The "final handler" concept
+ *     will be replaced with a "default delegate", which will be an
+ *     implementation of Interop\Http\ServerMiddleware\DelegateInterface that
+ *     returns a canned response. Expressive will provide tools to migrate your
+ *     code to use default delegates for 2.0; you will only need to manually
+ *     change your code if you are extending this class.
  */
 class WhoopsErrorHandler extends TemplatedErrorHandler
 {


### PR DESCRIPTION
This patch marks a number of methods and classes as deprecated for an upcoming 1.1.0 version, based on features proposed in #428. These include:

- `Application::pipeErrorHandler()`
- `Application::routeMiddleware()`
- `Application::dispatchMiddleware()`
- `Application::getFinalHandler()` (this patch provides `getDefaultDelegate()` as a forwards-compatibility measure)
- `Container\InvalidArgumentException`
- `Container\NotFoundException`
- `Container\TemplatedErrorHandlerFactory`
- `Container\WhoopsErrorHandlerFactory`
- `ErrorMiddlewarePipe`
- `TemplatedErrorHandler`
- `WhoopsErrorHandler`

Do *not* merge until #428 is accepted to develop.