### PR TITLE
Forwarded method flag in head request

### DIFF
--- a/src/Middleware/ImplicitHeadMiddleware.php
+++ b/src/Middleware/ImplicitHeadMiddleware.php
@@ -43,6 +43,8 @@ use Zend\Expressive\Router\RouteResult;
  */
 class ImplicitHeadMiddleware implements ServerMiddlewareInterface
 {
+    const FORWARDED_HTTP_METHOD_ATTRIBUTE = 'forwarded_http_method';
+
     /**
      * @var null|ResponseInterface
      */
@@ -91,7 +93,7 @@ class ImplicitHeadMiddleware implements ServerMiddlewareInterface
         $response = $delegate->process(
             $request
                 ->withMethod(RequestMethod::METHOD_GET)
-                ->withAttribute('forwarded_http_method', RequestMethod::METHOD_HEAD)
+                ->withAttribute(self::FORWARDED_HTTP_METHOD_ATTRIBUTE, RequestMethod::METHOD_HEAD)
         );
 
         return $response->withBody(new Stream('php://temp/', 'wb+'));

--- a/src/Middleware/ImplicitHeadMiddleware.php
+++ b/src/Middleware/ImplicitHeadMiddleware.php
@@ -87,9 +87,11 @@ class ImplicitHeadMiddleware implements ServerMiddlewareInterface
         if (! $route->allowsMethod(RequestMethod::METHOD_GET)) {
             return $this->getResponse();
         }
-
+        
         $response = $delegate->process(
-            $request->withMethod(RequestMethod::METHOD_GET)
+            $request
+                ->withMethod(RequestMethod::METHOD_GET)
+                ->withAttribute('forwarded_http_method', RequestMethod::METHOD_HEAD)
         );
 
         return $response->withBody(new Stream('php://temp/', 'wb+'));

--- a/src/Middleware/ImplicitHeadMiddleware.php
+++ b/src/Middleware/ImplicitHeadMiddleware.php
@@ -87,7 +87,7 @@ class ImplicitHeadMiddleware implements ServerMiddlewareInterface
         if (! $route->allowsMethod(RequestMethod::METHOD_GET)) {
             return $this->getResponse();
         }
-        
+
         $response = $delegate->process(
             $request
                 ->withMethod(RequestMethod::METHOD_GET)

--- a/test/Middleware/ImplicitHeadMiddlewareTest.php
+++ b/test/Middleware/ImplicitHeadMiddlewareTest.php
@@ -14,7 +14,6 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Message\StreamInterface;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequest;
 use Zend\Expressive\Middleware\ImplicitHeadMiddleware;
@@ -170,7 +169,8 @@ class ImplicitHeadMiddlewareTest extends TestCase
 
         $delegate = $this->prophesize(DelegateInterface::class);
         $delegate->process(Argument::that(function (ServerRequestInterface $request) {
-            $this->assertSame('HEAD', $request->getAttribute('forwarded_http_method'));
+            $attr = $request->getAttribute(ImplicitHeadMiddleware::FORWARDED_HTTP_METHOD_ATTRIBUTE);
+            $this->assertSame('HEAD', $attr);
             return true;
         }))->willReturn($response);
 

--- a/test/Middleware/ImplicitHeadMiddlewareTest.php
+++ b/test/Middleware/ImplicitHeadMiddlewareTest.php
@@ -169,7 +169,7 @@ class ImplicitHeadMiddlewareTest extends TestCase
         $response = new Response\JsonResponse(['some_data' => true], 400);
 
         $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->process(Argument::that(function(ServerRequestInterface $request) {
+        $delegate->process(Argument::that(function (ServerRequestInterface $request) {
             $this->assertSame('HEAD', $request->getAttribute('forwarded_http_method'));
             return true;
         }))->willReturn($response);

--- a/test/Middleware/ImplicitHeadMiddlewareTest.php
+++ b/test/Middleware/ImplicitHeadMiddlewareTest.php
@@ -16,6 +16,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Zend\Diactoros\Response;
+use Zend\Diactoros\ServerRequest;
 use Zend\Expressive\Middleware\ImplicitHeadMiddleware;
 use Zend\Expressive\Router\Route;
 use Zend\Expressive\Router\RouteResult;
@@ -162,26 +163,22 @@ class ImplicitHeadMiddlewareTest extends TestCase
         $result = $this->prophesize(RouteResult::class);
         $result->getMatchedRoute()->will([$route, 'reveal']);
 
-        $request = $this->prophesize(ServerRequestInterface::class);
-        $request->getMethod()->willReturn(RequestMethod::METHOD_HEAD);
-        $request->getAttribute(RouteResult::class, false)->will([$result, 'reveal']);
-        $request->withMethod(RequestMethod::METHOD_GET)->will([$request, 'reveal']);
+        $request = (new ServerRequest([], [], null, RequestMethod::METHOD_HEAD))
+                ->withAttribute(RouteResult::class, $result->reveal());
 
-        $response = $this->prophesize(ResponseInterface::class);
-        $response
-            ->withBody(Argument::that(function ($body) {
-                $this->assertInstanceOf(StreamInterface::class, $body);
-                $this->assertEquals('', (string) $body);
-                return true;
-            }))
-            ->will([$response, 'reveal']);
+        $response = new Response\JsonResponse(['some_data' => true], 400);
 
         $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->process($request->reveal())->will([$response, 'reveal']);
+        $delegate->process(Argument::that(function(ServerRequestInterface $request) {
+            $this->assertSame('HEAD', $request->getAttribute('forwarded_http_method'));
+            return true;
+        }))->willReturn($response);
 
         $middleware = new ImplicitHeadMiddleware();
-        $result = $middleware->process($request->reveal(), $delegate->reveal());
+        $result = $middleware->process($request, $delegate->reveal());
 
-        $this->assertSame($response->reveal(), $result);
+        $this->assertSame(400, $result->getStatusCode());
+        $this->assertSame('', (string) $result->getBody());
+        $this->assertSame('application/json', $result->getHeaderLine('content-type'));
     }
 }


### PR DESCRIPTION
`ImplicitHeadMiddleware` clears body, but we now we are not able to detect that is a HEAD request in final middleware. `forwarded_http_method` can be use to abandon prepare response body