### PR TITLE
Allow expressive-router ^2.0 as well as ^1.1 (Expressive 1.1)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "container-interop/container-interop": "^1.1",
         "psr/http-message": "^1.0",
         "zendframework/zend-diactoros": "^1.1",
-        "zendframework/zend-expressive-router": "^1.1",
+        "zendframework/zend-expressive-router": "^1.1 || ^2.0",
         "zendframework/zend-expressive-template": "^1.0.1",
         "zendframework/zend-stratigility": "^1.3.3"
     },
@@ -28,9 +28,9 @@
         "filp/whoops": "^1.1 || ^2.0",
         "phpunit/phpunit": "^4.7",
         "zendframework/zend-coding-standard": "~1.0.0",
-        "zendframework/zend-expressive-aurarouter": "^1.0",
-        "zendframework/zend-expressive-fastroute": "^1.0",
-        "zendframework/zend-expressive-zendrouter": "^1.0",
+        "zendframework/zend-expressive-aurarouter": "^1.0 || ^2.0",
+        "zendframework/zend-expressive-fastroute": "^1.0 || ^2.0",
+        "zendframework/zend-expressive-zendrouter": "^1.0 || ^2.0",
         "zendframework/zend-servicemanager": "^2.6",
         "malukenho/docheader": "^0.1.5",
         "mockery/mockery": "^0.9.5"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "a44373a0533c1cf95e45247d4626d5ed",
-    "content-hash": "4190a9cbac2bd14afaf0a8f80a5dd3ff",
+    "content-hash": "cd9893366211788934efc7413b51592c",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -32,7 +31,7 @@
                 "MIT"
             ],
             "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
-            "time": "2014-12-30 15:22:37"
+            "time": "2014-12-30T15:22:37+00:00"
         },
         {
             "name": "fig/http-message-util",
@@ -82,7 +81,7 @@
                 "request",
                 "response"
             ],
-            "time": "2017-02-06 19:24:13"
+            "time": "2017-02-06T19:24:13+00:00"
         },
         {
             "name": "http-interop/http-middleware",
@@ -134,7 +133,7 @@
                 "request",
                 "response"
             ],
-            "time": "2016-09-25 13:30:27"
+            "time": "2016-09-25T13:30:27+00:00"
         },
         {
             "name": "psr/http-message",
@@ -184,7 +183,7 @@
                 "request",
                 "response"
             ],
-            "time": "2016-08-06 14:39:51"
+            "time": "2016-08-06T14:39:51+00:00"
         },
         {
             "name": "zendframework/zend-diactoros",
@@ -234,7 +233,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2017-01-23 04:53:24"
+            "time": "2017-01-23T04:53:24+00:00"
         },
         {
             "name": "zendframework/zend-escaper",
@@ -278,7 +277,7 @@
                 "escaper",
                 "zf2"
             ],
-            "time": "2016-06-30 19:48:38"
+            "time": "2016-06-30T19:48:38+00:00"
         },
         {
             "name": "zendframework/zend-expressive-router",
@@ -333,7 +332,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2016-12-14 13:49:15"
+            "time": "2016-12-14T13:49:15+00:00"
         },
         {
             "name": "zendframework/zend-expressive-template",
@@ -382,7 +381,7 @@
                 "expressive",
                 "template"
             ],
-            "time": "2017-01-11 18:42:34"
+            "time": "2017-01-11T18:42:34+00:00"
         },
         {
             "name": "zendframework/zend-stratigility",
@@ -435,7 +434,7 @@
                 "middleware",
                 "psr-7"
             ],
-            "time": "2017-01-23 22:59:03"
+            "time": "2017-01-23T22:59:03+00:00"
         }
     ],
     "packages-dev": [
@@ -485,7 +484,7 @@
                 "router",
                 "routing"
             ],
-            "time": "2016-10-03 21:48:40"
+            "time": "2016-10-03T21:48:40+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -539,7 +538,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14 21:17:01"
+            "time": "2015-06-14T21:17:01+00:00"
         },
         {
             "name": "filp/whoops",
@@ -599,7 +598,7 @@
                 "whoops",
                 "zf2"
             ],
-            "time": "2016-12-26 16:13:31"
+            "time": "2016-12-26T16:13:31+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -644,7 +643,7 @@
             "keywords": [
                 "test"
             ],
-            "time": "2015-05-11 14:41:42"
+            "time": "2015-05-11T14:41:42+00:00"
         },
         {
             "name": "malukenho/docheader",
@@ -694,7 +693,7 @@
                 "code standard",
                 "license"
             ],
-            "time": "2016-11-17 16:46:05"
+            "time": "2016-11-17T16:46:05+00:00"
         },
         {
             "name": "mockery/mockery",
@@ -759,7 +758,7 @@
                 "test double",
                 "testing"
             ],
-            "time": "2016-12-19 14:50:55"
+            "time": "2016-12-19T14:50:55+00:00"
         },
         {
             "name": "nikic/fast-route",
@@ -802,7 +801,7 @@
                 "router",
                 "routing"
             ],
-            "time": "2017-01-19 11:35:12"
+            "time": "2017-01-19T11:35:12+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -856,7 +855,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2015-12-27 11:43:31"
+            "time": "2015-12-27T11:43:31+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -901,7 +900,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2016-09-30 07:12:33"
+            "time": "2016-09-30T07:12:33+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -948,7 +947,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-11-25 06:54:22"
+            "time": "2016-11-25T06:54:22+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -1011,7 +1010,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-11-21 14:58:47"
+            "time": "2016-11-21T14:58:47+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1073,7 +1072,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06 15:47:00"
+            "time": "2015-10-06T15:47:00+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1120,7 +1119,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03 07:40:28"
+            "time": "2016-10-03T07:40:28+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -1161,7 +1160,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -1205,7 +1204,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2016-05-12 18:03:57"
+            "time": "2016-05-12T18:03:57+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -1254,7 +1253,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2016-11-15 14:06:22"
+            "time": "2016-11-15T14:06:22+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -1326,7 +1325,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-02-06 05:18:07"
+            "time": "2017-02-06T05:18:07+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -1382,7 +1381,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-10-02 06:51:40"
+            "time": "2015-10-02T06:51:40+00:00"
         },
         {
             "name": "psr/log",
@@ -1429,7 +1428,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10 12:19:37"
+            "time": "2016-10-10T12:19:37+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -1493,7 +1492,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2017-01-29 09:50:25"
+            "time": "2017-01-29T09:50:25+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -1545,7 +1544,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08 07:14:41"
+            "time": "2015-12-08T07:14:41+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -1595,7 +1594,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-08-18 05:49:44"
+            "time": "2016-08-18T05:49:44+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -1662,7 +1661,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-06-17 09:04:28"
+            "time": "2016-06-17T09:04:28+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -1713,7 +1712,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12 03:26:01"
+            "time": "2015-10-12T03:26:01+00:00"
         },
         {
             "name": "sebastian/recursion-context",
@@ -1766,7 +1765,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-11-11 19:50:13"
+            "time": "2015-11-11T19:50:13+00:00"
         },
         {
             "name": "sebastian/version",
@@ -1801,7 +1800,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21 13:59:46"
+            "time": "2015-06-21T13:59:46+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -1879,7 +1878,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-02-02 03:30:00"
+            "time": "2017-02-02T03:30:00+00:00"
         },
         {
             "name": "symfony/console",
@@ -1942,7 +1941,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2017-02-06 12:04:21"
+            "time": "2017-02-06T12:04:21+00:00"
         },
         {
             "name": "symfony/debug",
@@ -1999,7 +1998,7 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2017-01-28 02:37:08"
+            "time": "2017-01-28T02:37:08+00:00"
         },
         {
             "name": "symfony/finder",
@@ -2048,7 +2047,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2017-01-02 20:32:22"
+            "time": "2017-01-02T20:32:22+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -2107,7 +2106,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14 01:06:16"
+            "time": "2016-11-14T01:06:16+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -2162,7 +2161,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-01-21 17:06:35"
+            "time": "2017-01-21T17:06:35+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -2212,7 +2211,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-11-23 20:04:58"
+            "time": "2016-11-23T20:04:58+00:00"
         },
         {
             "name": "zendframework/zend-coding-standard",
@@ -2241,7 +2240,7 @@
                 "Coding Standard",
                 "zf"
             ],
-            "time": "2016-11-09 21:30:43"
+            "time": "2016-11-09T21:30:43+00:00"
         },
         {
             "name": "zendframework/zend-expressive-aurarouter",
@@ -2294,7 +2293,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2016-12-15 23:09:06"
+            "time": "2016-12-15T23:09:06+00:00"
         },
         {
             "name": "zendframework/zend-expressive-fastroute",
@@ -2347,7 +2346,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2016-12-14 19:47:05"
+            "time": "2016-12-14T19:47:05+00:00"
         },
         {
             "name": "zendframework/zend-expressive-zendrouter",
@@ -2401,7 +2400,7 @@
                 "psr-7",
                 "zf2"
             ],
-            "time": "2016-12-14 20:46:12"
+            "time": "2016-12-14T20:46:12+00:00"
         },
         {
             "name": "zendframework/zend-http",
@@ -2451,7 +2450,7 @@
                 "http",
                 "zf2"
             ],
-            "time": "2017-01-31 14:41:02"
+            "time": "2017-01-31T14:41:02+00:00"
         },
         {
             "name": "zendframework/zend-loader",
@@ -2495,7 +2494,7 @@
                 "loader",
                 "zf2"
             ],
-            "time": "2015-06-03 14:05:47"
+            "time": "2015-06-03T14:05:47+00:00"
         },
         {
             "name": "zendframework/zend-psr7bridge",
@@ -2544,7 +2543,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2016-05-10 21:44:39"
+            "time": "2016-05-10T21:44:39+00:00"
         },
         {
             "name": "zendframework/zend-router",
@@ -2605,7 +2604,7 @@
                 "routing",
                 "zf2"
             ],
-            "time": "2016-05-31 20:47:48"
+            "time": "2016-05-31T20:47:48+00:00"
         },
         {
             "name": "zendframework/zend-servicemanager",
@@ -2657,7 +2656,7 @@
                 "servicemanager",
                 "zf2"
             ],
-            "time": "2016-12-19 19:14:29"
+            "time": "2016-12-19T19:14:29+00:00"
         },
         {
             "name": "zendframework/zend-stdlib",
@@ -2702,7 +2701,7 @@
                 "stdlib",
                 "zf2"
             ],
-            "time": "2016-09-13 14:38:50"
+            "time": "2016-09-13T14:38:50+00:00"
         },
         {
             "name": "zendframework/zend-uri",
@@ -2749,7 +2748,7 @@
                 "uri",
                 "zf2"
             ],
-            "time": "2016-02-17 22:38:51"
+            "time": "2016-02-17T22:38:51+00:00"
         },
         {
             "name": "zendframework/zend-validator",
@@ -2820,7 +2819,7 @@
                 "validator",
                 "zf2"
             ],
-            "time": "2017-01-29 17:24:24"
+            "time": "2017-01-29T17:24:24+00:00"
         }
     ],
     "aliases": [],

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -45,6 +45,7 @@ use ZendTest\Expressive\TestAsset\InvokableMiddleware;
 class ApplicationTest extends TestCase
 {
     use ContainerTrait;
+    use RouteResultTrait;
 
     public function setUp()
     {
@@ -239,7 +240,7 @@ class ApplicationTest extends TestCase
         ];
 
         $request = new ServerRequest([], [], '/', 'GET');
-        $routeResult = RouteResult::fromRouteMatch(__METHOD__, $middleware, []);
+        $routeResult = $this->getRouteResult(__METHOD__, $middleware, []);
         $request = $request->withAttribute(RouteResult::class, $routeResult);
 
         $container = $this->mockContainerInterface();
@@ -266,7 +267,7 @@ class ApplicationTest extends TestCase
     public function testThrowsExceptionWhenDispatchingUncallableMiddleware($middleware)
     {
         $request = new ServerRequest([], [], '/', 'GET');
-        $routeResult = RouteResult::fromRouteMatch(__METHOD__, $middleware, []);
+        $routeResult = $this->getRouteResult(__METHOD__, $middleware, []);
         $request = $request->withAttribute(RouteResult::class, $routeResult);
 
         $this->getApp()->dispatchMiddleware($request, new Response(), function () {

--- a/test/RouteMiddlewareTest.php
+++ b/test/RouteMiddlewareTest.php
@@ -30,6 +30,7 @@ use Zend\Stratigility\Route;
 class RouteMiddlewareTest extends TestCase
 {
     use ContainerTrait;
+    use RouteResultTrait;
 
     /** @var ObjectProphecy */
     protected $container;
@@ -141,11 +142,7 @@ class RouteMiddlewareTest extends TestCase
             return $finalResponse;
         };
 
-        $result = RouteResult::fromRouteMatch(
-            '/foo',
-            $middleware,
-            []
-        );
+        $result = $this->getRouteResult('/foo', $middleware, []);
 
         $this->router->match($request)->willReturn($result);
         $request = $request->withAttribute(RouteResult::class, $result);
@@ -164,13 +161,7 @@ class RouteMiddlewareTest extends TestCase
         $request  = new ServerRequest();
         $response = new Response();
 
-        $middleware = (object) [];
-
-        $result = RouteResult::fromRouteMatch(
-            '/foo',
-            false,
-            []
-        );
+        $result = $this->getRouteResult('/foo', false, []);
 
         $this->router->match($request)->willReturn($result);
         $request = $request->withAttribute(RouteResult::class, $result);
@@ -191,11 +182,7 @@ class RouteMiddlewareTest extends TestCase
 
         $middleware = (object) [];
 
-        $result = RouteResult::fromRouteMatch(
-            '/foo',
-            $middleware,
-            []
-        );
+        $result = $this->getRouteResult('/foo', $middleware, []);
 
         $this->router->match($request)->willReturn($result);
         $request = $request->withAttribute(RouteResult::class, $result);
@@ -214,13 +201,7 @@ class RouteMiddlewareTest extends TestCase
         $request  = new ServerRequest();
         $response = new Response();
 
-        $middleware = (object) [];
-
-        $result = RouteResult::fromRouteMatch(
-            '/foo',
-            'not a class',
-            []
-        );
+        $result = $this->getRouteResult('/foo', 'not a class', []);
 
         $this->router->match($request)->willReturn($result);
         $request = $request->withAttribute(RouteResult::class, $result);
@@ -240,11 +221,7 @@ class RouteMiddlewareTest extends TestCase
     {
         $request  = new ServerRequest();
         $response = new Response();
-        $result   = RouteResult::fromRouteMatch(
-            '/foo',
-            __NAMESPACE__ . '\TestAsset\InvokableMiddleware',
-            []
-        );
+        $result   = $this->getRouteResult('/foo', TestAsset\InvokableMiddleware::class, []);
 
         $this->router->match($request)->willReturn($result);
         $request = $request->withAttribute(RouteResult::class, $result);
@@ -270,16 +247,12 @@ class RouteMiddlewareTest extends TestCase
             return $res->withHeader('X-Middleware', 'Invoked');
         };
 
-        $result = RouteResult::fromRouteMatch(
-            '/foo',
-            'TestAsset\Middleware',
-            []
-        );
+        $result = $this->getRouteResult('/foo', TestAsset\Middleware::class, []);
 
         $this->router->match($request)->willReturn($result);
         $request = $request->withAttribute(RouteResult::class, $result);
 
-        $this->injectServiceInContainer($this->container, 'TestAsset\Middleware', $middleware);
+        $this->injectServiceInContainer($this->container, TestAsset\Middleware::class, $middleware);
 
         $app = $this->getApplication();
 
@@ -609,7 +582,7 @@ class RouteMiddlewareTest extends TestCase
 
         $request  = new ServerRequest();
         $response = new Response();
-        $result   = RouteResult::fromRouteMatch('resource', $middleware, $matches);
+        $result   = $this->getRouteResult('resource', $middleware, $matches);
 
         $this->router->match($request)->willReturn($result);
 

--- a/test/RouteResultTrait.php
+++ b/test/RouteResultTrait.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive;
+
+use Zend\Expressive\Router\Route;
+use Zend\Expressive\Router\RouteResult;
+
+trait RouteResultTrait
+{
+    private function getRouteResult($name, $middleware, array $params)
+    {
+        if (method_exists(RouteResult::class, 'fromRouteMatch')) {
+            return RouteResult::fromRouteMatch($name, $middleware, $params);
+        }
+
+        $route = $this->prophesize(Route::class);
+        $route->getMiddleware()->willReturn($middleware);
+        $route->getPath()->willReturn($name);
+        $route->getName()->willReturn(null);
+
+        return RouteResult::fromRoute($route->reveal(), $params);
+    }
+}


### PR DESCRIPTION
Please see #434.

It is possible to use version 2.0 of libraries:
- zend-expressive-aurarouter
- zend-expressive-fastroute
- zend-expressive-zendrouter

