### PR TITLE
Document Expressive v2 changes

### DIFF
--- a/doc/book/features/container/delegator-factories.md
+++ b/doc/book/features/container/delegator-factories.md
@@ -1,0 +1,65 @@
+# Delegator Factories
+
+- Since 2.0.
+
+Starting with the 2.0 version of the Expressive skeleton, we now support the
+concept of _delegator factories_, which allow decoration of services created by
+your dependency injection container, across all dependency injection containers
+supported by Expressive.
+
+_Delegator factories_ accept the following arguments:
+
+- The container itself;
+- The name of the service whose creation is being decrorated;
+- A callback that will produce the service being decorated.
+
+As an example, let's say we have a `UserRepository` class that composes some sort of
+event manager. We might want to attach listeners to that event manager, but not
+wish to alter the basic creation logic for the repository itself. As such, we
+might write a _delegator factory_ as follows:
+
+```php
+namespace Acme;
+
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+class UserRepositoryListenerDelegatorFactory
+{
+    /**
+     * @param ContainerInterface $container
+     * @param string $name
+     * @param callable $callback
+     * @return UserRepository
+     */
+    public function __invoke(ContainerInterface $container, $name, callable $callback)
+    {
+        $listener = new LoggerListener($container->get(LoggerInterface::class));
+        $repository = $callback();
+        $repository->getEventManager()->attach($listener);
+        return $repository;
+    }
+}
+```
+
+To notify the container about this delegator factory, we would add the following
+configuration to our application:
+
+```php
+'dependencies' => [
+    'delegators' => [
+        Acme\UserRepository::class => [
+            Acme\UserRepositoryListenerDelegatorFactory::class,
+        ],
+    ],
+],
+```
+
+Note that you specify delegator factories using the service name being decorated
+as the key, with an _array_ of delegator factories as a value. **You may attach
+multiple delegator factories to any given service**, which can be a very
+powerful feature.
+
+At the time of writing, this feature works for each of the Aura.Di, Pimple, and
+zend-servicemanager container implementations. Delegator factories have been
+supported with Pimple and zend-servicemanager since the 1.X series.

--- a/doc/book/features/helpers/url-helper.md
+++ b/doc/book/features/helpers/url-helper.md
@@ -64,6 +64,12 @@ Each method will raise an exception if:
   represents a matching failure.
 - The given `$routeName` is not defined in the router.
 
+> ### Signature changes
+>
+> The signature listed above is current as of version 3.0.0 of
+> zendframework/zend-expressive-helpers. Prior to that version, the helper only
+> accepted the route name and route parameters.
+
 ## Creating an instance
 
 In order to use the helper, you will need to instantiate it with the current

--- a/doc/book/features/router/interface.md
+++ b/doc/book/features/router/interface.md
@@ -76,6 +76,21 @@ Implementors should also read the following sections detailing the `Route` and
 `RouteResult` classes, to ensure that their implementations interoperate
 correctly.
 
+> ### generateUri() signature change in 2.0
+>
+> Prior to zendframework/zend-expressive-router 2.0.0, the signature of
+> `generateUri()` was:
+>
+> ```php
+> public function generateUri(
+>     string $name,
+>     array $substitutions = []
+> ) : string
+> ```
+> 
+> If you are targeting that version, you may still provide the `$options`
+> argument, but it will not be invoked.
+
 ## Routes
 
 Routes are defined via `Zend\Expressive\Router\Route`, and aggregate the

--- a/doc/book/features/template/twig.md
+++ b/doc/book/features/template/twig.md
@@ -127,3 +127,8 @@ return [
     ],
 ];
 ```
+
+When specifying the `twig.extensions` values, always use fully qualified class
+names or actual extension instances to ensure compatibility with any version of
+Twig used. Version 2 of Twig _requires_ that a fully qualified class name is
+used, and not a short-name alias.

--- a/doc/book/features/template/zend-view.md
+++ b/doc/book/features/template/zend-view.md
@@ -92,6 +92,10 @@ for doing so:
 In each case, the zend-view implementation will do a depth-first, recursive
 render in order to provide content within the selected layout.
 
+- Since 1.3: You may also pass a boolean `false` value to either
+  `addDefaultParam()` or via the template variables for the `layout` key; doing
+  so will disable the layout.
+
 ### Layout name passed to constructor
 
 ```php

--- a/doc/book/getting-started/skeleton.md
+++ b/doc/book/getting-started/skeleton.md
@@ -78,6 +78,16 @@ The development configuration is set in `config/autoload/development.local.php.d
 It also allows you to specify configuration and modules that should only be enabled 
 when in development, and not when in production.
 
+### Clear config cache
+
+Production settings are the default, which means enabling the configuration cache. 
+However, it must be easy for developers to clear the configuration cache. That's
+what this command does.
+
+```bash
+$ composer clear-config-cache
+```
+
 ### Testing Your Code
 
 [PHPUnit](https://github.com/sebastianbergmann/phpunit) and 

--- a/doc/book/getting-started/skeleton.md
+++ b/doc/book/getting-started/skeleton.md
@@ -44,12 +44,27 @@ $ composer serve
 This starts up a web server on localhost port 8080; browse to
 http://localhost:8080/ to see if your application responds correctly!
 
+> ### Setting a timeout
+>
+> Composer commands time out after 300 seconds (5 minutes). On Linux-based
+> systems, the `php -S` command that `composer serve` spawns continues running
+> as a background process, but on other systems halts when the timeout occurs.
+>
+> If you want the server to live longer, you can use the
+> `COMPOSER_PROCESS_TIMEOUT` environment variable when executing `composer
+> serve` to extend the timeout. As an example, the following will extend it
+> to a full day:
+>
+> ```bash
+> $ COMPOSER_PROCESS_TIMEOUT=86400 composer serve
+> ```
+
 ## Next Steps
 
 The skeleton makes the assumption that you will be writing your middleware as
 classes, and using configuration to map routes to middleware. It also provides a
 default structure for templates, if you choose to use them. Let's see how you
-can create first vanilla middleware, and then templated middleware.
+can create your first vanilla middleware, and templated middleware.
 
 ### Creating middleware
 
@@ -93,7 +108,6 @@ provide a message, which is then returned in an HTML response.
 Now we need to inform the application of this middleware, and indicate what
 path will invoke it. Open the file `config/autoload/dependencies.global.php`.
 Edit that file to add an _invokable_ entry for the new middleware:
-that file, e
 
 ```php
 return [
@@ -182,8 +196,8 @@ The above modifies the class to accept a renderer to the constructor, and then
 calls on it to render a template. Note that we no longer need to escape our
 target; the template takes care of that for us.
 
-How does the template renderer get into the action, however? The answer is
-dependency injection.
+How does the template renderer get into the action? The answer is dependency 
+injection.
 
 For the next part of the example, we'll be creating and wiring a factory for
 creating the `HelloAction` instance; the example assumes you used the default

--- a/doc/book/getting-started/skeleton.md
+++ b/doc/book/getting-started/skeleton.md
@@ -50,13 +50,12 @@ http://localhost:8080/ to see if your application responds correctly!
 > systems, the `php -S` command that `composer serve` spawns continues running
 > as a background process, but on other systems halts when the timeout occurs.
 >
-> If you want the server to live longer, you can use the
-> `COMPOSER_PROCESS_TIMEOUT` environment variable when executing `composer
-> serve` to extend the timeout. As an example, the following will extend it
-> to a full day:
+> If you want the server to live longer, you can set the global composer 
+> process-timeout (NOTE: This does affect all composer commands). As an example, 
+> the following will extend it to 8 hours:
 >
 > ```bash
-> $ COMPOSER_PROCESS_TIMEOUT=86400 composer serve
+> $ composer config -g process-timeout 28800
 > ```
 
 ## Development Tools

--- a/doc/book/getting-started/skeleton.md
+++ b/doc/book/getting-started/skeleton.md
@@ -6,7 +6,7 @@ The skeleton provides a generic structure for creating your applications, and
 prompts you to choose a router, dependency injection container, template
 renderer, and error handler from the outset.
 
-## 1. Create a new project
+## Create a new project
 
 First, we'll create a new project, using Composer's `create-project` command:
 
@@ -29,7 +29,7 @@ This will prompt you to choose:
 - An error handler. Whoops is a very nice option for development, as it gives
   you extensive, browseable information for exceptions and errors raised.
 
-## 2. Start a web server
+## Start a web server
 
 The Skeleton + Installer creates a full application structure that's ready-to-go
 when complete. You can test it out using [built-in web
@@ -136,7 +136,7 @@ namespace App\Action;
 use Interop\Http\ServerMiddleware\DelegateInterface;
 use Interop\Http\ServerMiddleware\MiddlewareInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Zend\Expressive\Response\HtmlResponse;
+use Zend\Diactoros\Response\HtmlResponse;
 
 class HelloAction implements MiddlewareInterface
 {

--- a/doc/book/getting-started/skeleton.md
+++ b/doc/book/getting-started/skeleton.md
@@ -59,6 +59,42 @@ http://localhost:8080/ to see if your application responds correctly!
 > $ COMPOSER_PROCESS_TIMEOUT=86400 composer serve
 > ```
 
+## Development Tools
+
+With skeleton version 2 we are shipping some tools to make development easier.
+
+### Development Mode
+
+[zf-development-mode](https://github.com/zfcampus/zf-development-mode) allows 
+you to enable and disable development mode from your cli.
+
+```bash
+$ composer development-enable  # enable development mode
+$ composer development-disable # disable development mode
+$ composer development-status  # show development status
+```
+
+The development configuration is set in `config/autoload/development.local.php.dist`.
+It also allows you to specify configuration and modules that should only be enabled 
+when in development, and not when in production.
+
+### Testing Your Code
+
+[PHPUnit](https://github.com/sebastianbergmann/phpunit) and 
+[PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) are installed. To
+execute tests and detect coding standards violations run this composer command: 
+
+```bash
+$ composer check
+```
+
+### Security Advisories
+
+We have included [security-advisories](https://github.com/Roave/SecurityAdvisories)
+to notify you about installed dependencies with known security vulnerabilities.
+Each time you run `composer update` or `composer install` it prevents installation of
+software with known and documented security issues.
+
 ## Next Steps
 
 The skeleton makes the assumption that you will be writing your middleware as

--- a/doc/book/getting-started/skeleton.md
+++ b/doc/book/getting-started/skeleton.md
@@ -275,6 +275,9 @@ This tool provides the following functionality:
   for the module from `composer.json`, and deregister its `ConfigProvider`, if
   found, from the application configuration.
 
+You can find out more about its features in the [command line tooling
+documentation](../reference/cli-tooling.md#modules).
+
 ## Adding Middleware
 
 The skeleton makes the assumption that you will be writing your middleware as

--- a/doc/book/getting-started/skeleton.md
+++ b/doc/book/getting-started/skeleton.md
@@ -97,6 +97,13 @@ execute tests and detect coding standards violations run this composer command:
 $ composer check
 ```
 
+### Component Installer
+
+The [zend-component-installer](https://zendframework.github.io/zend-component-installer/)
+is included by default. Whenever you add a component or module that exposes itself 
+as such, the plugin will prompt you, asking if and where you want to inject its
+configuration. This ensures that components are wired automatically for you.
+
 ### Security Advisories
 
 We have included [security-advisories](https://github.com/Roave/SecurityAdvisories)

--- a/doc/book/getting-started/standalone.md
+++ b/doc/book/getting-started/standalone.md
@@ -125,20 +125,27 @@ http://localhost:8080/ to see if your application responds correctly!
 > ```bash
 > $ composer serve
 > ```
->
+
 > ### Setting a timeout
 >
 > Composer commands time out after 300 seconds (5 minutes). On Linux-based
 > systems, the `php -S` command that `composer serve` spawns continues running
 > as a background process, but on other systems halts when the timeout occurs.
 >
-> If you want the server to live longer, you can set the global composer 
-> process-timeout (NOTE: This does affect all composer commands). As an example, 
-> the following will extend it to 8 hours:
+> If you want the server to live longer, you can set the composer
+> `process-timeout` configuration, which can be specified either local to your
+> project, or globally. As examples, each of the following set the timeout to 8
+> hours:
 >
 > ```bash
+> # Local to your project:
+> $ composer config process-timeout 28800
+> # Globally (all projects):
 > $ composer config -g process-timeout 28800
 > ```
+>
+> NOTE: This setting affects _all_ composer commands, including install, update,
+> and require operations, so be careful about resetting it, particularly globally.
 
 ## Next steps
 

--- a/doc/book/getting-started/standalone.md
+++ b/doc/book/getting-started/standalone.md
@@ -125,6 +125,21 @@ http://localhost:8080/ to see if your application responds correctly!
 > ```bash
 > $ composer serve
 > ```
+>
+> ### Setting a timeout
+>
+> Composer commands time out after 300 seconds (5 minutes). On Linux-based
+> systems, the `php -S` command that `composer serve` spawns continues running
+> as a background process, but on other systems halts when the timeout occurs.
+>
+> If you want the server to live longer, you can use the
+> `COMPOSER_PROCESS_TIMEOUT` environment variable when executing `composer
+> serve` to extend the timeout. As an example, the following will extend it
+> to a full day:
+>
+> ```bash
+> $ COMPOSER_PROCESS_TIMEOUT=86400 composer serve
+> ```
 
 ## Next steps
 

--- a/doc/book/getting-started/standalone.md
+++ b/doc/book/getting-started/standalone.md
@@ -132,13 +132,12 @@ http://localhost:8080/ to see if your application responds correctly!
 > systems, the `php -S` command that `composer serve` spawns continues running
 > as a background process, but on other systems halts when the timeout occurs.
 >
-> If you want the server to live longer, you can use the
-> `COMPOSER_PROCESS_TIMEOUT` environment variable when executing `composer
-> serve` to extend the timeout. As an example, the following will extend it
-> to a full day:
+> If you want the server to live longer, you can set the global composer 
+> process-timeout (NOTE: This does affect all composer commands). As an example, 
+> the following will extend it to 8 hours:
 >
 > ```bash
-> $ COMPOSER_PROCESS_TIMEOUT=86400 composer serve
+> $ composer config -g process-timeout 28800
 > ```
 
 ## Next steps

--- a/doc/book/index.html
+++ b/doc/book/index.html
@@ -1,9 +1,8 @@
 <div class="container">
   <div class="jumbotron">
     <h1>Expressive</h1>
-    
-    <p>PSR-7 Middleware in Minutes</p>
 
+    <p>PSR-7 Middleware in Minutes</p>
 
     <pre><code class="language-bash">$ composer create-project zendframework/zend-expressive-skeleton expressive</code></pre>
   </div>
@@ -30,7 +29,7 @@
         <h3>Middleware</h3>
 
         <p>
-          Create <a href="https://github.com/zendframework/zend-stratigility/blob/master/doc/book/middleware.md">middleware</a>
+          Create <a href="https://docs.zendframework.com/zend-stratigility/middleware/">middleware</a>
           applications, using as many layers as you want, and the architecture
           your project needs.
         </p>

--- a/doc/book/reference/cli-tooling.md
+++ b/doc/book/reference/cli-tooling.md
@@ -1,0 +1,225 @@
+# Command Line Tooling
+
+Expressive offers a number of tools for assisting in project development. This
+page catalogues each.
+
+## Development Mode
+
+- Since 2.0.
+
+The package [zfcampus/zf-development-mode](https://github.com/zfcampus/zf-development-mode)
+provides a simple way to toggle in and out of _development mode_. Doing so
+allows you to ship known development-specific settings within your repository,
+while ensuring they are not enabled in production. The tooling essentially
+enables optional, development-specific configuration in your application by:
+
+- Copying the file `config/development.config.php.dist` to
+  `config/development.config.php`; this can be used to enable
+  development-specific modules or settings (such as the `debug` flag).
+- Copying the file `config/autoload/development.local.php.dist` to
+  `config/autoload/development.local.php`; this can be used to provide local
+  overrides of a number of configuration settings.
+
+The package provides the tooling via `vendor/bin/zf-development-mode`. If you
+are using the Expressive skeleton, it provides aliases via Composer:
+
+```php
+$ composer development-enable
+$ composer development-disable
+$ composer development-status
+```
+
+Add settings to your `development.*.php.dist` files, and commit those files to
+your repository; always toggle out of and into development mode after making
+changes, to ensure they pick up in your development environment.
+
+## Modules
+
+- Since 2.0.
+
+The package [zendframework/zend-expressive-tooling](https://github.com/zendframework/zend-expressive-tooling)
+provides the binary `vendor/bin/expressive-module`, which allows you to create,
+register, and deregister modules, assuming you are using a [modular application
+layout](../features/modular-applications.md).
+
+> ### Adding tooling to existing applications
+>
+> If you have upgraded from Expressive 1.X, you can install
+> zendframework/zend-expressive-tooling via Composer:
+>
+> ```bash
+> $ composer require --dev zendframework/zend-expressive-tooling
+> ```
+
+For instance, if you wish to create a new module for managing users, you might
+execute the following:
+
+```bash
+$ ./vendor/bin/expressive-module create User
+```
+
+Which would create the following tree:
+
+```text
+src/
+  User/
+    src/
+      ConfigProvider.php
+    templates/
+```
+
+It would also create an autoloading rule within your `composer.json` for the
+`User` namespace, pointing it at the `src/User/src/` tree (and updating the
+autoloader in the process), and register the new module's `ConfigProvider`
+within your `config/config.php`.
+
+The `register` command will take an existing module and:
+
+- Add an autoloading rule for it to your `composer.json`, if necessary.
+- Add an entry for the module's `ConfigProvider` class to your
+  `config/config.php`, if possible.
+
+```bash
+$ ./vendor/bin/expressive-module register Account
+```
+
+The `deregister` command does the opposite of `register`.
+
+```bash
+$ ./vendor/bin/expressive-module deregister Account
+```
+
+## Migrate to programmatic pipelines
+
+- Since 2.0.
+
+Starting in 2.0, we recommend using _programmatic pipelines_, versus
+configuration-defined pipelines. For those upgrading their applications from 1.X
+versions, we provide a tool that will read their application configuration and
+generate:
+
+- `config/pipeline.php`, with the middleware pipeline
+- `config/routes.php`, with routing directives
+- `config/autoload/zend-expressive.global.php`, with settings to ensure
+  programmatic pipelines are used, and new middleware provided for Expressive
+  2.0 is registered.
+- directives within `public/index.php` for using the generated pipeline and
+  routes directives.
+
+To use this feature, you will need to first install
+zendframework/zend-expressive-tooling:
+
+```bash
+$ composer require --dev zendframework/zend-expressive-tooling
+```
+
+Invoke it as follows:
+
+```bash
+$ ./vendor/bin/expressive-pipeline-from-config generate
+```
+
+The tool will notify you of any errors, including whether or not it found (and
+skipped) Stratigility v1-style "error middleware".
+
+## Detect usage of legacy getOriginal*() calls
+
+- Since 2.0.
+
+When upgrading to version 2.0, you will also receive an upgrade to
+zendframework/zend-stratigility 2.0. That version eliminates internal decorator
+classes for the request and response instances, which were used to provide
+access to the outermost request/response; internal layers could use these to
+determine the full URI that resulted in their invocation, which is useful when
+you pipe using a path argument (as the path provided during piping is stripped
+from the URI when invoking the matched middleware).
+
+This affects the following methods:
+
+- `Request::getOriginalRequest()`
+- `Request::getOriginalUri()`
+- `Response::getOriginalResponse()`
+
+To provide equivalent functionality, we provide a couple of tools.
+
+First, Stratigility provides middleware, `Zend\Stratigility\Middleware\OriginalMessages`,
+which will inject the current request, its URI, and, if invoked as double-pass
+middleware, current response, as _request attributes_, named, respectively,
+`originalRequest`, `originalUri`, and `originalResponse`. (Since Expressive 2.0
+decorates double-pass middleware using a wrapper that composes a response, the
+"original response" will be the response prototype composed in the `Application`
+instance.) This should be registered as the outermost middleware layer.
+Middleware that needs access to these instances can then use the following
+syntax to retrieve them:
+
+```php
+$originalRequest = $request->getAttribute('originalRequest', $request);
+$originalUri = $request->getAttribute('originalUri', $request->getUri();
+$originalResponse = $request->getAttribute('originalResponse') ?: new Response();
+```
+
+> ### Original response is not trustworthy
+>
+> As noted above, the "original response" will likely be injected with the
+> response prototype from the `Application` instance. We recommend not using it,
+> and instead either composing a pristine response instance in your middleware,
+> or creating a new instance on-the-fly.
+
+To aid you in migrating your existing code to use the new `getAttribute()`
+syntax, zendframework/zend-expressive-tooling provides a binary,
+`vendor/bin/expressive-migrate-original-messages`. First, install that package:
+
+```bash
+$ composer require --dev zendframework/zend-expressive-tooling
+```
+
+Then invoke it as follows:
+
+```bash
+$ ./vendor/bin/expressive-migrate-original-messages scan
+```
+
+This script will update any `getOriginalRequest()` and `getOriginalUri()` calls,
+and notify you of any `getOriginalResponse()` calls, providing you with details
+on how to correct those manually.
+
+## Detect usage of legacy error middleware
+
+- Since 2.0.
+
+When upgrading to version 2.0, you will also receive an upgrade to
+zendframework/zend-stratigility 2.0. That version eliminates what was known as
+"error middleware", middleware that either implemented
+`Zend\Stratigility\ErrorMiddlewareInterface`, or duck-typed it by implementing
+the signature `function ($error, $request, $response, callable $next)`.
+
+Such "error middleware" allowed other middleware to invoke the `$next` argument
+with an additional, third argument representing an error condition; when that
+occurred, Stratigility/Expressive would start iterating through error middleware
+until one was able to return a response. Each would receive the error as the
+first argument, and determine how to act upon it.
+
+With version 2.0 of each project, such middleware is now no longer accepted, and
+users should instead be using [the new error handling
+features](../features/error-handling.md). However, you may find that:
+
+- You have defined error middleware in your application.
+- You have standard middleware in your application that invokes `$next` with the
+  third, error argument.
+
+To help you identify such instances, zendframework/zend-expressive-tooling
+provides the script `vendor/bin/expressive-scan-for-error-middleware`. First,
+install that package:
+
+```bash
+$ composer require --dev zendframework/zend-expressive-tooling
+```
+
+Then invoke it as follows:
+
+```bash
+$ ./vendor/bin/expressive-scan-for-error-middleware scan
+```
+
+The script will notify you of any places where it finds either use case, and
+provide feedback on how to update your application.

--- a/doc/book/reference/migration/to-v2.md
+++ b/doc/book/reference/migration/to-v2.md
@@ -738,3 +738,58 @@ entries for each will be injected into your generated pipeline.
 
 Please see the [chapter on the implicit methods middleware](../../features/middleware/implicit-methods-middleware.md)
 for more information on each.
+
+## Router interface changes
+
+Expressive 2.0 uses zendframework/zend-expressive-router 2.1+. Version 2.0 of
+that package introduced a change to the `Zend\Expressive\Router\RouterInterface::generateUri()`
+method; it now accepts an additional, optional, third argument, `array $options = []`,
+which can be used to pass router-specific options when generating a URI. As an
+example, the implementation that uses zendframework/zend-router might use these
+options to pass a translator instance in order to translate a path segment to
+the currently selected locale.
+
+For consumers, his represents no backwards-incompatible change; consumers may
+opt-in to the new argument at will. For those implementing the interface,
+upgrading will require updating your router implementation's signature to match
+the new interface:
+
+```php
+public function generateUri(
+    string $name,
+    array $substitutions = [],
+    array $options = []
+) : string
+```
+
+## URL helper changes
+
+Expressive 2.0 uses zendframework/zend-expressive-helpers version 3.0+. This new
+version updates the signature of the `Zend\Expressive\Helper\UrlHelper` from:
+
+```php
+function (
+    $routeName,
+    array $routeParams = []
+) : string
+```
+
+to:
+
+```php
+function (
+    $routeName,
+    array $routeParams = [],
+    $queryParams = [],
+    $fragmentIdentifier = null,
+    array $options = []
+) : string
+```
+
+For consumers, this should represent a widening of features, and will not
+require any changes, unless you wish to opt-in to the new arguments. See the
+[UrlHelper documentation](../../features/helpers/url-helper.md) for information
+on each argument.
+
+For any users who were _extending_ the class, you will need to update your
+extension accordingly.

--- a/doc/book/reference/migration/to-v2.md
+++ b/doc/book/reference/migration/to-v2.md
@@ -793,3 +793,10 @@ on each argument.
 
 For any users who were _extending_ the class, you will need to update your
 extension accordingly.
+
+## zend-view renderer changes
+
+Expressive 2.0 will use zend-expressive-zendviewrenderer 1.3+ if that renderer
+is chosen. Starting with 1.3.0 of that renderer, you may now pass a boolean
+`false` value for the `layout` variable when calling either `addDefaultParam()`
+or `render()` on the renderer instance in order to disable the layout.

--- a/doc/book/reference/migration/to-v2.md
+++ b/doc/book/reference/migration/to-v2.md
@@ -800,3 +800,8 @@ Expressive 2.0 will use zend-expressive-zendviewrenderer 1.3+ if that renderer
 is chosen. Starting with 1.3.0 of that renderer, you may now pass a boolean
 `false` value for the `layout` variable when calling either `addDefaultParam()`
 or `render()` on the renderer instance in order to disable the layout.
+
+## Twig renderer changes
+
+Expressive 2.0 will use zend-expressive-twigrenderer 1.3+ if that renderer
+is chosen. Starting with 1.3.0 of that renderer, Twig 2.1+ is now supported.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,7 @@ pages:
         - 'Passing data between middleware': cookbook/passing-data-between-middleware.md
     - Reference:
         - "Why choose Expressive?": why-expressive.md
+        - "CLI Tooling": reference/cli-tooling.md
         - Examples: reference/usage-examples.md
         - 'Expressive Projects': reference/expressive-projects.md
         - Migration:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ pages:
         - Containers:
             - Introduction: features/container/intro.md
             - 'Container Factories': features/container/factories.md
+            - 'Delegator Factories': features/container/delegator-factories.md
             - 'Using zend-servicemanager': features/container/zend-servicemanager.md
             - 'Using Pimple': features/container/pimple.md
             - 'Using Aura.Di': features/container/aura-di.md


### PR DESCRIPTION
This patch builds on #456.

> Create new tutorials based on new skeleton, and mark old tutorials as deprecated.

- [x] Security advisories
- [x] Development mode
- [x] composer check
- [x] composer clear-config-cache
- [x] zend-component-installer
- [x] zend-config-aggregator / ConfigProvider
- [x] pipeline.php
- [x] routes.php
- [x] expressive-module tool
  - [x] in getting-started guide
  - [x] in tooling section
- [x] changes in the zend-expressive-router package
- [x] new features in the Url helper (addition of query strings and fragments, and router options)
- [x] document new zend-expressive-zendviewrenderer features (see zendframework/zend-expressive-zendviewrenderer#23)
- [x] document that we now support Twig 2.1+