### PR TITLE
Fix Argument 2 passed to injectRoutesAndPipeline()

### DIFF
--- a/src/Container/ApplicationFactory.php
+++ b/src/Container/ApplicationFactory.php
@@ -176,7 +176,7 @@ class ApplicationFactory
         }
 
         if (empty($config['zend-expressive']['programmatic_pipeline'])) {
-            $this->injectRoutesAndPipeline($app, $config);
+            $this->injectRoutesAndPipeline($app, $container);
         }
 
         return $app;
@@ -186,10 +186,11 @@ class ApplicationFactory
      * Injects routes and the middleware pipeline into the application.
      *
      * @param Application $app
-     * @param array $config
+     * @param ContainerInterface $container
      */
-    private function injectRoutesAndPipeline(Application $app, array $config)
+    private function injectRoutesAndPipeline(Application $app, ContainerInterface $container)
     {
+        $config = $container->has('config') ? $container->get('config') : [];
         $pipelineCreated = false;
 
         if (isset($config['middleware_pipeline']) && is_array($config['middleware_pipeline'])) {


### PR DESCRIPTION
Resolves #446

Argument 2 passed to Zend\Expressive\Container\ApplicationFactory::injectRoutesAndPipeline() must be of the type array,
object given

IMHO: `$config` is not an array.

@zendframework