### PR TITLE
fix(WhoopsError): ensure the SCRIPT_NAME is set before attempting to use it

### DIFF
--- a/src/Middleware/WhoopsErrorResponseGenerator.php
+++ b/src/Middleware/WhoopsErrorResponseGenerator.php
@@ -91,11 +91,18 @@ class WhoopsErrorResponseGenerator
     {
         $uri = $request->getAttribute('originalUri', false) ?: $request->getUri();
         $request = $request->getAttribute('originalRequest', false) ?: $request;
+        
+        $serverParams = $request->getServerParams();
+        $scriptName = '';
+        
+        if (isset($serverParams['SCRIPT_NAME'])) {
+            $scriptName = $serverParams['SCRIPT_NAME'];
+        }
 
         $handler->addDataTable('Expressive Application Request', [
             'HTTP Method'            => $request->getMethod(),
             'URI'                    => (string) $uri,
-            'Script'                 => $request->getServerParams()['SCRIPT_NAME'],
+            'Script'                 => $scriptName,
             'Headers'                => $request->getHeaders(),
             'Cookies'                => $request->getCookieParams(),
             'Attributes'             => $request->getAttributes(),

--- a/src/Middleware/WhoopsErrorResponseGenerator.php
+++ b/src/Middleware/WhoopsErrorResponseGenerator.php
@@ -91,13 +91,9 @@ class WhoopsErrorResponseGenerator
     {
         $uri = $request->getAttribute('originalUri', false) ?: $request->getUri();
         $request = $request->getAttribute('originalRequest', false) ?: $request;
-        
+
         $serverParams = $request->getServerParams();
-        $scriptName = '';
-        
-        if (isset($serverParams['SCRIPT_NAME'])) {
-            $scriptName = $serverParams['SCRIPT_NAME'];
-        }
+        $scriptName = isset($serverParams['SCRIPT_NAME']) ? $serverParams['SCRIPT_NAME'] : '';
 
         $handler->addDataTable('Expressive Application Request', [
             'HTTP Method'            => $request->getMethod(),


### PR DESCRIPTION
PSR states
```
     * Retrieves data related to the incoming request environment,
     * typically derived from PHP's $_SERVER superglobal. The data IS NOT
     * REQUIRED to originate from $_SERVER.
```
Nothing suggests that `SCRIPT_NAME` will always exist. Therefore I've added a `isset()` guard and left the default as an empty string. 