### PR TITLE
Respect JsonResponseHandler flags when false

### DIFF
--- a/src/Container/WhoopsFactory.php
+++ b/src/Container/WhoopsFactory.php
@@ -75,11 +75,11 @@ class WhoopsFactory
 
         $handler = new JsonResponseHandler();
 
-        if (isset($config['json_exceptions']['show_trace'])) {
+        if (isset($config['json_exceptions']['show_trace']) && true === $config['json_exceptions']['show_trace']) {
             $handler->addTraceToOutput(true);
         }
 
-        if (isset($config['json_exceptions']['ajax_only'])) {
+        if (isset($config['json_exceptions']['ajax_only']) && true === $config['json_exceptions']['ajax_only']) {
             if (method_exists(\Whoops\Util\Misc::class, 'isAjaxRequest')) {
                 // Whoops 2.x
                 if (! \Whoops\Util\Misc::isAjaxRequest()) {

--- a/test/Container/WhoopsFactoryTest.php
+++ b/test/Container/WhoopsFactoryTest.php
@@ -12,6 +12,7 @@ namespace ZendTest\Expressive\Container;
 use PHPUnit_Framework_TestCase as TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
 use ReflectionProperty;
+use Traversable;
 use Whoops\Handler\JsonResponseHandler;
 use Whoops\Handler\PrettyPageHandler;
 use Whoops\Run as Whoops;
@@ -76,33 +77,65 @@ class WhoopsFactoryTest extends TestCase
     }
 
     /**
-     * @depends testWillInjectJsonResponseHandlerIfConfigurationExpectsIt
+     * @depends      testWillInjectJsonResponseHandlerIfConfigurationExpectsIt
+     * @dataProvider provideConfig
+     *
+     * @param bool  $showsTrace
+     * @param bool  $isAjaxOnly
+     * @param bool  $requestIsAjax
      */
-    public function testJsonResponseHandlerCanBeConfigured()
+    public function testJsonResponseHandlerCanBeConfigured($showsTrace, $isAjaxOnly, $requestIsAjax)
     {
         // Set for Whoops 2.x json handler detection
-        $_SERVER['HTTP_X_REQUESTED_WITH'] = 'xmlhttprequest';
+        if ($requestIsAjax) {
+            $_SERVER['HTTP_X_REQUESTED_WITH'] = 'xmlhttprequest';
+        }
 
         $config = [
             'whoops' => [
                 'json_exceptions' => [
                     'display'    => true,
-                    'show_trace' => true,
-                    'ajax_only'  => true,
+                    'show_trace' => $showsTrace,
+                    'ajax_only'  => $isAjaxOnly,
                 ],
             ],
         ];
+
         $this->injectServiceInContainer($this->container, 'config', $config);
 
         $factory = $this->factory;
         $whoops  = $factory($this->container->reveal());
+        $handler = $whoops->popHandler();
 
-        $jsonHandler = $whoops->popHandler();
-        $this->assertInstanceOf(JsonResponseHandler::class, $jsonHandler);
-        $this->assertAttributeSame(true, 'returnFrames', $jsonHandler);
+        // If ajax only, not ajax request and Whoops 2, it does not inject JsonResponseHandler
+        if ($isAjaxOnly
+            && ! $requestIsAjax
+            && method_exists(\Whoops\Util\Misc::class, 'isAjaxRequest')
+        ) {
+            $this->assertInstanceOf(PrettyPageHandler::class, $handler);
 
-        if (method_exists($jsonHandler, 'onlyForAjaxRequests')) {
-            $this->assertAttributeSame(true, 'onlyForAjaxRequests', $jsonHandler);
+            // Skip remaining assertions
+            return;
         }
+
+        $this->assertAttributeSame($showsTrace, 'returnFrames', $handler);
+
+        if (method_exists($handler, 'onlyForAjaxRequests')) {
+            $this->assertAttributeSame($isAjaxOnly, 'onlyForAjaxRequests', $handler);
+        }
+    }
+
+    /**
+     * @return Traversable
+     */
+    public function provideConfig()
+    {
+        yield 'Shows trace' => [true, true, true];
+        yield 'Does not show trace' => [false, true, true];
+
+        yield 'Ajax only, request is ajax' => [true, true, true];
+        yield 'Ajax only, request is not ajax' => [true, true, false];
+
+        yield 'Not ajax only' => [true, false, false];
     }
 }


### PR DESCRIPTION
Currently, when you explicitly set the flags to false, it behaves as if it were true.