### PR TITLE
Allow DispatchMiddleware to handle callables and service names

### DIFF
--- a/src/MarshalMiddlewareTrait.php
+++ b/src/MarshalMiddlewareTrait.php
@@ -52,7 +52,7 @@ trait MarshalMiddlewareTrait
         }
 
         if ($middleware === Application::DISPATCH_MIDDLEWARE) {
-            return new Middleware\DispatchMiddleware();
+            return new Middleware\DispatchMiddleware($router, $responsePrototype, $container);
         }
 
         if ($middleware instanceof ServerMiddlewareInterface) {

--- a/test/Application/MarshalMiddlewareTraitTest.php
+++ b/test/Application/MarshalMiddlewareTraitTest.php
@@ -91,12 +91,18 @@ class MarshalMiddlewareTraitTest extends TestCase
     {
         $middleware = $this->prepareMiddleware(Application::DISPATCH_MIDDLEWARE);
         $this->assertInstanceOf(Middleware\DispatchMiddleware::class, $middleware);
+        $this->assertAttributeSame($this->container->reveal(), 'container', $middleware);
+        $this->assertAttributeSame($this->router->reveal(), 'router', $middleware);
+        $this->assertAttributeSame($this->responsePrototype->reveal(), 'responsePrototype', $middleware);
     }
 
     public function testPreparingDispatchMiddlewareWithoutContainerReturnsDispatchMiddleware()
     {
         $middleware = $this->prepareMiddlewareWithoutContainer(Application::DISPATCH_MIDDLEWARE);
         $this->assertInstanceOf(Middleware\DispatchMiddleware::class, $middleware);
+        $this->assertAttributeEmpty('container', $middleware);
+        $this->assertAttributeSame($this->router->reveal(), 'router', $middleware);
+        $this->assertAttributeSame($this->responsePrototype->reveal(), 'responsePrototype', $middleware);
     }
 
     public function testPreparingInteropMiddlewareReturnsMiddlewareVerbatim()

--- a/test/Middleware/DispatchMiddlewareTest.php
+++ b/test/Middleware/DispatchMiddlewareTest.php
@@ -11,28 +11,43 @@ use Interop\Http\ServerMiddleware\DelegateInterface;
 use Interop\Http\ServerMiddleware\MiddlewareInterface as ServerMiddlewareInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Zend\Expressive\Middleware\DispatchMiddleware;
 use Zend\Expressive\Router\Route;
 use Zend\Expressive\Router\RouteResult;
+use Zend\Expressive\Router\RouterInterface;
 
 class DispatchMiddlewareTest extends TestCase
 {
+    /** @var ContainerInterface|ObjectProphecy */
+    private $container;
+
+    /** @var DelegateInterface|ObjectProphecy */
+    private $delegate;
+
     /** @var DispatchMiddleware */
     private $middleware;
 
     /** @var ServerRequestInterface|ObjectProphecy */
     private $request;
 
-    /** @var DelegateInterface|ObjectProphecy */
-    private $delegate;
+    /** @var ResponseInterface|ObjectProphecy */
+    private $responsePrototype;
 
     public function setUp()
     {
-        $this->middleware = new DispatchMiddleware();
-        $this->request    = $this->prophesize(ServerRequestInterface::class);
-        $this->delegate   = $this->prophesize(DelegateInterface::class);
+        $this->container         = $this->prophesize(ContainerInterface::class);
+        $this->responsePrototype = $this->prophesize(ResponseInterface::class);
+        $this->router            = $this->prophesize(RouterInterface::class);
+        $this->request           = $this->prophesize(ServerRequestInterface::class);
+        $this->delegate          = $this->prophesize(DelegateInterface::class);
+        $this->middleware        = new DispatchMiddleware(
+            $this->router->reveal(),
+            $this->responsePrototype->reveal(),
+            $this->container->reveal()
+        );
     }
 
     public function testInvokesDelegateIfRequestDoesNotContainRouteResult()
@@ -57,6 +72,51 @@ class DispatchMiddlewareTest extends TestCase
             ->willReturn($expected);
 
         $routeResult = RouteResult::fromRoute(new Route('/', $routedMiddleware->reveal()));
+
+        $this->request->getAttribute(RouteResult::class, false)->willReturn($routeResult);
+
+        $response = $this->middleware->process($this->request->reveal(), $this->delegate->reveal());
+
+        $this->assertSame($expected, $response);
+    }
+
+    /**
+     * @group 453
+     */
+    public function testCanDispatchCallableDoublePassMiddleware()
+    {
+        $this->delegate->process()->shouldNotBeCalled();
+
+        $expected = $this->prophesize(ResponseInterface::class)->reveal();
+        $routedMiddleware = function ($request, $response, $next) use ($expected) {
+            return $expected;
+        };
+
+        $routeResult = RouteResult::fromRoute(new Route('/', $routedMiddleware));
+
+        $this->request->getAttribute(RouteResult::class, false)->willReturn($routeResult);
+
+        $response = $this->middleware->process($this->request->reveal(), $this->delegate->reveal());
+
+        $this->assertSame($expected, $response);
+    }
+
+    /**
+     * @group 453
+     */
+    public function testCanDispatchMiddlewareServices()
+    {
+        $this->delegate->process()->shouldNotBeCalled();
+
+        $expected = $this->prophesize(ResponseInterface::class)->reveal();
+        $routedMiddleware = function ($request, $response, $next) use ($expected) {
+            return $expected;
+        };
+
+        $this->container->has('RoutedMiddleware')->willReturn(true);
+        $this->container->get('RoutedMiddleware')->willReturn($routedMiddleware);
+
+        $routeResult = RouteResult::fromRoute(new Route('/', 'RoutedMiddleware'));
 
         $this->request->getAttribute(RouteResult::class, false)->willReturn($routeResult);
 


### PR DESCRIPTION
Because `Zend\Expressive\Router\Route` is lenient in the middleware it composes, we cannot assume that the middleware composed is valid http-interop middleware in the dispatcher. As such, this patch does the following:

- Updates `DispatchMiddleware` to compose a router, response prototype, and container, as all are necessary for preparing interop middleware shims.
- Updates `DispatchMiddleware::process` to check if the middleware received is http-interop compatible; if not, it delegates to `MarshalMiddlewareTrait::prepareMiddleware()` to cast it to interop middleware.

This patch supercedes the approach from #454, and fixes #453.