### PR TITLE
Added zimuel.it in expressive project list

### DIFF
--- a/doc/book/reference/expressive-projects.md
+++ b/doc/book/reference/expressive-projects.md
@@ -14,3 +14,4 @@ zend-expressive.
 - [mwop.net](https://mwop.net/) - [*source*](https://github.com/weierophinney/mwop.net)
 - [xtreamwayz.com](https://xtreamwayz.com/) - [*source*](https://github.com/xtreamwayz/xtreamwayz.com)
 - [alejandrocelaya.com](http://www.alejandrocelaya.com/) - [*source*](https://github.com/acelaya/website-expressive)
+- [zimuel.it](http://www.zimuel.it) - [*source*](https://github.com/ezimuel/zimuel.it)


### PR DESCRIPTION
This PR adds the [zimuel.it](http://www.zimuel.it) web site in the expressive project list under *Personal Sites* section of `reference/expressive-projects.md`.