### PR TITLE
Fixed markdown typo (docs)

### DIFF
--- a/doc/book/getting-started/skeleton.md
+++ b/doc/book/getting-started/skeleton.md
@@ -25,7 +25,7 @@ This will prompt you to choose:
   ServiceManager.
 
 - A router. We recommend using the default, FastRoute.
--
+
 - A template renderer. You can ignore this when creating an API project, but if
   you will be creating any HTML pages, we recommend installing one. We prefer
   Plates.


### PR DESCRIPTION
![now](https://cloud.githubusercontent.com/assets/1247388/23705879/19afbfba-040c-11e7-882b-de8b4a07a862.PNG)
