### PR TITLE
Adds Info for usage of expressive-pipeline-from-config

### DIFF
--- a/doc/book/reference/migration/to-v2.md
+++ b/doc/book/reference/migration/to-v2.md
@@ -679,6 +679,12 @@ time, to allow you to test and verify your application first; however, due to
 the configuration in `config/autoload/programmatic-pipeline.global.php`, these
 are now ignored.
 
+Be aware, the default expressive-skeleton installation does not provide configuration
+for the dispatch- and routing-middleware. Make sure that you have registered the 
+`Zend\Expressive\Application::ROUTING_MIDDLEWARE` as well as 
+`Zend\Expressive\Application::DISPATCH_MIDDLEWARE` inside your `middleware_pipeline` 
+configuration.
+
 If you wish to use Whoops in your development environment, you may add the
 following to a local configuration file (e.g., `config/autoload/local.php`):
 


### PR DESCRIPTION
I ran into the trouble that using the `expressive-pipeline-from-config` tool my routes haven't been found. That's because at some points the expressive-skeleton application didn't have the configuration for the routing- and dispatch-middlewares in their configs, as they were programmatically added.

This patch provides additional information that it will most likely be required to manually add them to your `middleware_pipeline` configuration.