### PR TITLE
Require http-interop/http-middleware 0.4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "fig/http-message-util": "^1.1.2",
+        "http-interop/http-middleware": "^0.4.1",
         "psr/container": "^1.0",
         "psr/http-message": "^1.0.1",
         "zendframework/zend-diactoros": "^1.3.10",


### PR DESCRIPTION
Since the newest versions of zend-stratigility and zend-expressive-router each now depend on webimpress/http-middleware-compatibility, http-interop/http-middleware is no longer a required package. As such, new installations fail, as this package is necessary in order to run Expressive.

This patch adds the package with a constraint of ^0.4.1 in order to fix issues on the existing 2.0.X branch.

Fixes #519.