### PR TITLE
ImplicitOptionsMiddleware: Add Access-Control-Allow-Methods if needed

### DIFF
--- a/src/Middleware/ImplicitOptionsMiddleware.php
+++ b/src/Middleware/ImplicitOptionsMiddleware.php
@@ -79,6 +79,11 @@ class ImplicitOptionsMiddleware implements ServerMiddlewareInterface
         }
 
         $methods = implode(',', $route->getAllowedMethods());
+
+        if ($request->hasHeader('Access-Control-Request-Method')) {
+            $this->response = $this->getResponse()->withHeader('Access-Control-Allow-Methods', $methods);
+        }
+
         return $this->getResponse()->withHeader('Allow', $methods);
     }
 

--- a/test/Middleware/ImplicitOptionsMiddlewareTest.php
+++ b/test/Middleware/ImplicitOptionsMiddlewareTest.php
@@ -169,7 +169,10 @@ class ImplicitOptionsMiddlewareTest extends TestCase
         $delegate->process($request->reveal())->shouldNotBeCalled();
 
         $expected = $this->prophesize(ResponseInterface::class);
-        $expected->withHeader('Access-Control-Allow-Methods', implode(',', $allowedMethods))->will([$expected, 'reveal']);
+        $expected->withHeader(
+            'Access-Control-Allow-Methods',
+            implode(',', $allowedMethods)
+        )->will([$expected, 'reveal']);
         $expected->withHeader('Allow', implode(',', $allowedMethods))->will([$expected, 'reveal']);
 
         $middleware = new ImplicitOptionsMiddleware($expected->reveal());

--- a/test/Middleware/ImplicitOptionsMiddlewareTest.php
+++ b/test/Middleware/ImplicitOptionsMiddlewareTest.php
@@ -106,6 +106,7 @@ class ImplicitOptionsMiddlewareTest extends TestCase
 
         $request = $this->prophesize(ServerRequestInterface::class);
         $request->getMethod()->willReturn(RequestMethod::METHOD_OPTIONS);
+        $request->hasHeader("Access-Control-Request-Method")->willReturn(false);
         $request->getAttribute(RouteResult::class, false)->will([$result, 'reveal']);
 
         $response = $this->prophesize(ResponseInterface::class)->reveal();
@@ -134,12 +135,41 @@ class ImplicitOptionsMiddlewareTest extends TestCase
 
         $request = $this->prophesize(ServerRequestInterface::class);
         $request->getMethod()->willReturn(RequestMethod::METHOD_OPTIONS);
+        $request->hasHeader("Access-Control-Request-Method")->willReturn(false);
         $request->getAttribute(RouteResult::class, false)->will([$result, 'reveal']);
 
         $delegate = $this->prophesize(DelegateInterface::class);
         $delegate->process($request->reveal())->shouldNotBeCalled();
 
         $expected = $this->prophesize(ResponseInterface::class);
+        $expected->withHeader('Allow', implode(',', $allowedMethods))->will([$expected, 'reveal']);
+
+        $middleware = new ImplicitOptionsMiddleware($expected->reveal());
+        $result = $middleware->process($request->reveal(), $delegate->reveal());
+        $this->assertSame($expected->reveal(), $result);
+    }
+
+    public function testInjectsAccessControlAllowMethodsHeaderInResponseProvidedToConstructorDuringOptionsRequest()
+    {
+        $allowedMethods = [RequestMethod::METHOD_GET, RequestMethod::METHOD_POST];
+
+        $route = $this->prophesize(Route::class);
+        $route->implicitOptions()->willReturn(true);
+        $route->getAllowedMethods()->willReturn($allowedMethods);
+
+        $result = $this->prophesize(RouteResult::class);
+        $result->getMatchedRoute()->will([$route, 'reveal']);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getMethod()->willReturn(RequestMethod::METHOD_OPTIONS);
+        $request->hasHeader("Access-Control-Request-Method")->willReturn(true);
+        $request->getAttribute(RouteResult::class, false)->will([$result, 'reveal']);
+
+        $delegate = $this->prophesize(DelegateInterface::class);
+        $delegate->process($request->reveal())->shouldNotBeCalled();
+
+        $expected = $this->prophesize(ResponseInterface::class);
+        $expected->withHeader('Access-Control-Allow-Methods', implode(',', $allowedMethods))->will([$expected, 'reveal']);
         $expected->withHeader('Allow', implode(',', $allowedMethods))->will([$expected, 'reveal']);
 
         $middleware = new ImplicitOptionsMiddleware($expected->reveal());


### PR DESCRIPTION
Add Access-Control-Allow-Methods to response if the request sends Access-Control-Request-Method. Used for cross-domain calls.