### PR TITLE
#446 hotfix - Arg 2 of ApplicationFactory::injectRoutesAndPipeline() 

### DIFF
--- a/src/Container/ApplicationFactory.php
+++ b/src/Container/ApplicationFactory.php
@@ -515,10 +515,10 @@ class ApplicationFactory
      * Create default FinalHandler with options configured under the key final_handler.options.
      *
      * @param ContainerInterface $container
-     * @param array|\ArrayObject $config
+     * @param array $config
      * @return callable|FinalHandler
      */
-    private function marshalLegacyFinalHandler(ContainerInterface $container, $config)
+    private function marshalLegacyFinalHandler(ContainerInterface $container, array $config)
     {
         if ($container->has('Zend\Expressive\FinalHandler')) {
             return $container->get('Zend\Expressive\FinalHandler');

--- a/src/Container/ApplicationFactory.php
+++ b/src/Container/ApplicationFactory.php
@@ -7,6 +7,7 @@
 
 namespace Zend\Expressive\Container;
 
+use ArrayObject;
 use Interop\Container\ContainerInterface;
 use SplPriorityQueue;
 use Zend\Diactoros\Response\EmitterInterface;
@@ -156,6 +157,7 @@ class ApplicationFactory
     public function __invoke(ContainerInterface $container)
     {
         $config = $container->has('config') ? $container->get('config') : [];
+        $config = $config instanceof ArrayObject ? $config->getArrayCopy() : $config;
 
         $router = $container->has(RouterInterface::class)
             ? $container->get(RouterInterface::class)

--- a/test/Container/ApplicationFactoryIntegrationTest.php
+++ b/test/Container/ApplicationFactoryIntegrationTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\Expressive\Container;
 
+use ArrayObject;
 use PHPUnit_Framework_TestCase as TestCase;
 use Prophecy\Argument;
 use Psr\Http\Message\ServerRequestInterface;
@@ -50,7 +51,12 @@ class ApplicationFactoryIntegrationTest extends TestCase
         $this->injectServiceInContainer($this->container, EmitterInterface::class, $this->emitter->reveal());
     }
 
-    public function testConfiguredErrorMiddlewarePipeIsExecutedWhenMiddlewareCallsNextWithError()
+    /**
+     * @dataProvider configType
+     *
+     * @param string $type
+     */
+    public function testConfiguredErrorMiddlewarePipeIsExecutedWhenMiddlewareCallsNextWithError($type)
     {
         $always = function ($request, $response, $next) {
             $response = $next($request, $response);
@@ -121,6 +127,11 @@ class ApplicationFactoryIntegrationTest extends TestCase
                 ],
             ],
         ];
+
+        if ($type !== 'array') {
+            $config = new $type($config);
+        }
+
         $this->injectServiceInContainer($this->container, 'config', $config);
 
         $app = $this->factory->__invoke($this->container->reveal());
@@ -139,7 +150,12 @@ class ApplicationFactoryIntegrationTest extends TestCase
         $this->assertEquals('Error middleware called', (string) $response->getBody());
     }
 
-    public function testConfiguredErrorMiddlewareIsExecutedWhenMiddlewareCallsNextWithError()
+    /**
+     * @dataProvider configType
+     *
+     * @param string $type
+     */
+    public function testConfiguredErrorMiddlewareIsExecutedWhenMiddlewareCallsNextWithError($type)
     {
         $always = function ($request, $response, $next) {
             $response = $next($request, $response);
@@ -209,6 +225,11 @@ class ApplicationFactoryIntegrationTest extends TestCase
                 ],
             ],
         ];
+
+        if ($type !== 'array') {
+            $config = new $type($config);
+        }
+
         $this->injectServiceInContainer($this->container, 'config', $config);
 
         $app = $this->factory->__invoke($this->container->reveal());
@@ -225,5 +246,13 @@ class ApplicationFactoryIntegrationTest extends TestCase
         $this->assertTrue($response->hasHeader('X-Route-Result'));
         $this->assertEquals('needs-auth', $response->getHeaderLine('X-Route-Result'));
         $this->assertEquals('Error middleware called', (string) $response->getBody());
+    }
+
+    public function configType()
+    {
+        return [
+            [ArrayObject::class],
+            ['array'],
+        ];
     }
 }


### PR DESCRIPTION
Configuration passed into `ApplicationFactory::injectRoutesAndPipeline()` can be `ArrayObject` or `array`

Resolves #446 