### PR TITLE
Ensure invokable, duck-typed, class-based interop middleware works

### DIFF
--- a/src/MarshalMiddlewareTrait.php
+++ b/src/MarshalMiddlewareTrait.php
@@ -148,6 +148,10 @@ trait MarshalMiddlewareTrait
             return $instance;
         }
 
+        if ($this->isCallableInteropMiddleware($instance)) {
+            return new CallableInteropMiddlewareWrapper($instance);
+        }
+
         if (! is_callable($instance)) {
             throw new Exception\InvalidMiddlewareException(sprintf(
                 'Middleware of class "%s" is invalid; neither invokable nor %s',

--- a/test/Application/MarshalMiddlewareTraitTest.php
+++ b/test/Application/MarshalMiddlewareTraitTest.php
@@ -256,7 +256,7 @@ class MarshalMiddlewareTraitTest extends TestCase
 
         $middleware = $this->prepareMiddleware($base);
 
-        $this->assertInstanceOf(CallableMiddlewareWrapper::class, $middleware);
+        $this->assertInstanceOf(CallableInteropMiddlewareWrapper::class, $middleware);
         $this->assertAttributeInstanceOf(TestAsset\CallableInteropMiddleware::class, 'middleware', $middleware);
     }
 

--- a/test/TestAsset/CallableInteropMiddleware.php
+++ b/test/TestAsset/CallableInteropMiddleware.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Expressive\TestAsset;
+
+use Interop\Http\ServerMiddleware\DelegateInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class CallableInteropMiddleware
+{
+    public function __invoke(ServerRequestInterface $request, DelegateInterface $delegate)
+    {
+        $response = $delegate->process($request);
+        return $response->withHeader('X-Callable-Interop-Middleware', __CLASS__);
+    }
+}


### PR DESCRIPTION
When using invokable, class-based, duck-typed interop middleware that **NOT** composed in the DI container, `MarshalMiddlewareTrait::marshalInvokableMiddleware` was incorrectly wrapping this in a `CallableMiddlewareWrapper` instead of a `CallableInteropMiddlewareWrapper`; when such middleware was invoked, it was thus incorrectly being passed a response instead of a delegate, leading to a fatal error.

This patch adds a unit test to validate usage, and fixes an incorrect test in the process.

Fixes an issue reported by @robertbasic.