### PR TITLE
Added custom layout support in NotFoundDelegate

### DIFF
--- a/src/Container/NotFoundDelegateFactory.php
+++ b/src/Container/NotFoundDelegateFactory.php
@@ -27,7 +27,10 @@ class NotFoundDelegateFactory
         $template = isset($config['zend-expressive']['error_handler']['template_404'])
             ? $config['zend-expressive']['error_handler']['template_404']
             : NotFoundDelegate::TEMPLATE_DEFAULT;
+        $layout = isset($config['zend-expressive']['error_handler']['layout'])
+            ? $config['zend-expressive']['error_handler']['layout']
+            : NotFoundDelegate::LAYOUT_DEFAULT;
 
-        return new NotFoundDelegate(new Response(), $renderer, $template);
+        return new NotFoundDelegate(new Response(), $renderer, $template, $layout);
     }
 }

--- a/src/Delegate/NotFoundDelegate.php
+++ b/src/Delegate/NotFoundDelegate.php
@@ -16,6 +16,7 @@ use Zend\Expressive\Template\TemplateRendererInterface;
 class NotFoundDelegate implements DelegateInterface
 {
     const TEMPLATE_DEFAULT = 'error::404';
+    const LAYOUT_DEFAULT = 'layout::error';
 
     /**
      * @var TemplateRendererInterface
@@ -36,18 +37,26 @@ class NotFoundDelegate implements DelegateInterface
     private $template;
 
     /**
+     * @var string
+     */
+    private $layout;
+
+    /**
      * @param ResponseInterface $responsePrototype
      * @param TemplateRendererInterface $renderer
      * @param string $template
+     * @param string $layout
      */
     public function __construct(
         ResponseInterface $responsePrototype,
         TemplateRendererInterface $renderer = null,
-        $template = self::TEMPLATE_DEFAULT
+        $template = self::TEMPLATE_DEFAULT,
+        $layout = self::LAYOUT_DEFAULT
     ) {
         $this->responsePrototype = $responsePrototype;
         $this->renderer          = $renderer;
         $this->template          = $template;
+        $this->layout            = $layout;
     }
 
     /**
@@ -93,9 +102,14 @@ class NotFoundDelegate implements DelegateInterface
      */
     private function generateTemplatedResponse(ServerRequestInterface $request)
     {
+        $templateData = [
+            'request'  => $request,
+            'layout'  => $this->layout,
+        ];
+
         $response = $this->responsePrototype->withStatus(StatusCodeInterface::STATUS_NOT_FOUND);
         $response->getBody()->write(
-            $this->renderer->render($this->template, ['request' => $request])
+            $this->renderer->render($this->template, $templateData)
         );
 
         return $response;

--- a/src/Delegate/NotFoundDelegate.php
+++ b/src/Delegate/NotFoundDelegate.php
@@ -54,9 +54,9 @@ class NotFoundDelegate implements DelegateInterface
         $layout = self::LAYOUT_DEFAULT
     ) {
         $this->responsePrototype = $responsePrototype;
-        $this->renderer          = $renderer;
-        $this->template          = $template;
-        $this->layout            = $layout;
+        $this->renderer = $renderer;
+        $this->template = $template;
+        $this->layout = $layout;
     }
 
     /**
@@ -67,7 +67,7 @@ class NotFoundDelegate implements DelegateInterface
      */
     public function process(ServerRequestInterface $request)
     {
-        if (! $this->renderer) {
+        if (!$this->renderer) {
             return $this->generatePlainTextResponse($request);
         }
 
@@ -87,7 +87,7 @@ class NotFoundDelegate implements DelegateInterface
             ->write(sprintf(
                 'Cannot %s %s',
                 $request->getMethod(),
-                (string) $request->getUri()
+                (string)$request->getUri()
             ));
         return $response;
     }
@@ -102,14 +102,9 @@ class NotFoundDelegate implements DelegateInterface
      */
     private function generateTemplatedResponse(ServerRequestInterface $request)
     {
-        $templateData = [
-            'request'  => $request,
-            'layout'  => $this->layout,
-        ];
-
         $response = $this->responsePrototype->withStatus(StatusCodeInterface::STATUS_NOT_FOUND);
         $response->getBody()->write(
-            $this->renderer->render($this->template, $templateData)
+            $this->renderer->render($this->template, ['request' => $request, 'layout' => $this->layout])
         );
 
         return $response;

--- a/test/Container/NotFoundDelegateFactoryTest.php
+++ b/test/Container/NotFoundDelegateFactoryTest.php
@@ -54,6 +54,7 @@ class NotFoundDelegateFactoryTest extends TestCase
         $config = [
             'zend-expressive' => [
                 'error_handler' => [
+                    'layout' => 'layout::error',
                     'template_404' => 'foo::bar',
                 ],
             ],
@@ -64,6 +65,11 @@ class NotFoundDelegateFactoryTest extends TestCase
         $factory = new NotFoundDelegateFactory();
 
         $delegate = $factory($this->container->reveal());
+        $this->assertAttributeEquals(
+            $config['zend-expressive']['error_handler']['layout'],
+            'layout',
+            $delegate
+        );
         $this->assertAttributeEquals(
             $config['zend-expressive']['error_handler']['template_404'],
             'template',

--- a/test/Delegate/NotFoundDelegateTest.php
+++ b/test/Delegate/NotFoundDelegateTest.php
@@ -36,12 +36,14 @@ class NotFoundDelegateTest extends TestCase
     public function testConstructorCanAcceptRendererAndTemplate()
     {
         $renderer = $this->prophesize(TemplateRendererInterface::class)->reveal();
+        $layout = 'layout::error';
         $template = 'foo::bar';
 
-        $delegate = new NotFoundDelegate($this->response->reveal(), $renderer, $template);
+        $delegate = new NotFoundDelegate($this->response->reveal(), $renderer, $template, $layout);
 
         $this->assertInstanceOf(NotFoundDelegate::class, $delegate);
         $this->assertAttributeSame($renderer, 'renderer', $delegate);
+        $this->assertAttributeEquals($layout, 'layout', $delegate);
         $this->assertAttributeEquals($template, 'template', $delegate);
     }
 
@@ -68,7 +70,7 @@ class NotFoundDelegateTest extends TestCase
         $request = $this->prophesize(ServerRequestInterface::class)->reveal();
 
         $renderer = $this->prophesize(TemplateRendererInterface::class);
-        $renderer->render(NotFoundDelegate::TEMPLATE_DEFAULT, ['request' => $request])
+        $renderer->render(NotFoundDelegate::TEMPLATE_DEFAULT, ['request' => $request, 'layout' => NotFoundDelegate::LAYOUT_DEFAULT])
             ->willReturn('CONTENT');
 
         $stream = $this->prophesize(StreamInterface::class);

--- a/test/Delegate/NotFoundDelegateTest.php
+++ b/test/Delegate/NotFoundDelegateTest.php
@@ -70,8 +70,10 @@ class NotFoundDelegateTest extends TestCase
         $request = $this->prophesize(ServerRequestInterface::class)->reveal();
 
         $renderer = $this->prophesize(TemplateRendererInterface::class);
-        $renderer->render(NotFoundDelegate::TEMPLATE_DEFAULT, ['request' => $request, 'layout' => NotFoundDelegate::LAYOUT_DEFAULT])
-            ->willReturn('CONTENT');
+        $renderer->render(NotFoundDelegate::TEMPLATE_DEFAULT, [
+            'request' => $request,
+            'layout' => NotFoundDelegate::LAYOUT_DEFAULT
+            ])->willReturn('CONTENT');
 
         $stream = $this->prophesize(StreamInterface::class);
         $stream->write('CONTENT')->shouldBeCalled();


### PR DESCRIPTION
This is a better implementation for chaning the layout of error pages. See also the issue: #360 

I hope my pull request will be accepted :-)