### PR TITLE
Added support for http-interop/http-middleware 0.5.0 (no BC Break)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,15 +24,26 @@
             "dev-develop": "2.1-dev"
         }
     },
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/webimpress/zend-expressive-router.git"
+        },
+        {
+            "type": "git",
+            "url": "https://github.com/webimpress/zend-stratigility.git"
+        }
+    ],
     "require": {
         "php": "^5.6 || ^7.0",
         "fig/http-message-util": "^1.1.2",
         "psr/container": "^1.0",
         "psr/http-message": "^1.0.1",
+        "webimpress/http-middleware-compatibility": "^0.1.1",
         "zendframework/zend-diactoros": "^1.3.10",
-        "zendframework/zend-expressive-router": "^2.1",
+        "zendframework/zend-expressive-router": "dev-feature/http-middleware-0.5 as 2.2",
         "zendframework/zend-expressive-template": "^1.0.4",
-        "zendframework/zend-stratigility": "^2.0.1"
+        "zendframework/zend-stratigility": "dev-feature/http-middleware-0.5"
     },
     "require-dev": {
         "filp/whoops": "^2.1.6 || ^1.1.10",

--- a/composer.json
+++ b/composer.json
@@ -24,16 +24,6 @@
             "dev-develop": "2.1-dev"
         }
     },
-    "repositories": [
-        {
-            "type": "git",
-            "url": "https://github.com/webimpress/zend-expressive-router.git"
-        },
-        {
-            "type": "git",
-            "url": "https://github.com/webimpress/zend-stratigility.git"
-        }
-    ],
     "require": {
         "php": "^5.6 || ^7.0",
         "fig/http-message-util": "^1.1.2",
@@ -41,9 +31,9 @@
         "psr/http-message": "^1.0.1",
         "webimpress/http-middleware-compatibility": "^0.1.1",
         "zendframework/zend-diactoros": "^1.3.10",
-        "zendframework/zend-expressive-router": "dev-feature/http-middleware-0.5 as 2.2",
+        "zendframework/zend-expressive-router": "^2.2",
         "zendframework/zend-expressive-template": "^1.0.4",
-        "zendframework/zend-stratigility": "dev-feature/http-middleware-0.5"
+        "zendframework/zend-stratigility": "^2.1"
     },
     "require-dev": {
         "filp/whoops": "^2.1.6 || ^1.1.10",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "f6513b889a3c44064f683ac1b1849054",
+    "content-hash": "6720673b6d8dda2b2d727ac5dcda7029",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -345,11 +345,17 @@
         },
         {
             "name": "zendframework/zend-expressive-router",
-            "version": "dev-feature/http-middleware-0.5",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webimpress/zend-expressive-router.git",
-                "reference": "6d385d9f2f29194f8b5c9073a3d09e46affd86d7"
+                "url": "https://github.com/zendframework/zend-expressive-router.git",
+                "reference": "f6eac53d39cdbf7b6db11b3e6bb3565896633de4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/f6eac53d39cdbf7b6db11b3e6bb3565896633de4",
+                "reference": "f6eac53d39cdbf7b6db11b3e6bb3565896633de4",
+                "shasum": ""
             },
             "require": {
                 "fig/http-message-util": "^1.1.2",
@@ -370,8 +376,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev",
-                    "dev-develop": "2.2-dev"
+                    "dev-master": "2.2-dev",
+                    "dev-develop": "2.3-dev"
                 }
             },
             "autoload": {
@@ -379,36 +385,7 @@
                     "Zend\\Expressive\\Router\\": "src/"
                 }
             },
-            "autoload-dev": {
-                "psr-4": {
-                    "ZendTest\\Expressive\\Router\\": "test/"
-                }
-            },
-            "scripts": {
-                "check": [
-                    "@license-check",
-                    "@cs-check",
-                    "@test"
-                ],
-                "upload-coverage": [
-                    "coveralls -v"
-                ],
-                "cs-check": [
-                    "phpcs --colors"
-                ],
-                "cs-fix": [
-                    "phpcbf --colors"
-                ],
-                "license-check": [
-                    "docheader check src/ test/"
-                ],
-                "test": [
-                    "phpunit --colors=always"
-                ],
-                "test-coverage": [
-                    "phpunit --coverage-clover clover.xml"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
             ],
@@ -420,7 +397,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2017-10-05T16:20:19+00:00"
+            "time": "2017-10-09T18:44:11+00:00"
         },
         {
             "name": "zendframework/zend-expressive-template",
@@ -473,11 +450,17 @@
         },
         {
             "name": "zendframework/zend-stratigility",
-            "version": "dev-feature/http-middleware-0.5",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webimpress/zend-stratigility.git",
-                "reference": "bddc3d633f5356de9df6fc4951e24e2df14da4be"
+                "url": "https://github.com/zendframework/zend-stratigility.git",
+                "reference": "74617cffd44180bef0aea63daca830d0b675c1c8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-stratigility/zipball/74617cffd44180bef0aea63daca830d0b675c1c8",
+                "reference": "74617cffd44180bef0aea63daca830d0b675c1c8",
+                "shasum": ""
             },
             "require": {
                 "php": "^5.6 || ^7.0",
@@ -497,8 +480,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.0-dev",
-                    "dev-develop": "2.1.0-dev"
+                    "dev-master": "2.1.0-dev",
+                    "dev-develop": "2.2.0-dev"
                 }
             },
             "autoload": {
@@ -506,36 +489,7 @@
                     "Zend\\Stratigility\\": "src/"
                 }
             },
-            "autoload-dev": {
-                "psr-4": {
-                    "ZendTest\\Stratigility\\": "test/"
-                }
-            },
-            "scripts": {
-                "check": [
-                    "@license-check",
-                    "@cs-check",
-                    "@test"
-                ],
-                "upload-coverage": [
-                    "coveralls -v"
-                ],
-                "cs-check": [
-                    "phpcs --colors"
-                ],
-                "cs-fix": [
-                    "phpcbf --colors"
-                ],
-                "license-check": [
-                    "docheader check src/ test/"
-                ],
-                "test": [
-                    "phpunit --colors=always"
-                ],
-                "test-coverage": [
-                    "phpunit --coverage-clover clover.xml"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
             ],
@@ -546,11 +500,7 @@
                 "middleware",
                 "psr-7"
             ],
-            "support": {
-                "issues": "https://github.com/zendframework/zend-stratigility/issues",
-                "source": "https://github.com/zendframework/zend-stratigility"
-            },
-            "time": "2017-10-05T22:34:02+00:00"
+            "time": "2017-10-09T19:25:33+00:00"
         }
     ],
     "packages-dev": [
@@ -3328,19 +3278,9 @@
             "time": "2017-05-17T22:06:13+00:00"
         }
     ],
-    "aliases": [
-        {
-            "alias": "2.2",
-            "alias_normalized": "2.2.0.0",
-            "version": "dev-feature/http-middleware-0.5",
-            "package": "zendframework/zend-expressive-router"
-        }
-    ],
+    "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "zendframework/zend-expressive-router": 20,
-        "zendframework/zend-stratigility": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "18b9c1c8d340ae62722961862eed3cca",
+    "content-hash": "f6513b889a3c44064f683ac1b1849054",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -208,6 +208,46 @@
             "time": "2016-08-06T14:39:51+00:00"
         },
         {
+            "name": "webimpress/http-middleware-compatibility",
+            "version": "0.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webimpress/http-middleware-compatibility.git",
+                "reference": "793d21864a0417bbe01437c33f902cac49c1788c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webimpress/http-middleware-compatibility/zipball/793d21864a0417bbe01437c33f902cac49c1788c",
+                "reference": "793d21864a0417bbe01437c33f902cac49c1788c",
+                "shasum": ""
+            },
+            "require": {
+                "http-interop/http-middleware": "^0.1.1 || ^0.2 || ^0.3 || ^0.4.1 || ^0.5",
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7.22 || ^6.3.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "autoload/http-middleware.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "description": "Compatibility library for Draft PSR-15 HTTP Middleware",
+            "homepage": "https://github.com/webimpress/http-middleware-compatibility",
+            "keywords": [
+                "middleware",
+                "psr-15",
+                "webimpress"
+            ],
+            "time": "2017-10-05T15:55:30+00:00"
+        },
+        {
             "name": "zendframework/zend-diactoros",
             "version": "1.4.0",
             "source": {
@@ -305,27 +345,21 @@
         },
         {
             "name": "zendframework/zend-expressive-router",
-            "version": "2.1.0",
+            "version": "dev-feature/http-middleware-0.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/zendframework/zend-expressive-router.git",
-                "reference": "88d711aee740ac8fbd684472469e16b85435cc79"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/88d711aee740ac8fbd684472469e16b85435cc79",
-                "reference": "88d711aee740ac8fbd684472469e16b85435cc79",
-                "shasum": ""
+                "url": "https://github.com/webimpress/zend-expressive-router.git",
+                "reference": "6d385d9f2f29194f8b5c9073a3d09e46affd86d7"
             },
             "require": {
-                "fig/http-message-util": "^1.1",
-                "http-interop/http-middleware": "^0.4.1",
+                "fig/http-message-util": "^1.1.2",
                 "php": "^5.6 || ^7.0",
-                "psr/http-message": "^1.0"
+                "psr/http-message": "^1.0.1",
+                "webimpress/http-middleware-compatibility": "^0.1.1"
             },
             "require-dev": {
                 "malukenho/docheader": "^0.1.5",
-                "phpunit/phpunit": "^4.7 || ^5.6",
+                "phpunit/phpunit": "^6.0.8 || ^5.7.15",
                 "zendframework/zend-coding-standard": "~1.0.0"
             },
             "suggest": {
@@ -345,7 +379,36 @@
                     "Zend\\Expressive\\Router\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "ZendTest\\Expressive\\Router\\": "test/"
+                }
+            },
+            "scripts": {
+                "check": [
+                    "@license-check",
+                    "@cs-check",
+                    "@test"
+                ],
+                "upload-coverage": [
+                    "coveralls -v"
+                ],
+                "cs-check": [
+                    "phpcs --colors"
+                ],
+                "cs-fix": [
+                    "phpcbf --colors"
+                ],
+                "license-check": [
+                    "docheader check src/ test/"
+                ],
+                "test": [
+                    "phpunit --colors=always"
+                ],
+                "test-coverage": [
+                    "phpunit --coverage-clover clover.xml"
+                ]
+            },
             "license": [
                 "BSD-3-Clause"
             ],
@@ -357,7 +420,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2017-01-24T22:28:12+00:00"
+            "time": "2017-10-05T16:20:19+00:00"
         },
         {
             "name": "zendframework/zend-expressive-template",
@@ -410,27 +473,21 @@
         },
         {
             "name": "zendframework/zend-stratigility",
-            "version": "2.0.1",
+            "version": "dev-feature/http-middleware-0.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/zendframework/zend-stratigility.git",
-                "reference": "229e7d94010d09d9e68096ff6f1d35f354d8dac9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-stratigility/zipball/229e7d94010d09d9e68096ff6f1d35f354d8dac9",
-                "reference": "229e7d94010d09d9e68096ff6f1d35f354d8dac9",
-                "shasum": ""
+                "url": "https://github.com/webimpress/zend-stratigility.git",
+                "reference": "bddc3d633f5356de9df6fc4951e24e2df14da4be"
             },
             "require": {
-                "http-interop/http-middleware": "^0.4.1",
                 "php": "^5.6 || ^7.0",
                 "psr/http-message": "^1.0",
+                "webimpress/http-middleware-compatibility": "^0.1.1",
                 "zendframework/zend-escaper": "^2.3"
             },
             "require-dev": {
                 "malukenho/docheader": "^0.1.5",
-                "phpunit/phpunit": "^5.7",
+                "phpunit/phpunit": "^6.0.8 || ^5.7.15",
                 "zendframework/zend-coding-standard": "~1.0.0",
                 "zendframework/zend-diactoros": "^1.0"
             },
@@ -449,7 +506,36 @@
                     "Zend\\Stratigility\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "ZendTest\\Stratigility\\": "test/"
+                }
+            },
+            "scripts": {
+                "check": [
+                    "@license-check",
+                    "@cs-check",
+                    "@test"
+                ],
+                "upload-coverage": [
+                    "coveralls -v"
+                ],
+                "cs-check": [
+                    "phpcs --colors"
+                ],
+                "cs-fix": [
+                    "phpcbf --colors"
+                ],
+                "license-check": [
+                    "docheader check src/ test/"
+                ],
+                "test": [
+                    "phpunit --colors=always"
+                ],
+                "test-coverage": [
+                    "phpunit --coverage-clover clover.xml"
+                ]
+            },
             "license": [
                 "BSD-3-Clause"
             ],
@@ -460,7 +546,11 @@
                 "middleware",
                 "psr-7"
             ],
-            "time": "2017-01-25T19:16:16+00:00"
+            "support": {
+                "issues": "https://github.com/zendframework/zend-stratigility/issues",
+                "source": "https://github.com/zendframework/zend-stratigility"
+            },
+            "time": "2017-10-05T22:34:02+00:00"
         }
     ],
     "packages-dev": [
@@ -760,12 +850,12 @@
             "version": "0.9.9",
             "source": {
                 "type": "git",
-                "url": "https://github.com/padraic/mockery.git",
+                "url": "https://github.com/mockery/mockery.git",
                 "reference": "6fdb61243844dc924071d3404bb23994ea0b6856"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/padraic/mockery/zipball/6fdb61243844dc924071d3404bb23994ea0b6856",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/6fdb61243844dc924071d3404bb23994ea0b6856",
                 "reference": "6fdb61243844dc924071d3404bb23994ea0b6856",
                 "shasum": ""
             },
@@ -3238,9 +3328,19 @@
             "time": "2017-05-17T22:06:13+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "alias": "2.2",
+            "alias_normalized": "2.2.0.0",
+            "version": "dev-feature/http-middleware-0.5",
+            "package": "zendframework/zend-expressive-router"
+        }
+    ],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "zendframework/zend-expressive-router": 20,
+        "zendframework/zend-stratigility": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/src/Application.php
+++ b/src/Application.php
@@ -8,12 +8,12 @@
 namespace Zend\Expressive;
 
 use Fig\Http\Message\StatusCodeInterface as StatusCode;
-use Interop\Http\ServerMiddleware\DelegateInterface;
 use InvalidArgumentException;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use UnexpectedValueException;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\Response\EmitterInterface;
 use Zend\Diactoros\Response\SapiEmitter;

--- a/src/Delegate/NotFoundDelegate.php
+++ b/src/Delegate/NotFoundDelegate.php
@@ -8,9 +8,10 @@
 namespace Zend\Expressive\Delegate;
 
 use Fig\Http\Message\StatusCodeInterface;
-use Interop\Http\ServerMiddleware\DelegateInterface;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 use Zend\Expressive\Template\TemplateRendererInterface;
 
 class NotFoundDelegate implements DelegateInterface
@@ -51,12 +52,35 @@ class NotFoundDelegate implements DelegateInterface
     }
 
     /**
-     * Creates and returns a 404 response.
+     * Proxy to handle method to support http-interop/http-middleware 0.1.1
+     *
+     * @param RequestInterface $request
+     * @return ResponseInterface
+     */
+    public function next(RequestInterface $request)
+    {
+        return $this->handle($request);
+    }
+
+    /**
+     * Proxy to handle method to support http-interop/http-middleware
+     * versions between 0.2 and 0.4.1
      *
      * @param ServerRequestInterface $request
      * @return ResponseInterface
      */
     public function process(ServerRequestInterface $request)
+    {
+        return $this->handle($request);
+    }
+
+    /**
+     * Creates and returns a 404 response.
+     *
+     * @param ServerRequestInterface $request
+     * @return ResponseInterface
+     */
+    public function handle(ServerRequestInterface $request)
     {
         if (! $this->renderer) {
             return $this->generatePlainTextResponse($request);

--- a/src/MarshalMiddlewareTrait.php
+++ b/src/MarshalMiddlewareTrait.php
@@ -7,9 +7,9 @@
 
 namespace Zend\Expressive;
 
-use Interop\Http\ServerMiddleware\MiddlewareInterface as ServerMiddlewareInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 use Zend\Stratigility\Middleware\CallableInteropMiddlewareWrapper;
 use Zend\Stratigility\Middleware\CallableMiddlewareWrapper;
 use Zend\Stratigility\MiddlewarePipe;

--- a/src/Middleware/DispatchMiddleware.php
+++ b/src/Middleware/DispatchMiddleware.php
@@ -7,14 +7,16 @@
 
 namespace Zend\Expressive\Middleware;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface as ServerMiddlewareInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 use Zend\Expressive\MarshalMiddlewareTrait;
 use Zend\Expressive\Router\RouteResult;
 use Zend\Expressive\Router\RouterInterface;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 /**
  * Default dispatch middleware.
@@ -73,7 +75,7 @@ class DispatchMiddleware implements ServerMiddlewareInterface
     {
         $routeResult = $request->getAttribute(RouteResult::class, false);
         if (! $routeResult) {
-            return $delegate->process($request);
+            return $delegate->{HANDLER_METHOD}($request);
         }
 
         $middleware = $routeResult->getMatchedMiddleware();

--- a/src/Middleware/ImplicitHeadMiddleware.php
+++ b/src/Middleware/ImplicitHeadMiddleware.php
@@ -8,13 +8,15 @@
 namespace Zend\Expressive\Middleware;
 
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface as ServerMiddlewareInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\Stream;
 use Zend\Expressive\Router\RouteResult;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 /**
  * Handle implicit HEAD requests.
@@ -72,23 +74,23 @@ class ImplicitHeadMiddleware implements ServerMiddlewareInterface
     public function process(ServerRequestInterface $request, DelegateInterface $delegate)
     {
         if ($request->getMethod() !== RequestMethod::METHOD_HEAD) {
-            return $delegate->process($request);
+            return $delegate->{HANDLER_METHOD}($request);
         }
 
         if (false === ($result = $request->getAttribute(RouteResult::class, false))) {
-            return $delegate->process($request);
+            return $delegate->{HANDLER_METHOD}($request);
         }
 
         $route = $result->getMatchedRoute();
         if (! $route || ! $route->implicitHead()) {
-            return $delegate->process($request);
+            return $delegate->{HANDLER_METHOD}($request);
         }
 
         if (! $route->allowsMethod(RequestMethod::METHOD_GET)) {
             return $this->getResponse();
         }
 
-        $response = $delegate->process(
+        $response = $delegate->{HANDLER_METHOD}(
             $request->withMethod(RequestMethod::METHOD_GET)
         );
 

--- a/src/Middleware/ImplicitOptionsMiddleware.php
+++ b/src/Middleware/ImplicitOptionsMiddleware.php
@@ -9,12 +9,14 @@ namespace Zend\Expressive\Middleware;
 
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;
 use Fig\Http\Message\StatusCodeInterface as StatusCode;
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface as ServerMiddlewareInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 use Zend\Diactoros\Response;
 use Zend\Expressive\Router\RouteResult;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 /**
  * Handle implicit OPTIONS requests.
@@ -66,16 +68,16 @@ class ImplicitOptionsMiddleware implements ServerMiddlewareInterface
     public function process(ServerRequestInterface $request, DelegateInterface $delegate)
     {
         if ($request->getMethod() !== RequestMethod::METHOD_OPTIONS) {
-            return $delegate->process($request);
+            return $delegate->{HANDLER_METHOD}($request);
         }
 
         if (false === ($result = $request->getAttribute(RouteResult::class, false))) {
-            return $delegate->process($request);
+            return $delegate->{HANDLER_METHOD}($request);
         }
 
         $route = $result->getMatchedRoute();
         if (! $route || ! $route->implicitOptions()) {
-            return $delegate->process($request);
+            return $delegate->{HANDLER_METHOD}($request);
         }
 
         $methods = implode(',', $route->getAllowedMethods());

--- a/src/Middleware/LazyLoadingMiddleware.php
+++ b/src/Middleware/LazyLoadingMiddleware.php
@@ -7,13 +7,15 @@
 
 namespace Zend\Expressive\Middleware;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface as ServerMiddlewareInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 use Zend\Expressive\Exception\InvalidMiddlewareException;
 use Zend\Expressive\IsCallableInteropMiddlewareTrait;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 class LazyLoadingMiddleware implements ServerMiddlewareInterface
 {
@@ -76,7 +78,7 @@ class LazyLoadingMiddleware implements ServerMiddlewareInterface
 
         // Legacy double-pass signature
         return $middleware($request, $this->responsePrototype, function ($request, $response) use ($delegate) {
-            return $delegate->process($request);
+            return $delegate->{HANDLER_METHOD}($request);
         });
     }
 }

--- a/src/Middleware/NotFoundHandler.php
+++ b/src/Middleware/NotFoundHandler.php
@@ -7,11 +7,13 @@
 
 namespace Zend\Expressive\Middleware;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
 use Zend\Expressive\Delegate\NotFoundDelegate;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 class NotFoundHandler implements MiddlewareInterface
 {
@@ -37,6 +39,6 @@ class NotFoundHandler implements MiddlewareInterface
      */
     public function process(ServerRequestInterface $request, DelegateInterface $delegate)
     {
-        return $this->internalDelegate->process($request);
+        return $this->internalDelegate->{HANDLER_METHOD}($request);
     }
 }

--- a/src/Middleware/RouteMiddleware.php
+++ b/src/Middleware/RouteMiddleware.php
@@ -8,12 +8,14 @@
 namespace Zend\Expressive\Middleware;
 
 use Fig\Http\Message\StatusCodeInterface as StatusCode;
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface as ServerMiddlewareInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 use Zend\Expressive\Router\RouteResult;
 use Zend\Expressive\Router\RouterInterface;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 /**
  * Default routing middleware.
@@ -68,7 +70,7 @@ class RouteMiddleware implements ServerMiddlewareInterface
                 return $this->responsePrototype->withStatus(StatusCode::STATUS_METHOD_NOT_ALLOWED)
                     ->withHeader('Allow', implode(',', $result->getAllowedMethods()));
             }
-            return $delegate->process($request);
+            return $delegate->{HANDLER_METHOD}($request);
         }
 
         // Inject the actual route result, as well as individual matched parameters.
@@ -77,6 +79,6 @@ class RouteMiddleware implements ServerMiddlewareInterface
             $request = $request->withAttribute($param, $value);
         }
 
-        return $delegate->process($request);
+        return $delegate->{HANDLER_METHOD}($request);
     }
 }

--- a/test/Application/MarshalMiddlewareTraitTest.php
+++ b/test/Application/MarshalMiddlewareTraitTest.php
@@ -7,8 +7,6 @@
 
 namespace ZendTest\Expressive\Application;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface as ServerMiddlewareInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
@@ -16,6 +14,8 @@ use Psr\Http\Message\ResponseInterface;
 use ReflectionMethod;
 use ReflectionProperty;
 use stdClass;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 use Zend\Expressive\Application;
 use Zend\Expressive\Exception\InvalidMiddlewareException;
 use Zend\Expressive\Middleware;

--- a/test/Application/TestAsset/CallableInteropMiddleware.php
+++ b/test/Application/TestAsset/CallableInteropMiddleware.php
@@ -7,7 +7,7 @@
 
 namespace ZendTest\Expressive\Application\TestAsset;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 
 class CallableInteropMiddleware
 {

--- a/test/Application/TestAsset/InteropMiddleware.php
+++ b/test/Application/TestAsset/InteropMiddleware.php
@@ -7,9 +7,9 @@
 
 namespace ZendTest\Expressive\Application\TestAsset;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
 
 class InteropMiddleware implements MiddlewareInterface
 {

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -10,7 +10,6 @@ namespace ZendTest\Expressive;
 use BadMethodCallException;
 use DomainException;
 use Fig\Http\Message\StatusCodeInterface as StatusCode;
-use Interop\Http\ServerMiddleware\DelegateInterface;
 use InvalidArgumentException;
 use Mockery;
 use PHPUnit\Framework\TestCase;
@@ -22,6 +21,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use ReflectionProperty;
 use RuntimeException;
 use UnexpectedValueException;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 use Zend\Diactoros\Response\EmitterInterface;
 use Zend\Diactoros\Response\SapiEmitter;
 use Zend\Diactoros\ServerRequest;
@@ -40,6 +40,8 @@ use Zend\Expressive\Router\RouterInterface;
 use Zend\Expressive\Template\TemplateRendererInterface;
 use Zend\Stratigility\MiddlewarePipe;
 use Zend\Stratigility\Route as StratigilityRoute;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 /**
  * @covers Zend\Expressive\Application
@@ -295,7 +297,7 @@ class ApplicationTest extends TestCase
 
         $finalResponse = $this->prophesize(ResponseInterface::class)->reveal();
         $defaultDelegate = $this->prophesize(DelegateInterface::class);
-        $defaultDelegate->process(Argument::type(ServerRequestInterface::class))
+        $defaultDelegate->{HANDLER_METHOD}(Argument::type(ServerRequestInterface::class))
             ->willReturn($finalResponse);
 
         $emitter = $this->prophesize(EmitterInterface::class);
@@ -339,7 +341,7 @@ class ApplicationTest extends TestCase
 
         $finalResponse = $this->prophesize(ResponseInterface::class)->reveal();
         $defaultDelegate = $this->prophesize(DelegateInterface::class);
-        $defaultDelegate->process(Argument::type(ServerRequestInterface::class))
+        $defaultDelegate->{HANDLER_METHOD}(Argument::type(ServerRequestInterface::class))
             ->willReturn($finalResponse);
 
         $emitter = $this->prophesize(EmitterInterface::class);

--- a/test/Container/ApplicationFactoryTest.php
+++ b/test/Container/ApplicationFactoryTest.php
@@ -8,12 +8,12 @@
 namespace ZendTest\Expressive\Container;
 
 use ArrayObject;
-use Interop\Http\ServerMiddleware\DelegateInterface;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 use ReflectionProperty;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 use Zend\Diactoros\Response\EmitterInterface;
 use Zend\Diactoros\Response\SapiEmitter;
 use Zend\Expressive\Application;

--- a/test/IntegrationTest.php
+++ b/test/IntegrationTest.php
@@ -8,13 +8,13 @@
 namespace ZendTest\Expressive;
 
 use Fig\Http\Message\StatusCodeInterface as StatusCode;
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\Response\EmitterInterface;
 use Zend\Diactoros\ServerRequest;

--- a/test/Middleware/DispatchMiddlewareTest.php
+++ b/test/Middleware/DispatchMiddlewareTest.php
@@ -7,17 +7,19 @@
 
 namespace ZendTest\Expressive\Middleware;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface as ServerMiddlewareInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 use Zend\Expressive\Middleware\DispatchMiddleware;
 use Zend\Expressive\Router\Route;
 use Zend\Expressive\Router\RouteResult;
 use Zend\Expressive\Router\RouterInterface;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 class DispatchMiddlewareTest extends TestCase
 {
@@ -54,7 +56,7 @@ class DispatchMiddlewareTest extends TestCase
     {
         $expected = $this->prophesize(ResponseInterface::class)->reveal();
         $this->request->getAttribute(RouteResult::class, false)->willReturn(false);
-        $this->delegate->process($this->request->reveal())->willReturn($expected);
+        $this->delegate->{HANDLER_METHOD}($this->request->reveal())->willReturn($expected);
 
         $response = $this->middleware->process($this->request->reveal(), $this->delegate->reveal());
 
@@ -63,7 +65,7 @@ class DispatchMiddlewareTest extends TestCase
 
     public function testInvokesMatchedMiddlewareWhenRouteResult()
     {
-        $this->delegate->process()->shouldNotBeCalled();
+        $this->delegate->{HANDLER_METHOD}()->shouldNotBeCalled();
 
         $expected = $this->prophesize(ResponseInterface::class)->reveal();
         $routedMiddleware = $this->prophesize(ServerMiddlewareInterface::class);
@@ -85,7 +87,7 @@ class DispatchMiddlewareTest extends TestCase
      */
     public function testCanDispatchCallableDoublePassMiddleware()
     {
-        $this->delegate->process()->shouldNotBeCalled();
+        $this->delegate->{HANDLER_METHOD}()->shouldNotBeCalled();
 
         $expected = $this->prophesize(ResponseInterface::class)->reveal();
         $routedMiddleware = function ($request, $response, $next) use ($expected) {
@@ -106,7 +108,7 @@ class DispatchMiddlewareTest extends TestCase
      */
     public function testCanDispatchMiddlewareServices()
     {
-        $this->delegate->process()->shouldNotBeCalled();
+        $this->delegate->{HANDLER_METHOD}()->shouldNotBeCalled();
 
         $expected = $this->prophesize(ResponseInterface::class)->reveal();
         $routedMiddleware = function ($request, $response, $next) use ($expected) {

--- a/test/Middleware/ImplicitHeadMiddlewareTest.php
+++ b/test/Middleware/ImplicitHeadMiddlewareTest.php
@@ -9,16 +9,18 @@ namespace ZendTest\Expressive\Middleware;
 
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;
 use Fig\Http\Message\StatusCodeInterface as StatusCode;
-use Interop\Http\ServerMiddleware\DelegateInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 use Zend\Diactoros\Response;
 use Zend\Expressive\Middleware\ImplicitHeadMiddleware;
 use Zend\Expressive\Router\Route;
 use Zend\Expressive\Router\RouteResult;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 class ImplicitHeadMiddlewareTest extends TestCase
 {
@@ -30,7 +32,7 @@ class ImplicitHeadMiddlewareTest extends TestCase
         $response = $this->prophesize(ResponseInterface::class)->reveal();
 
         $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->process($request->reveal())
+        $delegate->{HANDLER_METHOD}($request->reveal())
             ->willReturn($response);
 
         $middleware = new ImplicitHeadMiddleware();
@@ -48,7 +50,7 @@ class ImplicitHeadMiddlewareTest extends TestCase
         $response = $this->prophesize(ResponseInterface::class)->reveal();
 
         $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->process($request->reveal())
+        $delegate->{HANDLER_METHOD}($request->reveal())
             ->willReturn($response);
 
         $middleware = new ImplicitHeadMiddleware();
@@ -69,7 +71,7 @@ class ImplicitHeadMiddlewareTest extends TestCase
         $response = $this->prophesize(ResponseInterface::class)->reveal();
 
         $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->process($request->reveal())
+        $delegate->{HANDLER_METHOD}($request->reveal())
             ->willReturn($response);
 
         $middleware = new ImplicitHeadMiddleware();
@@ -93,7 +95,7 @@ class ImplicitHeadMiddlewareTest extends TestCase
         $response = $this->prophesize(ResponseInterface::class)->reveal();
 
         $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->process($request->reveal())
+        $delegate->{HANDLER_METHOD}($request->reveal())
             ->willReturn($response);
 
         $middleware = new ImplicitHeadMiddleware();
@@ -118,7 +120,7 @@ class ImplicitHeadMiddlewareTest extends TestCase
         $response = $this->prophesize(ResponseInterface::class)->reveal();
 
         $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->process($request->reveal())->shouldNotBeCalled($response);
+        $delegate->{HANDLER_METHOD}($request->reveal())->shouldNotBeCalled($response);
 
         $middleware = new ImplicitHeadMiddleware();
         $result = $middleware->process($request->reveal(), $delegate->reveal());
@@ -144,7 +146,7 @@ class ImplicitHeadMiddlewareTest extends TestCase
         $response = $this->prophesize(ResponseInterface::class)->reveal();
 
         $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->process($request->reveal())->shouldNotBeCalled($response);
+        $delegate->{HANDLER_METHOD}($request->reveal())->shouldNotBeCalled($response);
 
         $expected   = new Response();
         $middleware = new ImplicitHeadMiddleware($expected);
@@ -177,7 +179,7 @@ class ImplicitHeadMiddlewareTest extends TestCase
             ->will([$response, 'reveal']);
 
         $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->process($request->reveal())->will([$response, 'reveal']);
+        $delegate->{HANDLER_METHOD}($request->reveal())->will([$response, 'reveal']);
 
         $middleware = new ImplicitHeadMiddleware();
         $result = $middleware->process($request->reveal(), $delegate->reveal());

--- a/test/Middleware/ImplicitOptionsMiddlewareTest.php
+++ b/test/Middleware/ImplicitOptionsMiddlewareTest.php
@@ -9,14 +9,16 @@ namespace ZendTest\Expressive\Middleware;
 
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;
 use Fig\Http\Message\StatusCodeInterface as StatusCode;
-use Interop\Http\ServerMiddleware\DelegateInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 use Zend\Diactoros\Response;
 use Zend\Expressive\Middleware\ImplicitOptionsMiddleware;
 use Zend\Expressive\Router\Route;
 use Zend\Expressive\Router\RouteResult;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 class ImplicitOptionsMiddlewareTest extends TestCase
 {
@@ -29,7 +31,7 @@ class ImplicitOptionsMiddlewareTest extends TestCase
         $response = $this->prophesize(ResponseInterface::class)->reveal();
 
         $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->process($request->reveal())->willReturn($response);
+        $delegate->{HANDLER_METHOD}($request->reveal())->willReturn($response);
 
         $middleware = new ImplicitOptionsMiddleware();
         $result = $middleware->process($request->reveal(), $delegate->reveal());
@@ -45,7 +47,7 @@ class ImplicitOptionsMiddlewareTest extends TestCase
         $response = $this->prophesize(ResponseInterface::class)->reveal();
 
         $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->process($request->reveal())->willReturn($response);
+        $delegate->{HANDLER_METHOD}($request->reveal())->willReturn($response);
 
         $middleware = new ImplicitOptionsMiddleware();
         $result = $middleware->process($request->reveal(), $delegate->reveal());
@@ -64,7 +66,7 @@ class ImplicitOptionsMiddlewareTest extends TestCase
         $response = $this->prophesize(ResponseInterface::class)->reveal();
 
         $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->process($request->reveal())->willReturn($response);
+        $delegate->{HANDLER_METHOD}($request->reveal())->willReturn($response);
 
         $middleware = new ImplicitOptionsMiddleware();
         $result = $middleware->process($request->reveal(), $delegate->reveal());
@@ -86,7 +88,7 @@ class ImplicitOptionsMiddlewareTest extends TestCase
         $response = $this->prophesize(ResponseInterface::class)->reveal();
 
         $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->process($request->reveal())->willReturn($response);
+        $delegate->{HANDLER_METHOD}($request->reveal())->willReturn($response);
 
         $middleware = new ImplicitOptionsMiddleware();
         $result = $middleware->process($request->reveal(), $delegate->reveal());
@@ -111,7 +113,7 @@ class ImplicitOptionsMiddlewareTest extends TestCase
         $response = $this->prophesize(ResponseInterface::class)->reveal();
 
         $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->process($request->reveal())->shouldNotBeCalled();
+        $delegate->{HANDLER_METHOD}($request->reveal())->shouldNotBeCalled();
 
         $middleware = new ImplicitOptionsMiddleware();
         $result = $middleware->process($request->reveal(), $delegate->reveal());
@@ -137,7 +139,7 @@ class ImplicitOptionsMiddlewareTest extends TestCase
         $request->getAttribute(RouteResult::class, false)->will([$result, 'reveal']);
 
         $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->process($request->reveal())->shouldNotBeCalled();
+        $delegate->{HANDLER_METHOD}($request->reveal())->shouldNotBeCalled();
 
         $expected = $this->prophesize(ResponseInterface::class);
         $expected->withHeader('Allow', implode(',', $allowedMethods))->will([$expected, 'reveal']);

--- a/test/Middleware/LazyLoadingMiddlewareTest.php
+++ b/test/Middleware/LazyLoadingMiddlewareTest.php
@@ -7,13 +7,13 @@
 
 namespace ZendTest\Expressive\Middleware;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface as ServerMiddlewareInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 use Zend\Expressive\Exception\InvalidMiddlewareException;
 use Zend\Expressive\Middleware\LazyLoadingMiddleware;
 

--- a/test/Middleware/NotFoundHandlerTest.php
+++ b/test/Middleware/NotFoundHandlerTest.php
@@ -7,14 +7,16 @@
 
 namespace ZendTest\Expressive\Middleware;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
 use Zend\Expressive\Delegate\NotFoundDelegate;
 use Zend\Expressive\Middleware\NotFoundHandler;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 class NotFoundHandlerTest extends TestCase
 {
@@ -33,7 +35,7 @@ class NotFoundHandlerTest extends TestCase
         $this->request  = $this->prophesize(ServerRequestInterface::class);
 
         $this->delegate = $this->prophesize(DelegateInterface::class);
-        $this->delegate->process(Argument::type(ServerRequestInterface::class))->shouldNotBeCalled();
+        $this->delegate->{HANDLER_METHOD}(Argument::type(ServerRequestInterface::class))->shouldNotBeCalled();
     }
 
     public function testImplementsInteropMiddleware()
@@ -45,7 +47,7 @@ class NotFoundHandlerTest extends TestCase
     public function testProxiesToInternalDelegate()
     {
         $this->internal
-            ->process(Argument::that([$this->request, 'reveal']))
+            ->{HANDLER_METHOD}(Argument::that([$this->request, 'reveal']))
             ->willReturn('CONTENT');
 
         $handler = new NotFoundHandler($this->internal->reveal());

--- a/test/Middleware/RouteMiddlewareTest.php
+++ b/test/Middleware/RouteMiddlewareTest.php
@@ -8,16 +8,18 @@
 namespace ZendTest\Expressive\Middleware;
 
 use Fig\Http\Message\StatusCodeInterface as StatusCode;
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface as ServerMiddlewareInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 use Zend\Expressive\Middleware\RouteMiddleware;
 use Zend\Expressive\Router\Route;
 use Zend\Expressive\Router\RouteResult;
 use Zend\Expressive\Router\RouterInterface;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 class RouteMiddlewareTest extends TestCase
 {
@@ -54,7 +56,7 @@ class RouteMiddlewareTest extends TestCase
         $result = RouteResult::fromRouteFailure(['GET', 'POST']);
 
         $this->router->match($this->request->reveal())->willReturn($result);
-        $this->delegate->process()->shouldNotBeCalled();
+        $this->delegate->{HANDLER_METHOD}()->shouldNotBeCalled();
         $this->request->withAttribute()->shouldNotBeCalled();
         $this->response->withStatus(StatusCode::STATUS_METHOD_NOT_ALLOWED)->will([$this->response, 'reveal']);
         $this->response->withHeader('Allow', 'GET,POST')->will([$this->response, 'reveal']);
@@ -73,7 +75,7 @@ class RouteMiddlewareTest extends TestCase
         $this->request->withAttribute()->shouldNotBeCalled();
 
         $expected = $this->prophesize(ResponseInterface::class)->reveal();
-        $this->delegate->process($this->request->reveal())->willReturn($expected);
+        $this->delegate->{HANDLER_METHOD}($this->request->reveal())->willReturn($expected);
 
         $response = $this->middleware->process($this->request->reveal(), $this->delegate->reveal());
         $this->assertSame($expected, $response);
@@ -102,7 +104,7 @@ class RouteMiddlewareTest extends TestCase
 
         $expected = $this->prophesize(ResponseInterface::class)->reveal();
         $this->delegate
-            ->process($this->request->reveal())
+            ->{HANDLER_METHOD}($this->request->reveal())
             ->willReturn($expected);
 
         $response = $this->middleware->process($this->request->reveal(), $this->delegate->reveal());

--- a/test/Router/IntegrationTest.php
+++ b/test/Router/IntegrationTest.php
@@ -9,11 +9,11 @@ namespace ZendTest\Expressive\Router;
 
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;
 use Fig\Http\Message\StatusCodeInterface as StatusCode;
-use Interop\Http\ServerMiddleware\DelegateInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequest;
 use Zend\Diactoros\Stream;
@@ -24,6 +24,8 @@ use Zend\Expressive\Router\FastRouteRouter;
 use Zend\Expressive\Router\RouterInterface;
 use Zend\Expressive\Router\ZendRouter;
 use ZendTest\Expressive\ContainerTrait;
+
+use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 class IntegrationTest extends TestCase
 {
@@ -130,7 +132,7 @@ class IntegrationTest extends TestCase
     {
         $app = $this->createApplicationWithGetPost($adapter);
         $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->process(Argument::type(ServerRequest::class))
+        $delegate->{HANDLER_METHOD}(Argument::type(ServerRequest::class))
             ->shouldNotBeCalled();
 
         $request = new ServerRequest(['REQUEST_METHOD' => 'DELETE'], [], '/foo', 'DELETE');
@@ -155,7 +157,7 @@ class IntegrationTest extends TestCase
         $app->pipeDispatchMiddleware();
 
         $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->process(Argument::type(ServerRequest::class))
+        $delegate->{HANDLER_METHOD}(Argument::type(ServerRequest::class))
             ->shouldNotBeCalled();
 
         $request = new ServerRequest(['REQUEST_METHOD' => 'GET'], [], '/foo', 'GET');
@@ -183,7 +185,7 @@ class IntegrationTest extends TestCase
         $app->pipeDispatchMiddleware();
 
         $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->process(Argument::type(ServerRequest::class))
+        $delegate->{HANDLER_METHOD}(Argument::type(ServerRequest::class))
             ->shouldNotBeCalled();
 
         $request = new ServerRequest(['REQUEST_METHOD' => 'GET'], [], '/foo', 'GET');
@@ -211,7 +213,7 @@ class IntegrationTest extends TestCase
         $app->pipeDispatchMiddleware();
 
         $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->process(Argument::type(ServerRequest::class))
+        $delegate->{HANDLER_METHOD}(Argument::type(ServerRequest::class))
             ->shouldNotBeCalled();
 
         $request = new ServerRequest(['REQUEST_METHOD' => 'GET'], [], '/foo', 'GET');
@@ -238,7 +240,7 @@ class IntegrationTest extends TestCase
         $app->pipeDispatchMiddleware();
 
         $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->process(Argument::type(ServerRequest::class))
+        $delegate->{HANDLER_METHOD}(Argument::type(ServerRequest::class))
             ->shouldNotBeCalled();
 
         $request = new ServerRequest(['REQUEST_METHOD' => 'GET'], [], '/foo', 'GET');
@@ -278,7 +280,7 @@ class IntegrationTest extends TestCase
         }, ['DELETE']);
 
         $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->process(Argument::type(ServerRequest::class))
+        $delegate->{HANDLER_METHOD}(Argument::type(ServerRequest::class))
             ->shouldNotBeCalled();
 
         $request = new ServerRequest(['REQUEST_METHOD' => 'GET'], [], '/foo', 'GET');
@@ -334,7 +336,7 @@ class IntegrationTest extends TestCase
         });
 
         $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->process(Argument::type(ServerRequest::class))
+        $delegate->{HANDLER_METHOD}(Argument::type(ServerRequest::class))
             ->shouldNotBeCalled();
 
         $request = new ServerRequest(['REQUEST_METHOD' => $method], [], '/foo', $method);
@@ -396,7 +398,7 @@ class IntegrationTest extends TestCase
         });
 
         $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->process(Argument::type(ServerRequest::class))
+        $delegate->{HANDLER_METHOD}(Argument::type(ServerRequest::class))
             ->shouldNotBeCalled();
 
         $request  = new ServerRequest(['REQUEST_METHOD' => $method], [], '/foo', $method);
@@ -428,7 +430,7 @@ class IntegrationTest extends TestCase
         }, []);
 
         $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->process(Argument::type(ServerRequest::class))
+        $delegate->{HANDLER_METHOD}(Argument::type(ServerRequest::class))
             ->willReturn($this->response);
 
         $request = new ServerRequest(['REQUEST_METHOD' => $method], [], '/foo', $method);
@@ -458,7 +460,7 @@ class IntegrationTest extends TestCase
         }, []);
 
         $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->process(Argument::type(ServerRequest::class))
+        $delegate->{HANDLER_METHOD}(Argument::type(ServerRequest::class))
             ->shouldNotBeCalled();
 
         $request = new ServerRequest(['REQUEST_METHOD' => $method], [], '/foo', $method);
@@ -487,7 +489,7 @@ class IntegrationTest extends TestCase
 
         $expected = (new Response())->withStatus(StatusCode::STATUS_NOT_FOUND);
         $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->process(Argument::type(ServerRequest::class))
+        $delegate->{HANDLER_METHOD}(Argument::type(ServerRequest::class))
             ->willReturn($expected);
 
         $request = new ServerRequest(['REQUEST_METHOD' => 'GET'], [], '/foo', 'GET');

--- a/test/TestAsset/CallableInteropMiddleware.php
+++ b/test/TestAsset/CallableInteropMiddleware.php
@@ -7,8 +7,8 @@
 
 namespace ZendTest\Expressive\TestAsset;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 
 class CallableInteropMiddleware
 {

--- a/test/TestAsset/InteropMiddleware.php
+++ b/test/TestAsset/InteropMiddleware.php
@@ -7,9 +7,9 @@
 
 namespace ZendTest\Expressive\TestAsset;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface as ServerMiddlewareInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 
 class InteropMiddleware implements ServerMiddlewareInterface
 {


### PR DESCRIPTION
We accomplish it by using `webimpress/http-middleware-compatibility` library
which allows us to use any version of http-interop middleware.
Consumer of the library can decide what version want to use.

In composer.lock we keep `http-interop/http-middleware` in version 0.4.1
so tests run with the following version of middleware:
- lowest: 0.1.1
- locked: 0.4.1
- latest: 0.5.0


The question is if we want to support http-interop/http-middleware in version 0.1.1. This requires method `next` in `NotFoundHandler` (as a proxy to handle method). Method `process` is also now a proxy to `handle` method.

## Requires:

- https://github.com/zendframework/zend-expressive-router/pull/36
- https://github.com/zendframework/zend-stratigility/pull/112

to be merged and released before.