### PR TITLE
PSR-15 support (http-interop/http-server-middleware) + PHP 7.1

### DIFF
--- a/.docheader
+++ b/.docheader
@@ -1,5 +1,5 @@
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) %regexp:(20\d{2}-)?20\d{2}% Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) %regexp:(20\d{2}-)?20\d{2}% Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */

--- a/.docheader
+++ b/.docheader
@@ -3,3 +3,5 @@
  * @copyright Copyright (c) %regexp:(20\d{2}-)?20\d{2}% Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
+
+declare(strict_types=1);

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,36 +10,17 @@ env:
   global:
     - COMPOSER_ARGS="--no-interaction"
     - COVERAGE_DEPS="satooshi/php-coveralls"
-    - LEGACY_DEPS="phpunit/phpunit"
 
 matrix:
   include:
-    - php: 5.6
+    - php: 7.1
       env:
         - DEPS=lowest
-    - php: 5.6
+    - php: 7.1
       env:
         - DEPS=locked
         - CS_CHECK=true
         - TEST_COVERAGE=true
-    - php: 5.6
-      env:
-        - DEPS=latest
-    - php: 7
-      env:
-        - DEPS=lowest
-    - php: 7
-      env:
-        - DEPS=locked
-    - php: 7
-      env:
-        - DEPS=latest
-    - php: 7.1
-      env:
-        - DEPS=lowest
-    - php: 7.1
-      env:
-        - DEPS=locked
     - php: 7.1
       env:
         - DEPS=latest
@@ -52,16 +33,12 @@ matrix:
     - php: 7.2
       env:
         - DEPS=latest
-  allow_failures:
-    - php: 7.2
 
 before_install:
-  - if [[ $TEST_COVERAGE != 'true' && "$(php --version | grep xdebug -ci)" -ge 1 ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
-  - travis_retry composer self-update
+  - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
 
 install:
-  - travis_retry composer install $COMPOSER_ARGS --ignore-platform-reqs
-  - if [[ $TRAVIS_PHP_VERSION =~ ^5.6 ]]; then travis_retry composer update $COMPOSER_ARGS --with-dependencies $LEGACY_DEPS ; fi
+  - travis_retry composer install $COMPOSER_ARGS
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
   - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $COVERAGE_DEPS ; fi

--- a/bin/expressive-tooling
+++ b/bin/expressive-tooling
@@ -8,6 +8,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive;
 
 if (false === ($paths = getenv('PATH'))) {

--- a/bin/expressive-tooling
+++ b/bin/expressive-tooling
@@ -4,7 +4,7 @@
  * Script for migrating configuration-driven pipelines/routes to programmatic usage.
  *
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/composer.json
+++ b/composer.json
@@ -27,28 +27,37 @@
     "config": {
         "sort-packages": true
     },
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/webimpress/zend-expressive-router.git"
+        },
+        {
+            "type": "git",
+            "url": "https://github.com/webimpress/zend-stratigility.git"
+        }
+    ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.1",
         "fig/http-message-util": "^1.1.2",
-        "http-interop/http-middleware": "^0.4.1",
+        "http-interop/http-server-middleware": "^1.0.1",
         "psr/container": "^1.0",
         "psr/http-message": "^1.0.1",
-        "webimpress/http-middleware-compatibility": "^0.1.1",
         "zendframework/zend-diactoros": "^1.3.10",
-        "zendframework/zend-expressive-router": "^2.2",
+        "zendframework/zend-expressive-router": "dev-feature/psr-15 as 2.2",
         "zendframework/zend-expressive-template": "^1.0.4",
-        "zendframework/zend-stratigility": "^2.1"
+        "zendframework/zend-stratigility": "dev-feature/psr-15 as 2.2"
     },
     "require-dev": {
-        "filp/whoops": "^2.1.6 || ^1.1.10",
-        "malukenho/docheader": "^0.1.5",
+        "filp/whoops": "^1.1.10 || ^2.1.13",
+        "malukenho/docheader": "^0.1.6",
         "mockery/mockery": "^1.0",
-        "phpunit/phpunit": "^5.7.22 || ^6.4.1",
+        "phpunit/phpunit": "^6.4.4",
         "zendframework/zend-coding-standard": "~1.0.0",
         "zendframework/zend-expressive-aurarouter": "^2.0",
         "zendframework/zend-expressive-fastroute": "^2.0",
         "zendframework/zend-expressive-zendrouter": "^2.0.1",
-        "zendframework/zend-servicemanager": "^3.3 || ^2.7.8"
+        "zendframework/zend-servicemanager": "^2.7.8 || ^3.3"
     },
     "conflict": {
         "container-interop/container-interop": "<1.2.0"

--- a/composer.json
+++ b/composer.json
@@ -28,12 +28,6 @@
     "config": {
         "sort-packages": true
     },
-    "repositories": [
-        {
-            "type": "git",
-            "url": "https://github.com/webimpress/prophecy.git"
-        }
-    ],
     "require": {
         "php": "^7.1",
         "fig/http-message-util": "^1.1.2",
@@ -50,7 +44,6 @@
         "malukenho/docheader": "^0.1.6",
         "mockery/mockery": "^1.0",
         "phpunit/phpunit": "^6.5.3",
-        "phpspec/prophecy": "dev-hotfix/368 as 1.8",
         "zendframework/zend-coding-standard": "~1.0.0",
         "zendframework/zend-expressive-aurarouter": "^3.0.0-dev",
         "zendframework/zend-expressive-fastroute": "^3.0.0-dev",

--- a/composer.json
+++ b/composer.json
@@ -1,15 +1,16 @@
 {
     "name": "zendframework/zend-expressive",
     "description": "PSR-7 Middleware Microframework based on Stratigility",
-    "homepage": "https://docs.zendframework.com/zend-expressive/",
-    "type": "library",
     "license": "BSD-3-Clause",
     "keywords": [
         "http",
         "middleware",
         "psr",
         "psr-7",
-        "psr-11"
+        "psr-11",
+        "expressive",
+        "zf",
+        "zendframework"
     ],
     "support": {
         "docs": "https://docs.zendframework.com/zend-expressive/",
@@ -34,19 +35,19 @@
         "psr/container": "^1.0",
         "psr/http-message": "^1.0.1",
         "zendframework/zend-diactoros": "^1.3.10",
-        "zendframework/zend-expressive-router": "3.0.x-dev as 2.3",
+        "zendframework/zend-expressive-router": "^3.0.0-dev",
         "zendframework/zend-expressive-template": "^1.0.4",
-        "zendframework/zend-stratigility": "^3.0.0@dev"
+        "zendframework/zend-stratigility": "^3.0.0-dev"
     },
     "require-dev": {
         "filp/whoops": "^1.1.10 || ^2.1.13",
         "malukenho/docheader": "^0.1.6",
         "mockery/mockery": "^1.0",
-        "phpunit/phpunit": "^6.4.4",
+        "phpunit/phpunit": "^6.5.3",
         "zendframework/zend-coding-standard": "~1.0.0",
-        "zendframework/zend-expressive-aurarouter": "^2.0",
-        "zendframework/zend-expressive-fastroute": "^2.0",
-        "zendframework/zend-expressive-zendrouter": "^2.0.1",
+        "zendframework/zend-expressive-aurarouter": "^3.0.0-dev",
+        "zendframework/zend-expressive-fastroute": "^3.0.0-dev",
+        "zendframework/zend-expressive-zendrouter": "^3.0.0-dev",
         "zendframework/zend-servicemanager": "^2.7.8 || ^3.3"
     },
     "conflict": {

--- a/composer.json
+++ b/composer.json
@@ -27,12 +27,6 @@
     "config": {
         "sort-packages": true
     },
-    "repositories": [
-        {
-            "type": "git",
-            "url": "https://github.com/webimpress/zend-expressive-router.git"
-        }
-    ],
     "require": {
         "php": "^7.1",
         "fig/http-message-util": "^1.1.2",
@@ -40,9 +34,9 @@
         "psr/container": "^1.0",
         "psr/http-message": "^1.0.1",
         "zendframework/zend-diactoros": "^1.3.10",
-        "zendframework/zend-expressive-router": "dev-feature/psr-15 as 2.2",
+        "zendframework/zend-expressive-router": "3.0.x-dev as 2.3",
         "zendframework/zend-expressive-template": "^1.0.4",
-        "zendframework/zend-stratigility": "dev-release-3.0.0"
+        "zendframework/zend-stratigility": "^3.0.0@dev"
     },
     "require-dev": {
         "filp/whoops": "^1.1.10 || ^2.1.13",

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,12 @@
     "config": {
         "sort-packages": true
     },
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/webimpress/prophecy.git"
+        }
+    ],
     "require": {
         "php": "^7.1",
         "fig/http-message-util": "^1.1.2",
@@ -44,6 +50,7 @@
         "malukenho/docheader": "^0.1.6",
         "mockery/mockery": "^1.0",
         "phpunit/phpunit": "^6.5.3",
+        "phpspec/prophecy": "dev-hotfix/368 as 1.8",
         "zendframework/zend-coding-standard": "~1.0.0",
         "zendframework/zend-expressive-aurarouter": "^3.0.0-dev",
         "zendframework/zend-expressive-fastroute": "^3.0.0-dev",

--- a/composer.json
+++ b/composer.json
@@ -31,10 +31,6 @@
         {
             "type": "git",
             "url": "https://github.com/webimpress/zend-expressive-router.git"
-        },
-        {
-            "type": "git",
-            "url": "https://github.com/webimpress/zend-stratigility.git"
         }
     ],
     "require": {
@@ -46,7 +42,7 @@
         "zendframework/zend-diactoros": "^1.3.10",
         "zendframework/zend-expressive-router": "dev-feature/psr-15 as 2.2",
         "zendframework/zend-expressive-template": "^1.0.4",
-        "zendframework/zend-stratigility": "dev-feature/psr-15 as 2.2"
+        "zendframework/zend-stratigility": "dev-release-3.0.0"
     },
     "require-dev": {
         "filp/whoops": "^1.1.10 || ^2.1.13",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "4d91c926d89ea540bc410f5f2322e929",
+    "content-hash": "464b8c7f81b30f4719a323fc3bc754c7",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -1229,17 +1229,11 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.7.3",
+            "version": "dev-hotfix/368",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
-                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
-                "shasum": ""
+                "url": "https://github.com/webimpress/prophecy.git",
+                "reference": "e485d91f7844c3e41d606e4ccb780baee2f61b77"
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
@@ -1263,7 +1257,11 @@
                     "Prophecy\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Fixtures\\Prophecy\\": "fixtures"
+                }
+            },
             "license": [
                 "MIT"
             ],
@@ -1283,12 +1281,12 @@
             "keywords": [
                 "Double",
                 "Dummy",
-                "fake",
-                "mock",
-                "spy",
-                "stub"
+                "Fake",
+                "Mock",
+                "Spy",
+                "Stub"
             ],
-            "time": "2017-11-24T13:59:53+00:00"
+            "time": "2017-12-07T10:12:50+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3331,11 +3329,19 @@
             "time": "2017-08-22T14:19:23+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "alias": "1.8",
+            "alias_normalized": "1.8.0.0",
+            "version": "dev-hotfix/368",
+            "package": "phpspec/prophecy"
+        }
+    ],
     "minimum-stability": "stable",
     "stability-flags": {
         "zendframework/zend-expressive-router": 20,
         "zendframework/zend-stratigility": 20,
+        "phpspec/prophecy": 20,
         "zendframework/zend-expressive-aurarouter": 20,
         "zendframework/zend-expressive-fastroute": 20,
         "zendframework/zend-expressive-zendrouter": 20

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "464b8c7f81b30f4719a323fc3bc754c7",
+    "content-hash": "4d91c926d89ea540bc410f5f2322e929",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -364,12 +364,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-expressive-router.git",
-                "reference": "a1e5bdee6bb0e9e9315ae3003f2f516e2082d82d"
+                "reference": "57ebf529def0743ab9e781040e2a3c5b5aeb7533"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/a1e5bdee6bb0e9e9315ae3003f2f516e2082d82d",
-                "reference": "a1e5bdee6bb0e9e9315ae3003f2f516e2082d82d",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/57ebf529def0743ab9e781040e2a3c5b5aeb7533",
+                "reference": "57ebf529def0743ab9e781040e2a3c5b5aeb7533",
                 "shasum": ""
             },
             "require": {
@@ -416,7 +416,7 @@
                 "zend-expressive",
                 "zf"
             ],
-            "time": "2017-12-06T22:05:47+00:00"
+            "time": "2017-12-07T17:39:11+00:00"
         },
         {
             "name": "zendframework/zend-expressive-template",
@@ -1229,11 +1229,17 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "dev-hotfix/368",
+            "version": "1.7.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webimpress/prophecy.git",
-                "reference": "e485d91f7844c3e41d606e4ccb780baee2f61b77"
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
+                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
+                "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
@@ -1257,11 +1263,7 @@
                     "Prophecy\\": "src/"
                 }
             },
-            "autoload-dev": {
-                "psr-4": {
-                    "Fixtures\\Prophecy\\": "fixtures"
-                }
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -1281,12 +1283,12 @@
             "keywords": [
                 "Double",
                 "Dummy",
-                "Fake",
-                "Mock",
-                "Spy",
-                "Stub"
+                "fake",
+                "mock",
+                "spy",
+                "stub"
             ],
-            "time": "2017-12-07T10:12:50+00:00"
+            "time": "2017-11-24T13:59:53+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2722,12 +2724,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-expressive-aurarouter.git",
-                "reference": "d0fe9def683cfacd089eec304a14ccc197e9a414"
+                "reference": "b22b587bb46607b7c43f45e9502f33694ec320c8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-aurarouter/zipball/d0fe9def683cfacd089eec304a14ccc197e9a414",
-                "reference": "d0fe9def683cfacd089eec304a14ccc197e9a414",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-aurarouter/zipball/b22b587bb46607b7c43f45e9502f33694ec320c8",
+                "reference": "b22b587bb46607b7c43f45e9502f33694ec320c8",
                 "shasum": ""
             },
             "require": {
@@ -2771,7 +2773,7 @@
                 "zend-expressive",
                 "zf"
             ],
-            "time": "2017-12-06T22:41:45+00:00"
+            "time": "2017-12-07T17:42:05+00:00"
         },
         {
             "name": "zendframework/zend-expressive-fastroute",
@@ -2779,12 +2781,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-expressive-fastroute.git",
-                "reference": "106092ecf2301a6a55532b61106363433fbabc23"
+                "reference": "79874159de7ba22b25fac5807116dc1c806d4787"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-fastroute/zipball/106092ecf2301a6a55532b61106363433fbabc23",
-                "reference": "106092ecf2301a6a55532b61106363433fbabc23",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-fastroute/zipball/79874159de7ba22b25fac5807116dc1c806d4787",
+                "reference": "79874159de7ba22b25fac5807116dc1c806d4787",
                 "shasum": ""
             },
             "require": {
@@ -2833,7 +2835,7 @@
                 "zend-expressive",
                 "zf"
             ],
-            "time": "2017-12-06T21:43:32+00:00"
+            "time": "2017-12-07T17:56:06+00:00"
         },
         {
             "name": "zendframework/zend-expressive-zendrouter",
@@ -2841,12 +2843,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-expressive-zendrouter.git",
-                "reference": "9ad38c8bafd42787eea5e0e86a2c7aae39d7cfaf"
+                "reference": "56b14a02d272c45c0b1273984d6a5bedbf6bd587"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-zendrouter/zipball/9ad38c8bafd42787eea5e0e86a2c7aae39d7cfaf",
-                "reference": "9ad38c8bafd42787eea5e0e86a2c7aae39d7cfaf",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-zendrouter/zipball/56b14a02d272c45c0b1273984d6a5bedbf6bd587",
+                "reference": "56b14a02d272c45c0b1273984d6a5bedbf6bd587",
                 "shasum": ""
             },
             "require": {
@@ -2891,7 +2893,7 @@
                 "zend-expressive",
                 "zf"
             ],
-            "time": "2017-12-06T22:57:42+00:00"
+            "time": "2017-12-07T17:48:31+00:00"
         },
         {
             "name": "zendframework/zend-http",
@@ -3329,19 +3331,11 @@
             "time": "2017-08-22T14:19:23+00:00"
         }
     ],
-    "aliases": [
-        {
-            "alias": "1.8",
-            "alias_normalized": "1.8.0.0",
-            "version": "dev-hotfix/368",
-            "package": "phpspec/prophecy"
-        }
-    ],
+    "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
         "zendframework/zend-expressive-router": 20,
         "zendframework/zend-stratigility": 20,
-        "phpspec/prophecy": 20,
         "zendframework/zend-expressive-aurarouter": 20,
         "zendframework/zend-expressive-fastroute": 20,
         "zendframework/zend-expressive-zendrouter": 20

--- a/composer.lock
+++ b/composer.lock
@@ -2724,12 +2724,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-expressive-aurarouter.git",
-                "reference": "b22b587bb46607b7c43f45e9502f33694ec320c8"
+                "reference": "7129a050b4aab3acbcdb68bdbb363bb982959fec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-aurarouter/zipball/b22b587bb46607b7c43f45e9502f33694ec320c8",
-                "reference": "b22b587bb46607b7c43f45e9502f33694ec320c8",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-aurarouter/zipball/7129a050b4aab3acbcdb68bdbb363bb982959fec",
+                "reference": "7129a050b4aab3acbcdb68bdbb363bb982959fec",
                 "shasum": ""
             },
             "require": {
@@ -2773,7 +2773,7 @@
                 "zend-expressive",
                 "zf"
             ],
-            "time": "2017-12-07T17:42:05+00:00"
+            "time": "2017-12-07T21:12:43+00:00"
         },
         {
             "name": "zendframework/zend-expressive-fastroute",
@@ -2843,12 +2843,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-expressive-zendrouter.git",
-                "reference": "56b14a02d272c45c0b1273984d6a5bedbf6bd587"
+                "reference": "1234ab08bf3180cf91590ddee35472fcb43719e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-zendrouter/zipball/56b14a02d272c45c0b1273984d6a5bedbf6bd587",
-                "reference": "56b14a02d272c45c0b1273984d6a5bedbf6bd587",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-zendrouter/zipball/1234ab08bf3180cf91590ddee35472fcb43719e4",
+                "reference": "1234ab08bf3180cf91590ddee35472fcb43719e4",
                 "shasum": ""
             },
             "require": {
@@ -2893,7 +2893,7 @@
                 "zend-expressive",
                 "zf"
             ],
-            "time": "2017-12-07T17:48:31+00:00"
+            "time": "2017-12-07T21:14:39+00:00"
         },
         {
             "name": "zendframework/zend-http",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "2001afe27d32d0a038f4e8f5d109b68d",
+    "content-hash": "4d91c926d89ea540bc410f5f2322e929",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -364,12 +364,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-expressive-router.git",
-                "reference": "20ac6001322e4dd200aced2e02a75b6bd7c7446d"
+                "reference": "a1e5bdee6bb0e9e9315ae3003f2f516e2082d82d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/20ac6001322e4dd200aced2e02a75b6bd7c7446d",
-                "reference": "20ac6001322e4dd200aced2e02a75b6bd7c7446d",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/a1e5bdee6bb0e9e9315ae3003f2f516e2082d82d",
+                "reference": "a1e5bdee6bb0e9e9315ae3003f2f516e2082d82d",
                 "shasum": ""
             },
             "require": {
@@ -416,7 +416,7 @@
                 "zend-expressive",
                 "zf"
             ],
-            "time": "2017-12-05T16:59:15+00:00"
+            "time": "2017-12-06T22:05:47+00:00"
         },
         {
             "name": "zendframework/zend-expressive-template",
@@ -473,12 +473,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-stratigility.git",
-                "reference": "f18dc2add534e15df3c9da6741fe831fdffdf1f1"
+                "reference": "a27cd099239e97f79d2adae5be7cbd62cda2a592"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-stratigility/zipball/f18dc2add534e15df3c9da6741fe831fdffdf1f1",
-                "reference": "f18dc2add534e15df3c9da6741fe831fdffdf1f1",
+                "url": "https://api.github.com/repos/zendframework/zend-stratigility/zipball/a27cd099239e97f79d2adae5be7cbd62cda2a592",
+                "reference": "a27cd099239e97f79d2adae5be7cbd62cda2a592",
                 "shasum": ""
             },
             "require": {
@@ -522,7 +522,7 @@
                 "psr-7",
                 "zf"
             ],
-            "time": "2017-12-05T15:25:15+00:00"
+            "time": "2017-12-05T19:16:17+00:00"
         }
     ],
     "packages-dev": [
@@ -662,16 +662,16 @@
         },
         {
             "name": "filp/whoops",
-            "version": "2.1.13",
+            "version": "2.1.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filp/whoops.git",
-                "reference": "9f640a4f129e57d3537887f840380109a4dd182b"
+                "reference": "c6081b8838686aa04f1e83ba7e91f78b7b2a23e6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filp/whoops/zipball/9f640a4f129e57d3537887f840380109a4dd182b",
-                "reference": "9f640a4f129e57d3537887f840380109a4dd182b",
+                "url": "https://api.github.com/repos/filp/whoops/zipball/c6081b8838686aa04f1e83ba7e91f78b7b2a23e6",
+                "reference": "c6081b8838686aa04f1e83ba7e91f78b7b2a23e6",
                 "shasum": ""
             },
             "require": {
@@ -719,7 +719,7 @@
                 "throwable",
                 "whoops"
             ],
-            "time": "2017-11-17T08:15:51+00:00"
+            "time": "2017-11-23T18:22:44+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -1131,29 +1131,35 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.1.1",
+            "version": "4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "2d3d238c433cf69caeb4842e97a3223a116f94b2"
+                "reference": "66465776cfc249844bde6d117abff1d22e06c2da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/2d3d238c433cf69caeb4842e97a3223a116f94b2",
-                "reference": "2d3d238c433cf69caeb4842e97a3223a116f94b2",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/66465776cfc249844bde6d117abff1d22e06c2da",
+                "reference": "66465776cfc249844bde6d117abff1d22e06c2da",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.0",
-                "phpdocumentor/reflection-common": "^1.0@dev",
+                "phpdocumentor/reflection-common": "^1.0.0",
                 "phpdocumentor/type-resolver": "^0.4.0",
                 "webmozart/assert": "^1.0"
             },
             "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^4.4"
+                "doctrine/instantiator": "~1.0.5",
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^6.4"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "phpDocumentor\\Reflection\\": [
@@ -1172,7 +1178,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-08-30T18:51:59+00:00"
+            "time": "2017-11-27T17:38:31+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -1223,16 +1229,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.7.2",
+            "version": "1.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6"
+                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6",
-                "reference": "c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
+                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
                 "shasum": ""
             },
             "require": {
@@ -1244,7 +1250,7 @@
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8 || ^5.6.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7"
             },
             "type": "library",
             "extra": {
@@ -1282,20 +1288,20 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-09-04T11:05:03+00:00"
+            "time": "2017-11-24T13:59:53+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "5.2.3",
+            "version": "5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "8e1d2397d8adf59a3f12b2878a3aaa66d1ab189d"
+                "reference": "661f34d0bd3f1a7225ef491a70a020ad23a057a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/8e1d2397d8adf59a3f12b2878a3aaa66d1ab189d",
-                "reference": "8e1d2397d8adf59a3f12b2878a3aaa66d1ab189d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/661f34d0bd3f1a7225ef491a70a020ad23a057a1",
+                "reference": "661f34d0bd3f1a7225ef491a70a020ad23a057a1",
                 "shasum": ""
             },
             "require": {
@@ -1304,14 +1310,13 @@
                 "php": "^7.0",
                 "phpunit/php-file-iterator": "^1.4.2",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^2.0",
+                "phpunit/php-token-stream": "^2.0.1",
                 "sebastian/code-unit-reverse-lookup": "^1.0.1",
                 "sebastian/environment": "^3.0",
                 "sebastian/version": "^2.0.1",
                 "theseer/tokenizer": "^1.1"
             },
             "require-dev": {
-                "ext-xdebug": "^2.5",
                 "phpunit/phpunit": "^6.0"
             },
             "suggest": {
@@ -1320,7 +1325,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.2.x-dev"
+                    "dev-master": "5.3.x-dev"
                 }
             },
             "autoload": {
@@ -1335,7 +1340,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -1346,20 +1351,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-11-03T13:47:33+00:00"
+            "time": "2017-12-06T09:29:45+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.2",
+            "version": "1.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
                 "shasum": ""
             },
             "require": {
@@ -1393,7 +1398,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03T07:40:28+00:00"
+            "time": "2017-11-27T13:52:08+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -1487,16 +1492,16 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "9a02332089ac48e704c70f6cefed30c224e3c0b0"
+                "reference": "791198a2c6254db10131eecfe8c06670700904db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/9a02332089ac48e704c70f6cefed30c224e3c0b0",
-                "reference": "9a02332089ac48e704c70f6cefed30c224e3c0b0",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/791198a2c6254db10131eecfe8c06670700904db",
+                "reference": "791198a2c6254db10131eecfe8c06670700904db",
                 "shasum": ""
             },
             "require": {
@@ -1532,20 +1537,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-08-20T05:47:52+00:00"
+            "time": "2017-11-27T05:48:46+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.4.4",
+            "version": "6.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "562f7dc75d46510a4ed5d16189ae57fbe45a9932"
+                "reference": "882e886cc928a0abd3c61282b2a64026237d14a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/562f7dc75d46510a4ed5d16189ae57fbe45a9932",
-                "reference": "562f7dc75d46510a4ed5d16189ae57fbe45a9932",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/882e886cc928a0abd3c61282b2a64026237d14a4",
+                "reference": "882e886cc928a0abd3c61282b2a64026237d14a4",
                 "shasum": ""
             },
             "require": {
@@ -1559,12 +1564,12 @@
                 "phar-io/version": "^1.0",
                 "php": "^7.0",
                 "phpspec/prophecy": "^1.7",
-                "phpunit/php-code-coverage": "^5.2.2",
-                "phpunit/php-file-iterator": "^1.4.2",
+                "phpunit/php-code-coverage": "^5.3",
+                "phpunit/php-file-iterator": "^1.4.3",
                 "phpunit/php-text-template": "^1.2.1",
                 "phpunit/php-timer": "^1.0.9",
-                "phpunit/phpunit-mock-objects": "^4.0.3",
-                "sebastian/comparator": "^2.0.2",
+                "phpunit/phpunit-mock-objects": "^5.0.4",
+                "sebastian/comparator": "^2.1",
                 "sebastian/diff": "^2.0",
                 "sebastian/environment": "^3.1",
                 "sebastian/exporter": "^3.1",
@@ -1590,7 +1595,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.4.x-dev"
+                    "dev-master": "6.5.x-dev"
                 }
             },
             "autoload": {
@@ -1616,20 +1621,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-11-08T11:26:09+00:00"
+            "time": "2017-12-06T09:42:03+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "4.0.4",
+            "version": "5.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "2f789b59ab89669015ad984afa350c4ec577ade0"
+                "reference": "16b50f4167e5e85e81ca8a3dd105d0a5fd32009a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/2f789b59ab89669015ad984afa350c4ec577ade0",
-                "reference": "2f789b59ab89669015ad984afa350c4ec577ade0",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/16b50f4167e5e85e81ca8a3dd105d0a5fd32009a",
+                "reference": "16b50f4167e5e85e81ca8a3dd105d0a5fd32009a",
                 "shasum": ""
             },
             "require": {
@@ -1642,7 +1647,7 @@
                 "phpunit/phpunit": "<6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^6.5"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -1650,7 +1655,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0.x-dev"
+                    "dev-master": "5.0.x-dev"
                 }
             },
             "autoload": {
@@ -1665,7 +1670,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -1675,7 +1680,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2017-08-03T14:08:16+00:00"
+            "time": "2017-12-02T05:31:19+00:00"
         },
         {
             "name": "psr/log",
@@ -2363,44 +2368,45 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.3.13",
+            "version": "v3.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "63cd7960a0a522c3537f6326706d7f3b8de65805"
+                "reference": "2cdef78de8f54f68ff16a857e710e7302b47d4c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/63cd7960a0a522c3537f6326706d7f3b8de65805",
-                "reference": "63cd7960a0a522c3537f6326706d7f3b8de65805",
+                "url": "https://api.github.com/repos/symfony/console/zipball/2cdef78de8f54f68ff16a857e710e7302b47d4c7",
+                "reference": "2cdef78de8f54f68ff16a857e710e7302b47d4c7",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.5.9|>=7.0.8",
-                "symfony/debug": "~2.8|~3.0",
+                "symfony/debug": "~2.8|~3.0|~4.0",
                 "symfony/polyfill-mbstring": "~1.0"
             },
             "conflict": {
-                "symfony/dependency-injection": "<3.3"
+                "symfony/dependency-injection": "<3.4",
+                "symfony/process": "<3.3"
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "~3.3",
-                "symfony/dependency-injection": "~3.3",
-                "symfony/event-dispatcher": "~2.8|~3.0",
-                "symfony/filesystem": "~2.8|~3.0",
-                "symfony/process": "~2.8|~3.0"
+                "symfony/config": "~3.3|~4.0",
+                "symfony/dependency-injection": "~3.4|~4.0",
+                "symfony/event-dispatcher": "~2.8|~3.0|~4.0",
+                "symfony/lock": "~3.4|~4.0",
+                "symfony/process": "~3.3|~4.0"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
                 "symfony/event-dispatcher": "",
-                "symfony/filesystem": "",
+                "symfony/lock": "",
                 "symfony/process": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "3.4-dev"
                 }
             },
             "autoload": {
@@ -2427,36 +2433,36 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2017-11-16T15:24:32+00:00"
+            "time": "2017-12-02T18:20:11+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v3.3.13",
+            "version": "v4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "74557880e2846b5c84029faa96b834da37e29810"
+                "reference": "26a15dab86c3820473716be4f846eac774ad4ad9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/74557880e2846b5c84029faa96b834da37e29810",
-                "reference": "74557880e2846b5c84029faa96b834da37e29810",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/26a15dab86c3820473716be4f846eac774ad4ad9",
+                "reference": "26a15dab86c3820473716be4f846eac774ad4ad9",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
+                "php": "^7.1.3",
                 "psr/log": "~1.0"
             },
             "conflict": {
-                "symfony/http-kernel": ">=2.3,<2.3.24|~2.4.0|>=2.5,<2.5.9|>=2.6,<2.6.2"
+                "symfony/http-kernel": "<3.4"
             },
             "require-dev": {
-                "symfony/http-kernel": "~2.8|~3.0"
+                "symfony/http-kernel": "~3.4|~4.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -2483,20 +2489,20 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2017-11-10T16:38:39+00:00"
+            "time": "2017-11-21T09:27:49+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v3.3.13",
+            "version": "v3.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "138af5ec075d4b1d1bd19de08c38a34bb2d7d880"
+                "reference": "dac8d7db537bac7ad8143eb11360a8c2231f251a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/138af5ec075d4b1d1bd19de08c38a34bb2d7d880",
-                "reference": "138af5ec075d4b1d1bd19de08c38a34bb2d7d880",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/dac8d7db537bac7ad8143eb11360a8c2231f251a",
+                "reference": "dac8d7db537bac7ad8143eb11360a8c2231f251a",
                 "shasum": ""
             },
             "require": {
@@ -2505,7 +2511,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "3.4-dev"
                 }
             },
             "autoload": {
@@ -2532,7 +2538,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2017-11-05T15:47:03+00:00"
+            "time": "2017-11-05T16:10:10+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -2714,35 +2720,36 @@
         },
         {
             "name": "zendframework/zend-expressive-aurarouter",
-            "version": "2.0.0",
+            "version": "dev-release-3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-expressive-aurarouter.git",
-                "reference": "f076b045481a931086d3b11eb7ebc3f0f66c041d"
+                "reference": "d0fe9def683cfacd089eec304a14ccc197e9a414"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-aurarouter/zipball/f076b045481a931086d3b11eb7ebc3f0f66c041d",
-                "reference": "f076b045481a931086d3b11eb7ebc3f0f66c041d",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-aurarouter/zipball/d0fe9def683cfacd089eec304a14ccc197e9a414",
+                "reference": "d0fe9def683cfacd089eec304a14ccc197e9a414",
                 "shasum": ""
             },
             "require": {
-                "aura/router": "^3.0",
-                "fig/http-message-util": "^1.1",
-                "php": "^5.6 || ^7.0",
-                "psr/http-message": "^1.0",
-                "zendframework/zend-expressive-router": "^2.0"
+                "aura/router": "^3.1",
+                "fig/http-message-util": "^1.1.2",
+                "php": "^7.1",
+                "psr/http-message": "^1.0.1",
+                "zendframework/zend-expressive-router": "^3.0.0@dev"
             },
             "require-dev": {
-                "malukenho/docheader": "^0.1.5",
-                "phpunit/phpunit": "^4.7 || ^5.6",
+                "malukenho/docheader": "^0.1.6",
+                "phpunit/phpunit": "^6.5.3",
                 "zendframework/zend-coding-standard": "~1.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev",
-                    "dev-develop": "2.1-dev"
+                    "dev-master": "2.1.x-dev",
+                    "dev-develop": "2.2.x-dev",
+                    "dev-release-3.0.0": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -2756,51 +2763,55 @@
             ],
             "description": "Aura.Router integration for Expressive",
             "keywords": [
+                "ZendFramework",
                 "aura",
                 "expressive",
                 "http",
                 "middleware",
                 "psr",
-                "psr-7"
+                "psr-7",
+                "zend-expressive",
+                "zf"
             ],
-            "time": "2017-01-11T21:59:35+00:00"
+            "time": "2017-12-06T22:41:45+00:00"
         },
         {
             "name": "zendframework/zend-expressive-fastroute",
-            "version": "2.1.0",
+            "version": "dev-release-3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-expressive-fastroute.git",
-                "reference": "20767d9df6d0154190e344e2bd6ba1a4db74a959"
+                "reference": "106092ecf2301a6a55532b61106363433fbabc23"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-fastroute/zipball/20767d9df6d0154190e344e2bd6ba1a4db74a959",
-                "reference": "20767d9df6d0154190e344e2bd6ba1a4db74a959",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-fastroute/zipball/106092ecf2301a6a55532b61106363433fbabc23",
+                "reference": "106092ecf2301a6a55532b61106363433fbabc23",
                 "shasum": ""
             },
             "require": {
                 "fig/http-message-util": "^1.1.2",
                 "nikic/fast-route": "^1.2",
-                "php": "^5.6 || ^7.0",
+                "php": "^7.1",
                 "psr/container": "^1.0",
                 "psr/http-message": "^1.0.1",
-                "zendframework/zend-expressive-router": "^2.0.1",
-                "zendframework/zend-stdlib": "^3.1"
+                "zendframework/zend-expressive-router": "^3.0.0@dev",
+                "zendframework/zend-stdlib": "^2.0 || ^3.1"
             },
             "conflict": {
                 "container-interop/container-interop": "<1.2.0"
             },
             "require-dev": {
-                "malukenho/docheader": "^0.1.5",
-                "phpunit/phpunit": "^6.0.7 || ^5.7.14",
+                "malukenho/docheader": "^0.1.6",
+                "phpunit/phpunit": "^6.5.3",
                 "zendframework/zend-coding-standard": "~1.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
                     "dev-master": "2.1-dev",
-                    "dev-develop": "2.2-dev"
+                    "dev-develop": "2.2-dev",
+                    "dev-release-3.0.0": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -2815,47 +2826,51 @@
             "description": "FastRoute integration for Expressive",
             "keywords": [
                 "FastRoute",
+                "ZendFramework",
                 "expressive",
                 "http",
                 "middleware",
                 "psr",
-                "psr-7"
+                "psr-7",
+                "zend-expressive",
+                "zf"
             ],
-            "time": "2017-08-11T18:46:49+00:00"
+            "time": "2017-12-06T21:43:32+00:00"
         },
         {
             "name": "zendframework/zend-expressive-zendrouter",
-            "version": "2.0.1",
+            "version": "dev-release-3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-expressive-zendrouter.git",
-                "reference": "89a18a82fff3c374d347f29b33411ca6a48a90c4"
+                "reference": "9ad38c8bafd42787eea5e0e86a2c7aae39d7cfaf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-zendrouter/zipball/89a18a82fff3c374d347f29b33411ca6a48a90c4",
-                "reference": "89a18a82fff3c374d347f29b33411ca6a48a90c4",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-zendrouter/zipball/9ad38c8bafd42787eea5e0e86a2c7aae39d7cfaf",
+                "reference": "9ad38c8bafd42787eea5e0e86a2c7aae39d7cfaf",
                 "shasum": ""
             },
             "require": {
-                "fig/http-message-util": "^1.1",
-                "php": "^5.6 || ^7.0",
-                "psr/http-message": "^1.0",
-                "zendframework/zend-expressive-router": "^2.0",
-                "zendframework/zend-psr7bridge": "^0.2.2",
-                "zendframework/zend-router": "^3.0"
+                "fig/http-message-util": "^1.1.2",
+                "php": "^7.1",
+                "psr/http-message": "^1.0.1",
+                "zendframework/zend-expressive-router": "^3.0.0@dev",
+                "zendframework/zend-psr7bridge": "^0.2.2 || ^1.0.0",
+                "zendframework/zend-router": "^3.0.2"
             },
             "require-dev": {
-                "malukenho/docheader": "^0.1.5",
-                "phpunit/phpunit": "^4.8 || ^5.6",
+                "malukenho/docheader": "^0.1.6",
+                "phpunit/phpunit": "^6.5.3",
                 "zendframework/zend-coding-standard": "~1.0.0",
-                "zendframework/zend-i18n": "^2.7"
+                "zendframework/zend-i18n": "^2.7.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev",
-                    "dev-develop": "2.1-dev"
+                    "dev-master": "2.1.x-dev",
+                    "dev-develop": "2.2.x-dev",
+                    "dev-release-3.0.0": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -2869,14 +2884,16 @@
             ],
             "description": "zend-mvc router support for Expressive",
             "keywords": [
+                "ZendFramework",
                 "expressive",
                 "http",
                 "middleware",
                 "psr",
                 "psr-7",
-                "zf2"
+                "zend-expressive",
+                "zf"
             ],
-            "time": "2017-03-01T22:55:46+00:00"
+            "time": "2017-12-06T22:57:42+00:00"
         },
         {
             "name": "zendframework/zend-http",
@@ -2977,27 +2994,27 @@
         },
         {
             "name": "zendframework/zend-psr7bridge",
-            "version": "0.2.2",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-psr7bridge.git",
-                "reference": "86c0b53b0c6381391c4add4a93a56e51d5c74605"
+                "reference": "935721336ded76fd5ba90ba7637c7d85b4d0cf68"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-psr7bridge/zipball/86c0b53b0c6381391c4add4a93a56e51d5c74605",
-                "reference": "86c0b53b0c6381391c4add4a93a56e51d5c74605",
+                "url": "https://api.github.com/repos/zendframework/zend-psr7bridge/zipball/935721336ded76fd5ba90ba7637c7d85b4d0cf68",
+                "reference": "935721336ded76fd5ba90ba7637c7d85b4d0cf68",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5",
+                "php": "^5.6 || ^7.0",
                 "psr/http-message": "^1.0",
                 "zendframework/zend-diactoros": "^1.1",
-                "zendframework/zend-http": "^2.5"
+                "zendframework/zend-http": "^2.6"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.7",
-                "squizlabs/php_codesniffer": "^2.3"
+                "phpunit/phpunit": "^5.7.15 || ^6.0.8",
+                "zendframework/zend-coding-standard": "~1.0.0"
             },
             "type": "library",
             "extra": {
@@ -3018,11 +3035,13 @@
             "description": "PSR-7 <-> Zend\\Http bridge",
             "homepage": "https://github.com/zendframework/zend-psr7bridge",
             "keywords": [
+                "ZendFramework",
                 "http",
                 "psr",
-                "psr-7"
+                "psr-7",
+                "zend"
             ],
-            "time": "2016-05-10T21:44:39+00:00"
+            "time": "2017-08-02T15:52:02+00:00"
         },
         {
             "name": "zendframework/zend-router",
@@ -3087,16 +3106,16 @@
         },
         {
             "name": "zendframework/zend-servicemanager",
-            "version": "3.3.0",
+            "version": "3.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-servicemanager.git",
-                "reference": "c3036efb81f71bfa36cc9962ee5d4474f36581d0"
+                "reference": "0fa3d3cf588dde0850fff1efa60d44a7aa3c3ab7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-servicemanager/zipball/c3036efb81f71bfa36cc9962ee5d4474f36581d0",
-                "reference": "c3036efb81f71bfa36cc9962ee5d4474f36581d0",
+                "url": "https://api.github.com/repos/zendframework/zend-servicemanager/zipball/0fa3d3cf588dde0850fff1efa60d44a7aa3c3ab7",
+                "reference": "0fa3d3cf588dde0850fff1efa60d44a7aa3c3ab7",
                 "shasum": ""
             },
             "require": {
@@ -3128,7 +3147,7 @@
             "extra": {
                 "branch-alias": {
                     "dev-master": "3.3-dev",
-                    "dev-develop": "3.4-dev"
+                    "dev-develop": "4.0-dev"
                 }
             },
             "autoload": {
@@ -3146,7 +3165,7 @@
                 "servicemanager",
                 "zf"
             ],
-            "time": "2017-03-01T22:08:02+00:00"
+            "time": "2017-11-27T18:11:25+00:00"
         },
         {
             "name": "zendframework/zend-stdlib",
@@ -3312,18 +3331,14 @@
             "time": "2017-08-22T14:19:23+00:00"
         }
     ],
-    "aliases": [
-        {
-            "alias": "2.3",
-            "alias_normalized": "2.3.0.0",
-            "version": "3.0.9999999.9999999-dev",
-            "package": "zendframework/zend-expressive-router"
-        }
-    ],
+    "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
         "zendframework/zend-expressive-router": 20,
-        "zendframework/zend-stratigility": 20
+        "zendframework/zend-stratigility": 20,
+        "zendframework/zend-expressive-aurarouter": 20,
+        "zendframework/zend-expressive-fastroute": 20,
+        "zendframework/zend-expressive-zendrouter": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/composer.lock
+++ b/composer.lock
@@ -492,12 +492,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-stratigility.git",
-                "reference": "ea9ea58c97f9dcadc7c70fcef93b9567fc82ab44"
+                "reference": "f810c5ca22d90929ed7fc36d976dd8a8cd519a51"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-stratigility/zipball/ea9ea58c97f9dcadc7c70fcef93b9567fc82ab44",
-                "reference": "ea9ea58c97f9dcadc7c70fcef93b9567fc82ab44",
+                "url": "https://api.github.com/repos/zendframework/zend-stratigility/zipball/f810c5ca22d90929ed7fc36d976dd8a8cd519a51",
+                "reference": "f810c5ca22d90929ed7fc36d976dd8a8cd519a51",
                 "shasum": ""
             },
             "require": {
@@ -540,7 +540,7 @@
                 "psr-7",
                 "zf"
             ],
-            "time": "2017-12-04T22:43:51+00:00"
+            "time": "2017-12-05T15:05:31+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "b72598edd15c6e040534eafb4d114a43",
+    "content-hash": "ab9f2f1ae47a6bdee9ab6a54b10debea",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -57,21 +57,21 @@
             "time": "2017-02-09T16:10:21+00:00"
         },
         {
-            "name": "http-interop/http-middleware",
-            "version": "0.4.1",
+            "name": "http-interop/http-server-handler",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/http-interop/http-middleware.git",
-                "reference": "9a801fe60e70d5d608b61d56b2dcde29516c81b9"
+                "url": "https://github.com/http-interop/http-server-handler.git",
+                "reference": "931a6495fb1b6005c9b4abc4dd11fb12a2a8103b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/http-interop/http-middleware/zipball/9a801fe60e70d5d608b61d56b2dcde29516c81b9",
-                "reference": "9a801fe60e70d5d608b61d56b2dcde29516c81b9",
+                "url": "https://api.github.com/repos/http-interop/http-server-handler/zipball/931a6495fb1b6005c9b4abc4dd11fb12a2a8103b",
+                "reference": "931a6495fb1b6005c9b4abc4dd11fb12a2a8103b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0",
+                "php": ">=7.0",
                 "psr/http-message": "^1.0"
             },
             "type": "library",
@@ -82,7 +82,63 @@
             },
             "autoload": {
                 "psr-4": {
-                    "Interop\\Http\\ServerMiddleware\\": "src/"
+                    "Interop\\Http\\Server\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP server-side request handler",
+            "keywords": [
+                "handler",
+                "http",
+                "psr",
+                "psr-15",
+                "psr-7",
+                "request",
+                "response",
+                "server"
+            ],
+            "time": "2017-11-09T18:35:22+00:00"
+        },
+        {
+            "name": "http-interop/http-server-middleware",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/http-interop/http-server-middleware.git",
+                "reference": "e605a7f47a002e857a3b9bb992010e2f859e4560"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/http-interop/http-server-middleware/zipball/e605a7f47a002e857a3b9bb992010e2f859e4560",
+                "reference": "e605a7f47a002e857a3b9bb992010e2f859e4560",
+                "shasum": ""
+            },
+            "require": {
+                "http-interop/http-server-handler": "^1.0",
+                "php": ">=7.0",
+                "psr/http-message": "^1.0"
+            },
+            "replace": {
+                "http-interop/http-middleware": ">=0.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Interop\\Http\\Server\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -97,16 +153,15 @@
             ],
             "description": "Common interface for HTTP server-side middleware",
             "keywords": [
-                "factory",
                 "http",
                 "middleware",
                 "psr",
-                "psr-17",
+                "psr-15",
                 "psr-7",
                 "request",
                 "response"
             ],
-            "time": "2017-01-14T15:23:42+00:00"
+            "time": "2017-11-09T21:42:30+00:00"
         },
         {
             "name": "psr/container",
@@ -208,57 +263,17 @@
             "time": "2016-08-06T14:39:51+00:00"
         },
         {
-            "name": "webimpress/http-middleware-compatibility",
-            "version": "0.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webimpress/http-middleware-compatibility.git",
-                "reference": "793d21864a0417bbe01437c33f902cac49c1788c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webimpress/http-middleware-compatibility/zipball/793d21864a0417bbe01437c33f902cac49c1788c",
-                "reference": "793d21864a0417bbe01437c33f902cac49c1788c",
-                "shasum": ""
-            },
-            "require": {
-                "http-interop/http-middleware": "^0.1.1 || ^0.2 || ^0.3 || ^0.4.1 || ^0.5",
-                "php": "^5.6 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.7.22 || ^6.3.1"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "autoload/http-middleware.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-2-Clause"
-            ],
-            "description": "Compatibility library for Draft PSR-15 HTTP Middleware",
-            "homepage": "https://github.com/webimpress/http-middleware-compatibility",
-            "keywords": [
-                "middleware",
-                "psr-15",
-                "webimpress"
-            ],
-            "time": "2017-10-05T15:55:30+00:00"
-        },
-        {
             "name": "zendframework/zend-diactoros",
-            "version": "1.6.0",
+            "version": "1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-diactoros.git",
-                "reference": "2faa791b66bac33ca40031d8bce03b7dc8143490"
+                "reference": "c8664b92a6d5bc229e48b0923486c097e45a7877"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-diactoros/zipball/2faa791b66bac33ca40031d8bce03b7dc8143490",
-                "reference": "2faa791b66bac33ca40031d8bce03b7dc8143490",
+                "url": "https://api.github.com/repos/zendframework/zend-diactoros/zipball/c8664b92a6d5bc229e48b0923486c097e45a7877",
+                "reference": "c8664b92a6d5bc229e48b0923486c097e45a7877",
                 "shasum": ""
             },
             "require": {
@@ -297,7 +312,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2017-09-13T14:47:08+00:00"
+            "time": "2017-10-12T15:24:51+00:00"
         },
         {
             "name": "zendframework/zend-escaper",
@@ -345,27 +360,21 @@
         },
         {
             "name": "zendframework/zend-expressive-router",
-            "version": "2.2.0",
+            "version": "dev-feature/psr-15",
             "source": {
                 "type": "git",
-                "url": "https://github.com/zendframework/zend-expressive-router.git",
-                "reference": "f6eac53d39cdbf7b6db11b3e6bb3565896633de4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/f6eac53d39cdbf7b6db11b3e6bb3565896633de4",
-                "reference": "f6eac53d39cdbf7b6db11b3e6bb3565896633de4",
-                "shasum": ""
+                "url": "https://github.com/webimpress/zend-expressive-router.git",
+                "reference": "62b11753700ec6c15766412d72dbe11d6fe9c60d"
             },
             "require": {
                 "fig/http-message-util": "^1.1.2",
-                "php": "^5.6 || ^7.0",
-                "psr/http-message": "^1.0.1",
-                "webimpress/http-middleware-compatibility": "^0.1.1"
+                "http-interop/http-server-middleware": "^1.0.1",
+                "php": "^7.1",
+                "psr/http-message": "^1.0.1"
             },
             "require-dev": {
                 "malukenho/docheader": "^0.1.5",
-                "phpunit/phpunit": "^6.0.8 || ^5.7.15",
+                "phpunit/phpunit": "^6.4.4",
                 "zendframework/zend-coding-standard": "~1.0.0"
             },
             "suggest": {
@@ -385,7 +394,36 @@
                     "Zend\\Expressive\\Router\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "ZendTest\\Expressive\\Router\\": "test/"
+                }
+            },
+            "scripts": {
+                "check": [
+                    "@license-check",
+                    "@cs-check",
+                    "@test"
+                ],
+                "upload-coverage": [
+                    "coveralls -v"
+                ],
+                "cs-check": [
+                    "phpcs --colors"
+                ],
+                "cs-fix": [
+                    "phpcbf --colors"
+                ],
+                "license-check": [
+                    "docheader check src/ test/"
+                ],
+                "test": [
+                    "phpunit --colors=always"
+                ],
+                "test-coverage": [
+                    "phpunit --coverage-clover clover.xml"
+                ]
+            },
             "license": [
                 "BSD-3-Clause"
             ],
@@ -397,7 +435,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2017-10-09T18:44:11+00:00"
+            "time": "2017-11-15T22:36:23+00:00"
         },
         {
             "name": "zendframework/zend-expressive-template",
@@ -450,27 +488,21 @@
         },
         {
             "name": "zendframework/zend-stratigility",
-            "version": "2.1.0",
+            "version": "dev-feature/psr-15",
             "source": {
                 "type": "git",
-                "url": "https://github.com/zendframework/zend-stratigility.git",
-                "reference": "74617cffd44180bef0aea63daca830d0b675c1c8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-stratigility/zipball/74617cffd44180bef0aea63daca830d0b675c1c8",
-                "reference": "74617cffd44180bef0aea63daca830d0b675c1c8",
-                "shasum": ""
+                "url": "https://github.com/webimpress/zend-stratigility.git",
+                "reference": "4a1cb4d27f0ee44616c6cb85ec29100cd66d13eb"
             },
             "require": {
-                "php": "^5.6 || ^7.0",
+                "http-interop/http-server-middleware": "^1.0.1",
+                "php": "^7.1",
                 "psr/http-message": "^1.0",
-                "webimpress/http-middleware-compatibility": "^0.1.1",
                 "zendframework/zend-escaper": "^2.3"
             },
             "require-dev": {
                 "malukenho/docheader": "^0.1.5",
-                "phpunit/phpunit": "^6.0.8 || ^5.7.15",
+                "phpunit/phpunit": "^5.7.22 || ^6.4.1",
                 "zendframework/zend-coding-standard": "~1.0.0",
                 "zendframework/zend-diactoros": "^1.0"
             },
@@ -489,7 +521,36 @@
                     "Zend\\Stratigility\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "ZendTest\\Stratigility\\": "test/"
+                }
+            },
+            "scripts": {
+                "check": [
+                    "@license-check",
+                    "@cs-check",
+                    "@test"
+                ],
+                "cs-check": [
+                    "phpcs"
+                ],
+                "cs-fix": [
+                    "phpcbf"
+                ],
+                "license-check": [
+                    "docheader check src/ test/"
+                ],
+                "test": [
+                    "phpunit --colors=always"
+                ],
+                "test-coverage": [
+                    "phpunit --colors=always --coverage-clover clover.xml"
+                ],
+                "upload-coverage": [
+                    "coveralls -v"
+                ]
+            },
             "license": [
                 "BSD-3-Clause"
             ],
@@ -498,9 +559,19 @@
             "keywords": [
                 "http",
                 "middleware",
-                "psr-7"
+                "psr-7",
+                "zendframework",
+                "zf"
             ],
-            "time": "2017-10-09T19:25:33+00:00"
+            "support": {
+                "docs": "https://docs.zendframework.com/zend-stratigility/",
+                "issues": "https://github.com/zendframework/zend-stratigility/issues",
+                "source": "https://github.com/zendframework/zend-stratigility",
+                "rss": "https://github.com/zendframework/zend-stratigility/releases.atom",
+                "slack": "https://zendframework-slack.herokuapp.com",
+                "forum": "https://discourse.zendframework.com/c/questions/expressive"
+            },
+            "time": "2017-11-13T11:14:36+00:00"
         }
     ],
     "packages-dev": [
@@ -640,16 +711,16 @@
         },
         {
             "name": "filp/whoops",
-            "version": "2.1.10",
+            "version": "2.1.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filp/whoops.git",
-                "reference": "ffbbd2c06c64b08fb47974eed5dbce4ca2bb0eec"
+                "reference": "9f640a4f129e57d3537887f840380109a4dd182b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filp/whoops/zipball/ffbbd2c06c64b08fb47974eed5dbce4ca2bb0eec",
-                "reference": "ffbbd2c06c64b08fb47974eed5dbce4ca2bb0eec",
+                "url": "https://api.github.com/repos/filp/whoops/zipball/9f640a4f129e57d3537887f840380109a4dd182b",
+                "reference": "9f640a4f129e57d3537887f840380109a4dd182b",
                 "shasum": ""
             },
             "require": {
@@ -658,7 +729,7 @@
             },
             "require-dev": {
                 "mockery/mockery": "0.9.*",
-                "phpunit/phpunit": "^4.8 || ^5.0",
+                "phpunit/phpunit": "^4.8.35 || ^5.7",
                 "symfony/var-dumper": "^2.6 || ^3.0"
             },
             "suggest": {
@@ -694,10 +765,10 @@
                 "exception",
                 "handling",
                 "library",
-                "whoops",
-                "zf2"
+                "throwable",
+                "whoops"
             ],
-            "time": "2017-08-03T18:23:40+00:00"
+            "time": "2017-11-17T08:15:51+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -865,37 +936,40 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.6.1",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "8e6e04167378abf1ddb4d3522d8755c5fd90d102"
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/8e6e04167378abf1ddb4d3522d8755c5fd90d102",
-                "reference": "8e6e04167378abf1ddb4d3522d8755c5fd90d102",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.0"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "doctrine/collections": "1.*",
-                "phpunit/phpunit": "~4.1"
+                "doctrine/collections": "^1.0",
+                "doctrine/common": "^2.6",
+                "phpunit/phpunit": "^4.1"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
                     "DeepCopy\\": "src/DeepCopy/"
-                }
+                },
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
             "description": "Create deep copies (clones) of your objects",
-            "homepage": "https://github.com/myclabs/DeepCopy",
             "keywords": [
                 "clone",
                 "copy",
@@ -903,7 +977,7 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-04-12T18:52:22+00:00"
+            "time": "2017-10-19T19:58:43+00:00"
         },
         {
             "name": "nikic/fast-route",
@@ -1261,16 +1335,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "5.2.2",
+            "version": "5.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "8ed1902a57849e117b5651fc1a5c48110946c06b"
+                "reference": "8e1d2397d8adf59a3f12b2878a3aaa66d1ab189d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/8ed1902a57849e117b5651fc1a5c48110946c06b",
-                "reference": "8ed1902a57849e117b5651fc1a5c48110946c06b",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/8e1d2397d8adf59a3f12b2878a3aaa66d1ab189d",
+                "reference": "8e1d2397d8adf59a3f12b2878a3aaa66d1ab189d",
                 "shasum": ""
             },
             "require": {
@@ -1279,7 +1353,7 @@
                 "php": "^7.0",
                 "phpunit/php-file-iterator": "^1.4.2",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^1.4.11 || ^2.0",
+                "phpunit/php-token-stream": "^2.0",
                 "sebastian/code-unit-reverse-lookup": "^1.0.1",
                 "sebastian/environment": "^3.0",
                 "sebastian/version": "^2.0.1",
@@ -1321,7 +1395,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-08-03T12:40:43+00:00"
+            "time": "2017-11-03T13:47:33+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1511,16 +1585,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.4.1",
+            "version": "6.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "b770d8ba7e60295ee91d69d5a5e01ae833cac220"
+                "reference": "562f7dc75d46510a4ed5d16189ae57fbe45a9932"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b770d8ba7e60295ee91d69d5a5e01ae833cac220",
-                "reference": "b770d8ba7e60295ee91d69d5a5e01ae833cac220",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/562f7dc75d46510a4ed5d16189ae57fbe45a9932",
+                "reference": "562f7dc75d46510a4ed5d16189ae57fbe45a9932",
                 "shasum": ""
             },
             "require": {
@@ -1591,7 +1665,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-10-07T17:53:53+00:00"
+            "time": "2017-11-08T11:26:09+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -1746,30 +1820,30 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "2.0.2",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "ae068fede81d06e7bb9bb46a367210a3d3e1fe6a"
+                "reference": "1174d9018191e93cb9d719edec01257fc05f8158"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/ae068fede81d06e7bb9bb46a367210a3d3e1fe6a",
-                "reference": "ae068fede81d06e7bb9bb46a367210a3d3e1fe6a",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/1174d9018191e93cb9d719edec01257fc05f8158",
+                "reference": "1174d9018191e93cb9d719edec01257fc05f8158",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.0",
                 "sebastian/diff": "^2.0",
-                "sebastian/exporter": "^3.0"
+                "sebastian/exporter": "^3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^6.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "2.1.x-dev"
                 }
             },
             "autoload": {
@@ -1800,13 +1874,13 @@
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
-            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
             "keywords": [
                 "comparator",
                 "compare",
                 "equality"
             ],
-            "time": "2017-08-03T07:14:59+00:00"
+            "time": "2017-11-03T07:16:52+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -2338,16 +2412,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.3.10",
+            "version": "v3.3.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "116bc56e45a8e5572e51eb43ab58c769a352366c"
+                "reference": "63cd7960a0a522c3537f6326706d7f3b8de65805"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/116bc56e45a8e5572e51eb43ab58c769a352366c",
-                "reference": "116bc56e45a8e5572e51eb43ab58c769a352366c",
+                "url": "https://api.github.com/repos/symfony/console/zipball/63cd7960a0a522c3537f6326706d7f3b8de65805",
+                "reference": "63cd7960a0a522c3537f6326706d7f3b8de65805",
                 "shasum": ""
             },
             "require": {
@@ -2402,20 +2476,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2017-10-02T06:42:24+00:00"
+            "time": "2017-11-16T15:24:32+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v3.3.10",
+            "version": "v3.3.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "eb95d9ce8f18dcc1b3dfff00cb624c402be78ffd"
+                "reference": "74557880e2846b5c84029faa96b834da37e29810"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/eb95d9ce8f18dcc1b3dfff00cb624c402be78ffd",
-                "reference": "eb95d9ce8f18dcc1b3dfff00cb624c402be78ffd",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/74557880e2846b5c84029faa96b834da37e29810",
+                "reference": "74557880e2846b5c84029faa96b834da37e29810",
                 "shasum": ""
             },
             "require": {
@@ -2458,20 +2532,20 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2017-10-02T06:42:24+00:00"
+            "time": "2017-11-10T16:38:39+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v3.3.10",
+            "version": "v3.3.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "773e19a491d97926f236942484cb541560ce862d"
+                "reference": "138af5ec075d4b1d1bd19de08c38a34bb2d7d880"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/773e19a491d97926f236942484cb541560ce862d",
-                "reference": "773e19a491d97926f236942484cb541560ce862d",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/138af5ec075d4b1d1bd19de08c38a34bb2d7d880",
+                "reference": "138af5ec075d4b1d1bd19de08c38a34bb2d7d880",
                 "shasum": ""
             },
             "require": {
@@ -2507,20 +2581,20 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2017-10-02T06:42:24+00:00"
+            "time": "2017-11-05T15:47:03+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.5.0",
+            "version": "v1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "7c8fae0ac1d216eb54349e6a8baa57d515fe8803"
+                "reference": "2ec8b39c38cb16674bbf3fea2b6ce5bf117e1296"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/7c8fae0ac1d216eb54349e6a8baa57d515fe8803",
-                "reference": "7c8fae0ac1d216eb54349e6a8baa57d515fe8803",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/2ec8b39c38cb16674bbf3fea2b6ce5bf117e1296",
+                "reference": "2ec8b39c38cb16674bbf3fea2b6ce5bf117e1296",
                 "shasum": ""
             },
             "require": {
@@ -2532,7 +2606,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.5-dev"
+                    "dev-master": "1.6-dev"
                 }
             },
             "autoload": {
@@ -2566,7 +2640,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2017-06-14T15:44:48+00:00"
+            "time": "2017-10-11T12:05:26+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -2855,35 +2929,35 @@
         },
         {
             "name": "zendframework/zend-http",
-            "version": "2.6.0",
+            "version": "2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-http.git",
-                "reference": "09f4d279f46d86be63171ff62ee0f79eca878678"
+                "reference": "78aa510c0ea64bfb2aa234f50c4f232c9531acfa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-http/zipball/09f4d279f46d86be63171ff62ee0f79eca878678",
-                "reference": "09f4d279f46d86be63171ff62ee0f79eca878678",
+                "url": "https://api.github.com/repos/zendframework/zend-http/zipball/78aa510c0ea64bfb2aa234f50c4f232c9531acfa",
+                "reference": "78aa510c0ea64bfb2aa234f50c4f232c9531acfa",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5 || ^7.0",
-                "zendframework/zend-loader": "^2.5",
-                "zendframework/zend-stdlib": "^2.5 || ^3.0",
-                "zendframework/zend-uri": "^2.5",
-                "zendframework/zend-validator": "^2.5"
+                "php": "^5.6 || ^7.0",
+                "zendframework/zend-loader": "^2.5.1",
+                "zendframework/zend-stdlib": "^3.1 || ^2.7.7",
+                "zendframework/zend-uri": "^2.5.2",
+                "zendframework/zend-validator": "^2.10.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0",
+                "phpunit/phpunit": "^6.4.1 || ^5.7.15",
                 "zendframework/zend-coding-standard": "~1.0.0",
-                "zendframework/zend-config": "^2.5"
+                "zendframework/zend-config": "^3.1 || ^2.6"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6-dev",
-                    "dev-develop": "2.7-dev"
+                    "dev-master": "2.7-dev",
+                    "dev-develop": "2.8-dev"
                 }
             },
             "autoload": {
@@ -2898,10 +2972,13 @@
             "description": "provides an easy interface for performing Hyper-Text Transfer Protocol (HTTP) requests",
             "homepage": "https://github.com/zendframework/zend-http",
             "keywords": [
+                "ZendFramework",
                 "http",
-                "zf2"
+                "http client",
+                "zend",
+                "zf"
             ],
-            "time": "2017-01-31T14:41:02+00:00"
+            "time": "2017-10-13T12:06:24+00:00"
         },
         {
             "name": "zendframework/zend-loader",
@@ -3284,13 +3361,29 @@
             "time": "2017-08-22T14:19:23+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "alias": "2.2",
+            "alias_normalized": "2.2.0.0",
+            "version": "dev-feature/psr-15",
+            "package": "zendframework/zend-expressive-router"
+        },
+        {
+            "alias": "2.2",
+            "alias_normalized": "2.2.0.0",
+            "version": "dev-feature/psr-15",
+            "package": "zendframework/zend-stratigility"
+        }
+    ],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "zendframework/zend-expressive-router": 20,
+        "zendframework/zend-stratigility": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^5.6 || ^7.0"
+        "php": "^7.1"
     },
     "platform-dev": []
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "160c5ca78e6e370057f7fc271a8aff4c",
+    "content-hash": "2001afe27d32d0a038f4e8f5d109b68d",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -360,11 +360,17 @@
         },
         {
             "name": "zendframework/zend-expressive-router",
-            "version": "dev-feature/psr-15",
+            "version": "dev-release-3.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webimpress/zend-expressive-router.git",
-                "reference": "62b11753700ec6c15766412d72dbe11d6fe9c60d"
+                "url": "https://github.com/zendframework/zend-expressive-router.git",
+                "reference": "20ac6001322e4dd200aced2e02a75b6bd7c7446d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/20ac6001322e4dd200aced2e02a75b6bd7c7446d",
+                "reference": "20ac6001322e4dd200aced2e02a75b6bd7c7446d",
+                "shasum": ""
             },
             "require": {
                 "fig/http-message-util": "^1.1.2",
@@ -385,8 +391,9 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2-dev",
-                    "dev-develop": "2.3-dev"
+                    "dev-master": "2.2.x-dev",
+                    "dev-develop": "2.3.x-dev",
+                    "dev-release-3.0.0": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -394,48 +401,22 @@
                     "Zend\\Expressive\\Router\\": "src/"
                 }
             },
-            "autoload-dev": {
-                "psr-4": {
-                    "ZendTest\\Expressive\\Router\\": "test/"
-                }
-            },
-            "scripts": {
-                "check": [
-                    "@license-check",
-                    "@cs-check",
-                    "@test"
-                ],
-                "upload-coverage": [
-                    "coveralls -v"
-                ],
-                "cs-check": [
-                    "phpcs --colors"
-                ],
-                "cs-fix": [
-                    "phpcbf --colors"
-                ],
-                "license-check": [
-                    "docheader check src/ test/"
-                ],
-                "test": [
-                    "phpunit --colors=always"
-                ],
-                "test-coverage": [
-                    "phpunit --coverage-clover clover.xml"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
             ],
             "description": "Router subcomponent for Expressive",
             "keywords": [
+                "ZendFramework",
                 "expressive",
                 "http",
                 "middleware",
                 "psr",
-                "psr-7"
+                "psr-7",
+                "zend-expressive",
+                "zf"
             ],
-            "time": "2017-11-15T22:36:23+00:00"
+            "time": "2017-12-05T16:59:15+00:00"
         },
         {
             "name": "zendframework/zend-expressive-template",
@@ -492,12 +473,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-stratigility.git",
-                "reference": "f810c5ca22d90929ed7fc36d976dd8a8cd519a51"
+                "reference": "f18dc2add534e15df3c9da6741fe831fdffdf1f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-stratigility/zipball/f810c5ca22d90929ed7fc36d976dd8a8cd519a51",
-                "reference": "f810c5ca22d90929ed7fc36d976dd8a8cd519a51",
+                "url": "https://api.github.com/repos/zendframework/zend-stratigility/zipball/f18dc2add534e15df3c9da6741fe831fdffdf1f1",
+                "reference": "f18dc2add534e15df3c9da6741fe831fdffdf1f1",
                 "shasum": ""
             },
             "require": {
@@ -518,8 +499,9 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1.0-dev",
-                    "dev-develop": "2.2.0-dev"
+                    "dev-master": "2.1.x-dev",
+                    "dev-develop": "2.2.x-dev",
+                    "dev-release-3.0.0": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -540,7 +522,7 @@
                 "psr-7",
                 "zf"
             ],
-            "time": "2017-12-05T15:05:31+00:00"
+            "time": "2017-12-05T15:25:15+00:00"
         }
     ],
     "packages-dev": [
@@ -3332,9 +3314,9 @@
     ],
     "aliases": [
         {
-            "alias": "2.2",
-            "alias_normalized": "2.2.0.0",
-            "version": "dev-feature/psr-15",
+            "alias": "2.3",
+            "alias_normalized": "2.3.0.0",
+            "version": "3.0.9999999.9999999-dev",
             "package": "zendframework/zend-expressive-router"
         }
     ],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "ab9f2f1ae47a6bdee9ab6a54b10debea",
+    "content-hash": "160c5ca78e6e370057f7fc271a8aff4c",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -488,11 +488,17 @@
         },
         {
             "name": "zendframework/zend-stratigility",
-            "version": "dev-feature/psr-15",
+            "version": "dev-release-3.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webimpress/zend-stratigility.git",
-                "reference": "4a1cb4d27f0ee44616c6cb85ec29100cd66d13eb"
+                "url": "https://github.com/zendframework/zend-stratigility.git",
+                "reference": "ea9ea58c97f9dcadc7c70fcef93b9567fc82ab44"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-stratigility/zipball/ea9ea58c97f9dcadc7c70fcef93b9567fc82ab44",
+                "reference": "ea9ea58c97f9dcadc7c70fcef93b9567fc82ab44",
+                "shasum": ""
             },
             "require": {
                 "http-interop/http-server-middleware": "^1.0.1",
@@ -521,57 +527,20 @@
                     "Zend\\Stratigility\\": "src/"
                 }
             },
-            "autoload-dev": {
-                "psr-4": {
-                    "ZendTest\\Stratigility\\": "test/"
-                }
-            },
-            "scripts": {
-                "check": [
-                    "@license-check",
-                    "@cs-check",
-                    "@test"
-                ],
-                "cs-check": [
-                    "phpcs"
-                ],
-                "cs-fix": [
-                    "phpcbf"
-                ],
-                "license-check": [
-                    "docheader check src/ test/"
-                ],
-                "test": [
-                    "phpunit --colors=always"
-                ],
-                "test-coverage": [
-                    "phpunit --colors=always --coverage-clover clover.xml"
-                ],
-                "upload-coverage": [
-                    "coveralls -v"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
             ],
             "description": "Middleware for PHP",
             "homepage": "https://github.com/zendframework/zend-stratigility",
             "keywords": [
+                "ZendFramework",
                 "http",
                 "middleware",
                 "psr-7",
-                "zendframework",
                 "zf"
             ],
-            "support": {
-                "docs": "https://docs.zendframework.com/zend-stratigility/",
-                "issues": "https://github.com/zendframework/zend-stratigility/issues",
-                "source": "https://github.com/zendframework/zend-stratigility",
-                "rss": "https://github.com/zendframework/zend-stratigility/releases.atom",
-                "slack": "https://zendframework-slack.herokuapp.com",
-                "forum": "https://discourse.zendframework.com/c/questions/expressive"
-            },
-            "time": "2017-11-13T11:14:36+00:00"
+            "time": "2017-12-04T22:43:51+00:00"
         }
     ],
     "packages-dev": [
@@ -3367,12 +3336,6 @@
             "alias_normalized": "2.2.0.0",
             "version": "dev-feature/psr-15",
             "package": "zendframework/zend-expressive-router"
-        },
-        {
-            "alias": "2.2",
-            "alias_normalized": "2.2.0.0",
-            "version": "dev-feature/psr-15",
-            "package": "zendframework/zend-stratigility"
         }
     ],
     "minimum-stability": "stable",

--- a/doc/book/cookbook/passing-data-between-middleware.md
+++ b/doc/book/cookbook/passing-data-between-middleware.md
@@ -16,15 +16,22 @@ want.
 ```php
 namespace App\Middleware;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
+// Expressive 3.X:
+use Interop\Http\Server\MiddlewareInterface;
+use Interop\Http\Server\RequestHandlerInterface;
+
+// Expressive 2.X:
+use Interop\Http\ServerMiddleware\DelegateInterface as RequestHandlerInterface;
 use Interop\Http\ServerMiddleware\MiddlewareInterface;
+
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 class PassingDataMiddleware implements MiddlewareInterface
 {
     // ...
 
-    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
     {
         // Step 1: Do something first
         $data = [
@@ -32,7 +39,10 @@ class PassingDataMiddleware implements MiddlewareInterface
         ];
         
         // Step 2: Inject data into the request, call the next middleware and wait for the response
-        $response = $delegate->process($request->withAttribute(self::class, $data));
+        // Expressive 3.X:
+        $response = $handler->handle($request->withAttribute(self::class, $data));
+        // Expressive 2.X:
+        $response = $handler->process($request->withAttribute(self::class, $data));
         
         // Step 3: Optionally, do something (with the response) before returning the response
         
@@ -47,21 +57,31 @@ Later, `ReceivingDataMiddleware` grabs the data and processes it:
 ```php
 namespace App\Middleware;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
+// Expressive 3.X:
+use Interop\Http\Server\MiddlewareInterface;
+use Interop\Http\Server\RequestHandlerInterface;
+
+// Expressive 2.X:
+use Interop\Http\ServerMiddleware\DelegateInterface as RequestHandlerInterface;
 use Interop\Http\ServerMiddleware\MiddlewareInterface;
+
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 class ReceivingDataMiddleware implements MiddlewareInterface
 {
     // ...
 
-    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
     {
         // Step 1: Grab the data from the request and use it
         $data = $request->getAttribute(PassingDataMiddleware::class);
         
         // Step 2: Call the next middleware and wait for the response
-        $response = $delegate->process($request);
+        // Expressive 3.X:
+        $response = $handler->handle($request);
+        // Expressive 2.X:
+        $response = $handler->process($request);
         
         // Step 3: Optionally, do something (with the response) before returning the response
         
@@ -78,8 +98,15 @@ information and passes it to the template renderer to create an `HtmlResponse`:
 ```php
 namespace App\Action;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
+// Expressive 3.X:
+use Interop\Http\Server\MiddlewareInterface;
+use Interop\Http\Server\RequestHandlerInterface;
+
+// Expressive 2.X:
+use Interop\Http\ServerMiddleware\DelegateInterface as RequestHandlerInterface;
 use Interop\Http\ServerMiddleware\MiddlewareInterface;
+
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Zend\Diactoros\Response\HtmlResponse;
 
@@ -87,7 +114,7 @@ class ExampleAction implements MiddlewareInterface
 {
     // ...
     
-    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
     {
         // Step 1: Grab the data from the request
         $data = $request->getAttribute(PassingDataMiddleware::class);

--- a/doc/book/cookbook/setting-locale-depending-routing-parameter.md
+++ b/doc/book/cookbook/setting-locale-depending-routing-parameter.md
@@ -136,19 +136,25 @@ Such a `LocalizationMiddleware` class could look similar to this:
 
 ```php
 <?php
-
 namespace Application\I18n;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
+// Expressive 3.X:
+use Interop\Http\Server\MiddlewareInterface;
+use Interop\Http\Server\RequestHandlerInterface;
+
+// Expressive 2.X:
+use Interop\Http\ServerMiddleware\DelegateInterface as RequestHandlerInterface;
 use Interop\Http\ServerMiddleware\MiddlewareInterface;
+
 use Locale;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 class LocalizationMiddleware implements MiddlewareInterface
 {
     const LOCALIZATION_ATTRIBUTE = 'locale';
 
-    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
     {
         // Get locale from route, fallback to the user's browser preference
         $locale = $request->getAttribute(
@@ -159,7 +165,10 @@ class LocalizationMiddleware implements MiddlewareInterface
         );
 
         // Store the locale as a request attribute
-        return $delegate->process($request->withAttribute(self::LOCALIZATION_ATTRIBUTE, $locale));
+        // Expressive 3.X:
+        return $handler->handle($request->withAttribute(self::LOCALIZATION_ATTRIBUTE, $locale));
+        // Expressive 2.X:
+        return $handler->process($request->withAttribute(self::LOCALIZATION_ATTRIBUTE, $locale));
     }
 }
 ```

--- a/doc/book/cookbook/using-routed-middleware-class-as-controller.md
+++ b/doc/book/cookbook/using-routed-middleware-class-as-controller.md
@@ -64,8 +64,16 @@ We might then implement `Album\Action\AlbumPage` as follows:
 namespace Album\Action;
 
 use Fig\Http\Message\StatusCodeInterface as StatusCode;
-use Interop\Http\ServerMiddleware\DelegateInterface;
+
+// Expressive 3.X:
+use Interop\Http\Server\MiddlewareInterface;
+use Interop\Http\Server\RequestHandlerInterface;
+
+// Expressive 2.X:
+use Interop\Http\ServerMiddleware\DelegateInterface as RequestHandlerInterface;
 use Interop\Http\ServerMiddleware\MiddlewareInterface;
+
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Zend\Diactoros\Response\EmptyResponse;
 use Zend\Diactoros\Response\HtmlResponse;
@@ -80,32 +88,32 @@ class AlbumPage implements MiddlewareInterface
         $this->template = $template;
     }
 
-    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
     {
         switch ($request->getAttribute('action', 'index')) {
             case 'index':
-                return $this->indexAction($request, $delegate);
+                return $this->indexAction($request, $handler);
             case 'add':
-                return $this->addAction($request, $delegate);
+                return $this->addAction($request, $handler);
             case 'edit':
-                return $this->editAction($request, $delegate);
+                return $this->editAction($request, $handler);
             default:
                 // Invalid; thus, a 404!
                 return new EmptyResponse(StatusCode::STATUS_NOT_FOUND);
         }
     }
 
-    public function indexAction(ServerRequestInterface $request, DelegateInterface $delegate)
+    public function indexAction(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
     {
         return new HtmlResponse($this->template->render('album::album-page'));
     }
 
-    public function addAction(ServerRequestInterface $request, DelegateInterface $delegate)
+    public function addAction(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
     {
         return new HtmlResponse($this->template->render('album::album-page-add'));
     }
 
-    public function editAction(ServerRequestInterface $request, DelegateInterface $delegate)
+    public function editAction(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
     {
         $id = $request->getAttribute('id', false);
         if (! $id) {
@@ -131,14 +139,22 @@ a generic implementation, via an `AbstractPage` class:
 namespace App\Action;
 
 use Fig\Http\Message\StatusCodeInterface as StatusCode;
-use Interop\Http\ServerMiddleware\DelegateInterface;
+
+// Expressive 3.X:
+use Interop\Http\Server\MiddlewareInterface;
+use Interop\http\Server\RequestHandlerInterface;
+
+// Expressive 2.X:
+use Interop\Http\ServerMiddleware\DelegateInterface as RequestHandlerInterface;
 use Interop\Http\ServerMiddleware\MiddlewareInterface;
+
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Zend\Diactoros\Response\EmptyResponse;
 
 abstract class AbstractPage implements MiddlewareInterface
 {
-    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
     {
         $action = $request->getAttribute('action', 'index') . 'Action';
 
@@ -146,7 +162,7 @@ abstract class AbstractPage implements MiddlewareInterface
             return new EmptyResponse(StatusCode::STATUS_NOT_FOUND);
         }
 
-        return $this->$action($request, $delegate);
+        return $this->$action($request, $handler);
     }
 }
 ```
@@ -160,12 +176,11 @@ Our original `AlbumPage` implementation could then be modified to extend
 `AbstractPage`:
 
 ```php
+<?php
 namespace Album\Action;
 
 use App\Action\AbstractPage;
-use Interop\Http\ServerMiddleware\DelegateInterface;
-use Psr\Http\Message\ServerRequestInterface;
-use Zend\Diactoros\Response\HtmlResponse;
+use Psr\Http\Message\ResponseInterface;
 use Zend\Expressive\Template\TemplateRendererInterface;
 
 class AlbumPage extends AbstractPage
@@ -177,9 +192,9 @@ class AlbumPage extends AbstractPage
         $this->template = $template;
     }
 
-    public function indexAction( /* ... */ ) { /* ... */ }
-    public function addAction( /* ... */ ) { /* ... */ }
-    public function editAction( /* ... */ ) { /* ... */ }
+    public function indexAction( /* ... */ ) : ResponseInterface { /* ... */ }
+    public function addAction( /* ... */ ) : ResponseInterface { /* ... */ }
+    public function editAction( /* ... */ ) : ResponseInterface { /* ... */ }
 }
 ```
 
@@ -193,13 +208,20 @@ class AlbumPage extends AbstractPage
 > namespace App\Action;
 > 
 > use Fig\Http\Message\StatusCodeInterface as StatusCode;
-> use Interop\Http\ServerMiddleware\DelegateInterface;
+>
+> // Expressive 3.X:
+> use Interop\Http\Server\RequestHandlerInterface;
+>
+> // Expressive 2.X:
+> use Interop\Http\ServerMiddleware\DelegateInterface as RequestHandlerInterface;
+>
+> use Psr\Http\Message\ResponseInterface;
 > use Psr\Http\Message\ServerRequestInterface;
 > use Zend\Diactoros\Response\EmptyResponse;
 > 
 > trait ActionBasedInvocation
 > {
->     public function process(ServerRequestInterface $request, DelegateInterface $delegate)
+>     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
 >     {
 >         $action = $request->getAttribute('action', 'index') . 'Action';
 > 
@@ -207,7 +229,7 @@ class AlbumPage extends AbstractPage
 >             return new EmptyResponse(StatusCode::STATUS_NOT_FOUND);
 >         }
 > 
->         return $this->$action($request, $delegate);
+>         return $this->$action($request, $handler);
 >     }
 > }
 > ```
@@ -217,23 +239,24 @@ class AlbumPage extends AbstractPage
 > ```php
 > <?php
 > namespace Album\Action;
-> 
+>
 > use App\Action\ActionBasedInvocation;
+> use Psr\Http\Message\ResponseInterface;
 > use Zend\Expressive\Template\TemplateRendererInterface;
-> 
+>
 > class AlbumPage
 > {
 >     use ActionBasedInvocation;
-> 
+>
 >     private $template;    
-> 
+>
 >     public function __construct(TemplateRendererInterface $template)
 >     {
 >         $this->template = $template;
 >     }
 > 
->     public function indexAction( /* ... */ ) { /* ... */ }
->     public function addAction( /* ... */ ) { /* ... */ }
->     public function editAction( /* ... */ ) { /* ... */ }
+>     public function indexAction( /* ... */ ) : ResponseInterface { /* ... */ }
+>     public function addAction( /* ... */ ) : ResponseInterface { /* ... */ }
+>     public function editAction( /* ... */ ) : ResponseInterface { /* ... */ }
 > }
 > ```

--- a/doc/book/cookbook/using-zend-form-view-helpers.md
+++ b/doc/book/cookbook/using-zend-form-view-helpers.md
@@ -197,10 +197,18 @@ regardless of the container implementation you choose.
 First, define the middleware:
 
 ```php
-namespace Your\Application
+<?php
+namespace Your\Application;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
+// Expressive 3.X:
+use Interop\Http\Server\MiddlewareInterface;
+use Interop\Http\Server\RequestHandlerInterface;
+
+// Expressive 2.X:
+use Interop\Http\ServerMiddleware\DelegateInterface as RequestHandlerInterface;
 use Interop\Http\ServerMiddleware\MiddlewareInterface;
+
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Zend\Form\View\HelperConfig as FormHelperConfig;
 use Zend\View\HelperPluginManager;
@@ -214,11 +222,15 @@ class FormHelpersMiddleware implements MiddlewareInterface
         $this->helpers = $helpers;
     }
 
-    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
     {
         $config = new FormHelperConfig();
         $config->configureServiceManager($this->helpers);
-        return $delegate->process($request);
+
+        // Expressive 3.X:
+        return $handler->handle($request);
+        // Expressive 2.X:
+        return $handler->process($request);
     }
 }
 ```

--- a/doc/book/features/helpers/server-url-helper.md
+++ b/doc/book/features/helpers/server-url-helper.md
@@ -131,8 +131,15 @@ Compose the helper in your middleware (or elsewhere), and then use it to
 generate URI paths:
 
 ```php
-use Interop\Http\ServerMiddleware\DelegateInterface;
+// Expressive 3.X:
+use Interop\Http\Server\MiddlewareInterfacel
+use Interop\Http\Server\RequestHandlerInterface;
+
+// Expressive 2.X:
+use Interop\Http\ServerMiddleware\DelegateInterface as RequestHandlerInterface;
 use Interop\Http\ServerMiddleware\MiddlewareInterface;
+
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Zend\Expressive\Helper\ServerUrlHelper;
 
@@ -145,9 +152,13 @@ class FooMiddleware implements MiddlewareInterface
         $this->helper = $helper;
     }
 
-    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
     {
-        $response = $delegate->process($request);
+        // Expressive 3.X:
+        $response = $handler->handle($request);
+        // Expressive 2.X:
+        $response = $handler->process($request);
+
         return $response->withHeader(
             'Link',
             $this->helper->generate() . '; rel="self"'

--- a/doc/book/features/middleware-types.md
+++ b/doc/book/features/middleware-types.md
@@ -18,22 +18,79 @@ HTTP POST requests to the path `/users`.
 
 Expressive allows you to define middleware using any of the following:
 
+- PSR-15 middlewares - [http-interop/http-server-middleware](https://github.com/http-interop/http-server-middleware)
+  instances (starting in Expressive 3.0)
+- Callable middleware that implements the http-interop/http-server-middleware signature
+  (starting in Expressive 3.0).
 - [http-interop/http-middleware](https://github.com/http-interop/http-middleware/tree/0.4.1)
-  instances (starting in Expressive 2.X).
+  instances (supported in Expressive 2.X only).
 - Callable middleware that implements the http-interop/http-middleware signature
-  (starting in Expressive 2.X).
+  (supported in Expressive 2.X only).
 - Callable "double-pass" middleware (as used in Expressive 1.X, and supported in
-  Expressive 2.X).
+  Expressive 2.X only).
 - Service names resolving to one of the above middleware types.
 - Middleware pipelines expressed as arrays of the above middleware types.
 
-## http-interop/http-middleware
+## PSR-15 middleware (http-interop/http-server-middleware) (Expressive 3.0)
+
+The http-interop/http-server-middleware project is the basis for the proposed
+PSR-15 specification, which covers HTTP Server Middleware that consumes
+[PSR-7](http://www.php-fig.org/psr/psr-7) HTTP messages. Expressive 3.0 accepts
+middleware that implements the `MiddlewareInterface`. As an example:
+
+```php
+use Interop\Http\Server\MiddlewareInterface;
+use Interop\Http\Server\RequestHandlerInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class SomeMiddleware implements MiddlewareInterface
+{
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
+    {
+        // do something and return a response, or
+        // delegate to another request handler capable
+        // of returning a response via:
+        //
+        // return $handler->handle($request);
+    }
+}
+```
+
+You could also implement such middleware via an anonymous class.
+
+## Callable http-server-middleware (Expressive 3.0)
+
+Sometimes you may not want to create a class for one-off middleware. As such,
+Expressive allows you to provide a PHP callable that uses the same signature as
+`Interop\Http\Server\MiddlewareInterface`:
+
+```php
+use Interop\Http\Server\MiddlewareInterface;
+use Interop\Http\Server\RequestHandlerInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+function (ServerRequestInterface $request, RequestHanlderInterface $handler) : ResponseInterface
+{
+    // do something and return a response, or
+    // delegate to another request handler capable
+    // of returning a response via:
+    //
+    // return $handler->handle($request);
+}
+```
+
+One note: the `$request` argument does not require a typehint, and examples
+throughout the manual will omit the typehint when demonstrating callable
+middleware.
+
+## http-interop/http-middleware (Expressive 2.X)
 
 The http-interop/http-middleware project is the basis for the proposed PSR-15
 specification, which covers HTTP Server Middleware that consumes
 [PSR-7](http://www.php-fig.org/psr/psr-7/) HTTP messages. The project defines two
 interfaces, `Interop\Http\ServerMiddleware\MiddlewareInterface` and 
-`Interop\Http\ServerMiddleware\DelegateInterface`. Expressive accepts middleware
+`Interop\Http\ServerMiddleware\DelegateInterface`. Expressive 2.0 accepts middleware
 that implements the `MiddlewareInterface`. As an example:
 
 ```php
@@ -57,7 +114,7 @@ class SomeMiddleware implements MiddlewareInterface
 If you are using PHP 7 or above, you could also implement such middleware via an
 anonymous class.
 
-## Callable http-middleware
+## Callable http-middleware (Expressive 2.X)
 
 Sometimes you may not want to create a class for one-off middleware. As such,
 Expressive allows you to provide a PHP callable that uses the same signature as
@@ -82,7 +139,7 @@ One note: the `$request` argument does not require a typehint, and examples
 throughout the manual will omit the typehint when demonstrating callable
 middleware.
 
-## Double-pass middleware
+## Double-pass middleware (Expressive 1.X and 2.X)
 
 Expressive 1.X was based on Stratigility 1.X, which allowed middleware with the
 following signature:
@@ -117,6 +174,9 @@ conditions that may otherwise occur due to incomplete or mutated response state.
 This middleware is still supported in Expressive 2.X, but we encourage users to
 adopt http-interop/http-middleware signatures, as we will be deprecating
 double-pass middleware eventually.
+
+> This functionality has been removed in Expressive 3.0.
+> We encourage users to use PSR-15 middlewares.
 
 ## Service-based middleware
 

--- a/doc/book/features/router/interface.md
+++ b/doc/book/features/router/interface.md
@@ -107,6 +107,10 @@ The `Route` class has the following signature:
 ```php
 namespace Zend\Expressive\Router;
 
+// Expressive 3.X:
+use Interop\Http\Server\MiddlewareInterface;
+
+// Expressive 2.X:
 use Interop\Http\ServerMiddleware\MiddlewareInterface;
 
 class Route

--- a/doc/book/features/template/middleware.md
+++ b/doc/book/features/template/middleware.md
@@ -16,10 +16,18 @@ middleware to accept the `TemplateRendererInterface` via either the constructor 
 setter. As an example:
 
 ```php
+<?php
 namespace Acme\Blog;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
+// Expressive 3.X:
+use Interop\Http\Server\MiddlewareInterface;
+use Interop\Http\Server\RequestHandlerInterface;
+
+// Expressive 2.X:
+use Interop\Http\ServerMiddleware\DelegateInterface as RequestHandlerInterface;
 use Interop\Http\ServerMiddleware\MiddlewareInterface;
+
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Zend\Expressive\Template\TemplateRendererInterface;
 
@@ -32,7 +40,7 @@ class EntryMiddleware implements MiddlewareInterface
         $this->templateRenderer = $renderer;
     }
 
-    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
     {
         // ...
     }
@@ -42,6 +50,7 @@ class EntryMiddleware implements MiddlewareInterface
 This will necessitate having a factory for your middleware:
 
 ```php
+<?php
 namespace Acme\Blog\Container;
 
 use Acme\Blog\EntryMiddleware;
@@ -70,10 +79,18 @@ consume it. Most often, we will want to render a template, optionally with
 substitutions to pass to it. This will typically look like the following:
 
 ```php
+<?php
 namespace Acme\Blog;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
+// Expressive 3.X:
+use Interop\Http\Server\MiddlewareInterface;
+use Interop\Http\Server\RequestHandlerInterface;
+
+// Expressive 2.X:
+use Interop\Http\ServerMiddleware\DelegateInterface as RequestHandlerInterface;
 use Interop\Http\ServerMiddleware\MiddlewareInterface;
+
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Zend\Diactoros\Response\HtmlResponse;
 use Zend\Expressive\Template\TemplateRendererInterface;
@@ -87,7 +104,7 @@ class EntryMiddleware implements MiddlewareInterface
         $this->templateRenderer = $renderer;
     }
 
-    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
     {
         // do some work...
         return new HtmlResponse(

--- a/doc/book/getting-started/features.md
+++ b/doc/book/getting-started/features.md
@@ -130,6 +130,9 @@ its way back out the onion.
 > 
 > Expressive 2.X still supports double-pass middleware, though we recommend the
 > lambda style.
+>
+> Expressive 3.0 does not longer support double-pass middleware. Please use
+> PSR-15 middlewares instead.
 
 > ### Stratigility 1.X Error Middleware
 >

--- a/doc/book/getting-started/skeleton.md
+++ b/doc/book/getting-started/skeleton.md
@@ -470,10 +470,13 @@ single method, `process()`, which accepts a
 > a "single-pass" or "lambda" architecture, whereby only the request instance is
 > passed between layers. We now recommend writing middleware using the
 > http-middleware interfaces for all new middleware.
+>
+> Starting in Expressive 3.0, we add support for
+> [PSR-15 middlewares](https://github.com/http-interop/http-server-middleware)
+> and abandoned http-interop/http-middleware middlewares are no longer supported.
 > 
-> Middleware using the double-pass style is still accepted by Expressive, but
-> support for it will be discontinued once http-middleware is formally approved
-> by PHP-FIG.
+> Middleware using the double-pass style is accepted only by Expressive 1.X and
+> 2.X, but no longer supported in Expressive 3.X.
 
 The skeleton defines an `App` namespace for you, and suggests placing middleware
 under the namespace `App\Action`.
@@ -485,14 +488,21 @@ Let's create a "Hello" action. Place the following in
 <?php
 namespace App\Action;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
+// Expressive 3.X:
+use Interop\Http\Server\MiddlewareInterface;
+use Interop\Http\Server\RequestHandlerInterface;
+
+// Expressive 2.X:
+use Interop\Http\ServerMiddleware\DelegateInterface as RequestHandlerInterface;
 use Interop\Http\ServerMiddleware\MiddlewareInterface;
+
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Zend\Diactoros\Response\HtmlResponse;
 
 class HelloAction implements MiddlewareInterface
 {
-    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
     {
         // On all PHP versions:
         $query  = $request->getQueryParams();
@@ -574,8 +584,15 @@ Replace your `src/App/Action/HelloAction.php` file with the following contents:
 <?php
 namespace App\Action;
 
-use Interop\Http\ServerMiddleware\DelegateInterface;
+// Expressive 3.X:
+use Interop\Http\Server\MiddlewareInterface;
+use Interop\Http\Server\RequestHandlerInterface;
+
+// Expressive 2.X:
+use Interop\Http\ServerMiddleware\DelegateInterface as RequestHandlerInterface;
 use Interop\Http\ServerMiddleware\MiddlewareInterface;
+
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Zend\Diactoros\Response\HtmlResponse;
 use Zend\Expressive\Template\TemplateRendererInterface;
@@ -589,7 +606,7 @@ class HelloAction implements MiddlewareInterface
         $this->renderer = $renderer;
     }
 
-    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
     {
         // On all PHP versions:
         $query  = $request->getQueryParams();

--- a/doc/book/index.html
+++ b/doc/book/index.html
@@ -126,7 +126,7 @@ $ composer create-project zendframework/zend-expressive-skeleton expressive</cod
           <pre><code class="language-php" data-trim>
 $pathMiddleware = function (
     ServerRequestInterface $request,
-    DelegateInterface $delegate
+    RequestHandlerInterface $handler
 ) {
     $uri  = $request->getUri();
     $path = $uri->getPath();

--- a/doc/book/reference/cli-tooling.md
+++ b/doc/book/reference/cli-tooling.md
@@ -75,6 +75,12 @@ Commands supported include:
   the [section on detecting legacy error middleware](#detect-usage-of-legacy-error-middleware)
   for more details.
 
+- **`migrate:interop-middleware [--src|-s=]`**: Scan for http-interop/http-middleware
+  middlewares and delegators and update them to PSR-15 (http-interop/http-server-middleware)
+  middlewares and request handlers. The script changes namespace of interfaces, rename method
+  `process` to `handle` for delegators/request handlers and adds PHP7 return type on method
+  `process` and `handle`. _Since Expressive 3.0._
+
 - **`migrate:original-messages [--src|-s]`**: Scan the associated source directory
   (defaults to `src`) for `getOriginal*()` method calls and replace them with
   `getAttribute()` calls. See the [section on detecting legacy

--- a/doc/book/reference/migration/to-v3.md
+++ b/doc/book/reference/migration/to-v3.md
@@ -1,0 +1,52 @@
+# Migration to Expressive 3.0
+
+Expressive 3.0 should not result in many upgrade problems for users. However,
+starting in this version, we offer a few changes affecting the following that
+you should be aware of, and potentially update your application to adopt:
+
+- [PHP 7.1 support](#php-7.1-support)
+- [Signature changes](#signature-changes)
+- [Removed functionality](#removed-functionality)
+- [PSR-15 support](#psr-15-support)
+
+## PHP 7.1 support
+
+Starting in Expressive 3.0 we support only PHP 7.1+.
+
+## Signature changes
+
+All middlewares and delegators implements now interfaces from PSR-15
+`http-interop/http-server-middleware`. It means the following changes:
+
+- middleware's `process` method type hint `RequestHandlerInterface` as
+  the second parameter instead of `DelegateInterface`,
+- middleware's `process` method has now return type
+  `\Psr\Http\Message\ResponseInterface`,
+- delegators are changed to request handlers: these now implements interface
+  `RequestHandlerInterface` instead of `DelegateInterface`,
+- delegator's `process` method has been renamed to `handle` and
+  return type `\Psr\Http\Message\ResponseInterface` has been declared.
+
+The following signature changes were made that could affect _class extensions_:
+
+- `Zend\Expressive\Application::__construct(...)`
+  Third parameter is now `RequestHandlerInterface` instead of `DelegateInterface`
+
+## Removed functionality 
+
+- double-pass middlewares (introduced in Expressive 1.X, deprecated in Expressive 2.X)
+
+## PSR-15 Support
+
+As said before, all middlewares and request handlers now implements PSR-15
+interfaces. It means `process` method (of middleware) and `handle` method
+(of request handler) have declared return type `\Psr\Http\Message\ResponseInterface`.
+
+To update your middlewares you can use tool available in `zend-expressive-tooling`:
+
+```console
+$ vendor/bin/expressive migrate:interop-middleware [--src|-s=<path-to-src>]
+```
+
+It looks for all interop middlewares and delegators and convert them to PSR-15
+middlewares and request delegators.

--- a/doc/book/reference/usage-examples.md
+++ b/doc/book/reference/usage-examples.md
@@ -166,7 +166,12 @@ the application will pull it from there when matched.
 Edit your `public/index.php` to read as follows:
 
 ```php
-use Interop\Http\ServerMiddleware\DelegateInterface;
+// Expressive 3.X:
+use Interop\Http\Server\RequestHandlerInterface;
+
+// Expressive 2.X:
+use Interop\Http\ServerMiddleware\DelegateInterface as RequestHandlerInterface;
+
 use Zend\Diactoros\Response\JsonResponse;
 use Zend\Diactoros\Response\TextResponse;
 use Zend\Expressive\AppFactory;
@@ -177,13 +182,13 @@ require __DIR__ . '/../vendor/autoload.php';
 $container = new ServiceManager();
 
 $container->setFactory('HelloWorld', function ($container) {
-    return function ($request, DelegateInterface $delegate) {
+    return function ($request, RequestHandlerInterface $handler) {
         return new TextResponse('Hello, world!');
     };
 });
 
 $container->setFactory('Ping', function ($container) {
-    return function ($request, DelegateInterface $delegate) {
+    return function ($request, RequestHandlerInterface $handler) {
         return new JsonResponse(['ack' => time()]);
     };
 });

--- a/src/AppFactory.php
+++ b/src/AppFactory.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/AppFactory.php
+++ b/src/AppFactory.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive;
 
 use Psr\Container\ContainerInterface;

--- a/src/Application.php
+++ b/src/Application.php
@@ -293,34 +293,18 @@ class Application extends MiddlewarePipe
      * @return Router\Route
      * @throws Exception\InvalidArgumentException if $path is not a Router\Route AND middleware is null.
      */
-    public function route($path, $middleware = null, array $methods = null, $name = null)
+    public function route(string $path, $middleware = null, array $methods = null, $name = null) : Router\Route
     {
-        if (! $path instanceof Router\Route && null === $middleware) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects either a route argument, or a combination of a path and middleware arguments',
-                __METHOD__
-            ));
-        }
-
-        if ($path instanceof Router\Route) {
-            $route   = $path;
-            $path    = $route->getPath();
-            $methods = $route->getAllowedMethods();
-            $name    = $route->getName();
-        }
-
         $this->checkForDuplicateRoute($path, $methods);
 
-        if (! isset($route)) {
-            $methods    = null === $methods ? Router\Route::HTTP_METHOD_ANY : $methods;
-            $middleware = $this->prepareMiddleware(
-                $middleware,
-                $this->router,
-                $this->responsePrototype,
-                $this->container
-            );
-            $route      = new Router\Route($path, $middleware, $methods, $name);
-        }
+        $methods    = null === $methods ? Router\Route::HTTP_METHOD_ANY : $methods;
+        $middleware = $this->prepareMiddleware(
+            $middleware,
+            $this->router,
+            $this->responsePrototype,
+            $this->container
+        );
+        $route      = new Router\Route($path, $middleware, $methods, $name);
 
         $this->routes[] = $route;
         $this->router->addRoute($route);

--- a/src/Application.php
+++ b/src/Application.php
@@ -204,7 +204,7 @@ class Application extends MiddlewarePipe
      * @param null|string|array|callable $middleware Middleware
      * @return self
      */
-    public function pipe($path, $middleware = null)
+    public function pipe($path, $middleware = null) : parent
     {
         if (null === $middleware) {
             $middleware = $this->prepareMiddleware(

--- a/src/Application.php
+++ b/src/Application.php
@@ -72,6 +72,11 @@ class Application extends MiddlewarePipe
     private $routes = [];
 
     /**
+     * @var ResponseInterface
+     */
+    private $responsePrototype;
+
+    /**
      * Constructor
      *
      * Calls on the parent constructor, and then uses the provided arguments
@@ -88,15 +93,15 @@ class Application extends MiddlewarePipe
         Router\RouterInterface $router,
         ContainerInterface $container = null,
         RequestHandlerInterface $defaultDelegate = null,
-        EmitterInterface $emitter = null
+        EmitterInterface $emitter = null,
+        ResponseInterface $responsePrototype = null
     ) {
         parent::__construct();
         $this->router          = $router;
         $this->container       = $container;
         $this->defaultDelegate = $defaultDelegate;
         $this->emitter         = $emitter;
-
-        $this->setResponsePrototype(new Response());
+        $this->responsePrototype = $responsePrototype ?: new Response();
     }
 
     /**

--- a/src/Application.php
+++ b/src/Application.php
@@ -15,6 +15,7 @@ use InvalidArgumentException;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
 use UnexpectedValueException;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\Response\EmitterInterface;
@@ -483,10 +484,10 @@ class Application extends MiddlewarePipe
     }
 
     /**
-     * @param \Exception|\Throwable $exception
+     * @param Throwable $exception
      * @return void
      */
-    private function emitMarshalServerRequestException($exception)
+    private function emitMarshalServerRequestException(Throwable $exception)
     {
         if ($this->container && $this->container->has(Middleware\ErrorResponseGenerator::class)) {
             $generator = $this->container->get(Middleware\ErrorResponseGenerator::class);

--- a/src/Application.php
+++ b/src/Application.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Zend\Expressive;
 
 use Fig\Http\Message\StatusCodeInterface as StatusCode;
+use Interop\Http\Server\MiddlewareInterface;
 use Interop\Http\Server\RequestHandlerInterface;
 use InvalidArgumentException;
 use Psr\Container\ContainerInterface;
@@ -286,14 +287,13 @@ class Application extends MiddlewarePipe
      * On first invocation, pipes the route middleware to the middleware
      * pipeline.
      *
-     * @param string|Router\Route $path
-     * @param callable|string|array $middleware Middleware (or middleware service name) to associate with route.
+     * @param callable|string|array|MiddlewareInterface $middleware Middleware (or middleware service name)
+     *     to associate with route.
      * @param null|array $methods HTTP method to accept; null indicates any.
      * @param null|string $name The name of the route.
-     * @return Router\Route
      * @throws Exception\InvalidArgumentException if $path is not a Router\Route AND middleware is null.
      */
-    public function route(string $path, $middleware = null, array $methods = null, $name = null) : Router\Route
+    public function route(string $path, $middleware, array $methods = null, string $name = null) : Router\Route
     {
         $this->checkForDuplicateRoute($path, $methods);
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive;
 
 use Fig\Http\Message\StatusCodeInterface as StatusCode;

--- a/src/Application.php
+++ b/src/Application.php
@@ -359,12 +359,8 @@ class Application extends MiddlewarePipe
     {
         try {
             $request  = $request ?: ServerRequestFactory::fromGlobals();
-        } catch (InvalidArgumentException $e) {
-            // Unable to parse uploaded files
-            $this->emitMarshalServerRequestException($e);
-            return;
-        } catch (UnexpectedValueException $e) {
-            // Invalid request method
+        } catch (InvalidArgumentException | UnexpectedValueException $e) {
+            // Unable to parse uploaded files | Invalid request method
             $this->emitMarshalServerRequestException($e);
             return;
         }

--- a/src/Application.php
+++ b/src/Application.php
@@ -8,12 +8,12 @@
 namespace Zend\Expressive;
 
 use Fig\Http\Message\StatusCodeInterface as StatusCode;
+use Interop\Http\Server\RequestHandlerInterface;
 use InvalidArgumentException;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use UnexpectedValueException;
-use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\Response\EmitterInterface;
 use Zend\Diactoros\Response\SapiEmitter;
@@ -38,7 +38,7 @@ class Application extends MiddlewarePipe
     private $container;
 
     /**
-     * @var null|DelegateInterface
+     * @var null|RequestHandlerInterface
      */
     private $defaultDelegate;
 
@@ -79,7 +79,7 @@ class Application extends MiddlewarePipe
      *
      * @param Router\RouterInterface $router
      * @param null|ContainerInterface $container IoC container from which to pull services, if any.
-     * @param null|DelegateInterface $defaultDelegate Default delegate
+     * @param null|RequestHandlerInterface $defaultDelegate Default delegate
      *     to use when $out is not provided on invocation / run() is invoked.
      * @param null|EmitterInterface $emitter Emitter to use when `run()` is
      *     invoked.
@@ -87,7 +87,7 @@ class Application extends MiddlewarePipe
     public function __construct(
         Router\RouterInterface $router,
         ContainerInterface $container = null,
-        DelegateInterface $defaultDelegate = null,
+        RequestHandlerInterface $defaultDelegate = null,
         EmitterInterface $emitter = null
     ) {
         parent::__construct();
@@ -397,7 +397,7 @@ class Application extends MiddlewarePipe
      * - If no container is composed, creates an instance of Delegate\NotFoundDelegate
      *   using the current response prototype only (i.e., no templating).
      *
-     * @return DelegateInterface
+     * @return RequestHandlerInterface
      */
     public function getDefaultDelegate()
     {

--- a/src/Application.php
+++ b/src/Application.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/ApplicationConfigInjectionTrait.php
+++ b/src/ApplicationConfigInjectionTrait.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive;
 
 use SplPriorityQueue;

--- a/src/ApplicationConfigInjectionTrait.php
+++ b/src/ApplicationConfigInjectionTrait.php
@@ -166,7 +166,7 @@ trait ApplicationConfigInjectionTrait
             }
 
             $name  = $spec['name'] ?? null;
-            $route = new Route($spec['path'], $spec['middleware'], $methods, $name);
+            $route = $this->route($spec['path'], $spec['middleware'], $methods, $name);
 
             if (isset($spec['options'])) {
                 $options = $spec['options'];
@@ -179,8 +179,6 @@ trait ApplicationConfigInjectionTrait
 
                 $route->setOptions($options);
             }
-
-            $this->route($route);
         }
     }
 

--- a/src/ApplicationConfigInjectionTrait.php
+++ b/src/ApplicationConfigInjectionTrait.php
@@ -93,7 +93,7 @@ trait ApplicationConfigInjectionTrait
         );
 
         foreach ($queue as $spec) {
-            $path = isset($spec['path']) ? $spec['path'] : '/';
+            $path = $spec['path'] ?? '/';
             $this->pipe($path, $spec['middleware']);
         }
     }
@@ -165,7 +165,7 @@ trait ApplicationConfigInjectionTrait
                 }
             }
 
-            $name  = isset($spec['name']) ? $spec['name'] : null;
+            $name  = $spec['name'] ?? null;
             $route = new Route($spec['path'], $spec['middleware'], $methods, $name);
 
             if (isset($spec['options'])) {

--- a/src/ApplicationConfigInjectionTrait.php
+++ b/src/ApplicationConfigInjectionTrait.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Container/ApplicationFactory.php
+++ b/src/Container/ApplicationFactory.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Container;
 
 use ArrayObject;

--- a/src/Container/ApplicationFactory.php
+++ b/src/Container/ApplicationFactory.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Container/ErrorHandlerFactory.php
+++ b/src/Container/ErrorHandlerFactory.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Container/ErrorHandlerFactory.php
+++ b/src/Container/ErrorHandlerFactory.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Container;
 
 use Psr\Container\ContainerInterface;

--- a/src/Container/ErrorResponseGeneratorFactory.php
+++ b/src/Container/ErrorResponseGeneratorFactory.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Container/ErrorResponseGeneratorFactory.php
+++ b/src/Container/ErrorResponseGeneratorFactory.php
@@ -23,11 +23,10 @@ class ErrorResponseGeneratorFactory
     {
         $config = $container->has('config') ? $container->get('config') : [];
 
-        $debug = isset($config['debug']) ? $config['debug'] : false;
+        $debug = $config['debug'] ?? false;
 
-        $template = isset($config['zend-expressive']['error_handler']['template_error'])
-            ? $config['zend-expressive']['error_handler']['template_error']
-            : ErrorResponseGenerator::TEMPLATE_DEFAULT;
+        $template = $config['zend-expressive']['error_handler']['template_error']
+            ?? ErrorResponseGenerator::TEMPLATE_DEFAULT;
 
         $renderer = $container->has(TemplateRendererInterface::class)
             ? $container->get(TemplateRendererInterface::class)

--- a/src/Container/ErrorResponseGeneratorFactory.php
+++ b/src/Container/ErrorResponseGeneratorFactory.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Container;
 
 use Psr\Container\ContainerInterface;

--- a/src/Container/Exception/ExceptionInterface.php
+++ b/src/Container/Exception/ExceptionInterface.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Container\Exception;
 
 /**

--- a/src/Container/Exception/ExceptionInterface.php
+++ b/src/Container/Exception/ExceptionInterface.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Container/Exception/InvalidServiceException.php
+++ b/src/Container/Exception/InvalidServiceException.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Container\Exception;
 
 use Psr\Container\ContainerExceptionInterface;

--- a/src/Container/Exception/InvalidServiceException.php
+++ b/src/Container/Exception/InvalidServiceException.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Container/NotFoundDelegateFactory.php
+++ b/src/Container/NotFoundDelegateFactory.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Container;
 
 use Psr\Container\ContainerInterface;

--- a/src/Container/NotFoundDelegateFactory.php
+++ b/src/Container/NotFoundDelegateFactory.php
@@ -26,12 +26,10 @@ class NotFoundDelegateFactory
         $renderer = $container->has(TemplateRendererInterface::class)
             ? $container->get(TemplateRendererInterface::class)
             : null;
-        $template = isset($config['zend-expressive']['error_handler']['template_404'])
-            ? $config['zend-expressive']['error_handler']['template_404']
-            : NotFoundDelegate::TEMPLATE_DEFAULT;
-        $layout = isset($config['zend-expressive']['error_handler']['layout'])
-            ? $config['zend-expressive']['error_handler']['layout']
-            : NotFoundDelegate::LAYOUT_DEFAULT;
+        $template = $config['zend-expressive']['error_handler']['template_404']
+            ?? NotFoundDelegate::TEMPLATE_DEFAULT;
+        $layout = $config['zend-expressive']['error_handler']['layout']
+            ?? NotFoundDelegate::LAYOUT_DEFAULT;
 
         return new NotFoundDelegate(new Response(), $renderer, $template, $layout);
     }

--- a/src/Container/NotFoundDelegateFactory.php
+++ b/src/Container/NotFoundDelegateFactory.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Container/NotFoundHandlerFactory.php
+++ b/src/Container/NotFoundHandlerFactory.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Container/NotFoundHandlerFactory.php
+++ b/src/Container/NotFoundHandlerFactory.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Container;
 
 use Psr\Container\ContainerInterface;

--- a/src/Container/WhoopsErrorResponseGeneratorFactory.php
+++ b/src/Container/WhoopsErrorResponseGeneratorFactory.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Container/WhoopsErrorResponseGeneratorFactory.php
+++ b/src/Container/WhoopsErrorResponseGeneratorFactory.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Container;
 
 use Psr\Container\ContainerInterface;

--- a/src/Container/WhoopsFactory.php
+++ b/src/Container/WhoopsFactory.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Container;
 
 use Psr\Container\ContainerInterface;

--- a/src/Container/WhoopsFactory.php
+++ b/src/Container/WhoopsFactory.php
@@ -51,7 +51,7 @@ class WhoopsFactory
     public function __invoke(ContainerInterface $container)
     {
         $config = $container->has('config') ? $container->get('config') : [];
-        $config = isset($config['whoops']) ? $config['whoops'] : [];
+        $config = $config['whoops'] ?? [];
 
         $whoops = new Whoops();
         $whoops->writeToOutput(false);

--- a/src/Container/WhoopsFactory.php
+++ b/src/Container/WhoopsFactory.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Container/WhoopsPageHandlerFactory.php
+++ b/src/Container/WhoopsPageHandlerFactory.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Container;
 
 use Psr\Container\ContainerInterface;

--- a/src/Container/WhoopsPageHandlerFactory.php
+++ b/src/Container/WhoopsPageHandlerFactory.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Container/WhoopsPageHandlerFactory.php
+++ b/src/Container/WhoopsPageHandlerFactory.php
@@ -40,7 +40,7 @@ class WhoopsPageHandlerFactory
     public function __invoke(ContainerInterface $container)
     {
         $config = $container->has('config') ? $container->get('config') : [];
-        $config = isset($config['whoops']) ? $config['whoops'] : [];
+        $config = $config['whoops'] ?? [];
 
         $pageHandler = new PrettyPageHandler();
 

--- a/src/Delegate/NotFoundDelegate.php
+++ b/src/Delegate/NotFoundDelegate.php
@@ -8,13 +8,12 @@
 namespace Zend\Expressive\Delegate;
 
 use Fig\Http\Message\StatusCodeInterface;
-use Psr\Http\Message\RequestInterface;
+use Interop\Http\Server\RequestHandlerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 use Zend\Expressive\Template\TemplateRendererInterface;
 
-class NotFoundDelegate implements DelegateInterface
+class NotFoundDelegate implements RequestHandlerInterface
 {
     const TEMPLATE_DEFAULT = 'error::404';
     const LAYOUT_DEFAULT = 'layout::default';
@@ -61,35 +60,12 @@ class NotFoundDelegate implements DelegateInterface
     }
 
     /**
-     * Proxy to handle method to support http-interop/http-middleware 0.1.1
-     *
-     * @param RequestInterface $request
-     * @return ResponseInterface
-     */
-    public function next(RequestInterface $request)
-    {
-        return $this->handle($request);
-    }
-
-    /**
-     * Proxy to handle method to support http-interop/http-middleware
-     * versions between 0.2 and 0.4.1
-     *
-     * @param ServerRequestInterface $request
-     * @return ResponseInterface
-     */
-    public function process(ServerRequestInterface $request)
-    {
-        return $this->handle($request);
-    }
-
-    /**
      * Creates and returns a 404 response.
      *
      * @param ServerRequestInterface $request
      * @return ResponseInterface
      */
-    public function handle(ServerRequestInterface $request)
+    public function handle(ServerRequestInterface $request) : ResponseInterface
     {
         if (! $this->renderer) {
             return $this->generatePlainTextResponse($request);
@@ -104,7 +80,7 @@ class NotFoundDelegate implements DelegateInterface
      * @param ServerRequestInterface $request
      * @return ResponseInterface
      */
-    private function generatePlainTextResponse(ServerRequestInterface $request)
+    private function generatePlainTextResponse(ServerRequestInterface $request) : ResponseInterface
     {
         $response = $this->responsePrototype->withStatus(StatusCodeInterface::STATUS_NOT_FOUND);
         $response->getBody()
@@ -113,6 +89,7 @@ class NotFoundDelegate implements DelegateInterface
                 $request->getMethod(),
                 (string) $request->getUri()
             ));
+
         return $response;
     }
 
@@ -124,7 +101,7 @@ class NotFoundDelegate implements DelegateInterface
      * @param ServerRequestInterface $request
      * @return ResponseInterface
      */
-    private function generateTemplatedResponse(ServerRequestInterface $request)
+    private function generateTemplatedResponse(ServerRequestInterface $request) : ResponseInterface
     {
         $response = $this->responsePrototype->withStatus(StatusCodeInterface::STATUS_NOT_FOUND);
         $response->getBody()->write(

--- a/src/Delegate/NotFoundDelegate.php
+++ b/src/Delegate/NotFoundDelegate.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Delegate;
 
 use Fig\Http\Message\StatusCodeInterface;

--- a/src/Delegate/NotFoundDelegate.php
+++ b/src/Delegate/NotFoundDelegate.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Emitter/EmitterStack.php
+++ b/src/Emitter/EmitterStack.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Emitter;
 
 use InvalidArgumentException;

--- a/src/Emitter/EmitterStack.php
+++ b/src/Emitter/EmitterStack.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Exception/BadMethodCallException.php
+++ b/src/Exception/BadMethodCallException.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Exception;
 
 class BadMethodCallException extends \BadMethodCallException implements

--- a/src/Exception/BadMethodCallException.php
+++ b/src/Exception/BadMethodCallException.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Exception/ContainerNotRegisteredException.php
+++ b/src/Exception/ContainerNotRegisteredException.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Exception;
 
 use RuntimeException;

--- a/src/Exception/ContainerNotRegisteredException.php
+++ b/src/Exception/ContainerNotRegisteredException.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Exception/DuplicateRouteException.php
+++ b/src/Exception/DuplicateRouteException.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Exception/DuplicateRouteException.php
+++ b/src/Exception/DuplicateRouteException.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Exception;
 
 use DomainException;

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Exception;
 
 /**

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Exception;
 
 class InvalidArgumentException extends \InvalidArgumentException implements

--- a/src/Exception/InvalidMiddlewareException.php
+++ b/src/Exception/InvalidMiddlewareException.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Exception;
 
 use RuntimeException;

--- a/src/Exception/InvalidMiddlewareException.php
+++ b/src/Exception/InvalidMiddlewareException.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Exception/MissingDependencyException.php
+++ b/src/Exception/MissingDependencyException.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Exception;
 
 use RuntimeException;

--- a/src/Exception/MissingDependencyException.php
+++ b/src/Exception/MissingDependencyException.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2015-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Exception;
 
 class RuntimeException extends \RuntimeException implements

--- a/src/IsCallableInteropMiddlewareTrait.php
+++ b/src/IsCallableInteropMiddlewareTrait.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive;
 
 use Closure;

--- a/src/IsCallableInteropMiddlewareTrait.php
+++ b/src/IsCallableInteropMiddlewareTrait.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/MarshalMiddlewareTrait.php
+++ b/src/MarshalMiddlewareTrait.php
@@ -10,8 +10,8 @@ namespace Zend\Expressive;
 use Interop\Http\Server\MiddlewareInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
-use Zend\Stratigility\Middleware\CallableInteropMiddlewareWrapper;
-use Zend\Stratigility\Middleware\CallableMiddlewareWrapper;
+use Zend\Stratigility\Middleware\CallableMiddlewareDecorator;
+use Zend\Stratigility\Middleware\DoublePassMiddlewareDecorator;
 use Zend\Stratigility\MiddlewarePipe;
 
 /**
@@ -60,11 +60,11 @@ trait MarshalMiddlewareTrait
         }
 
         if ($this->isCallableInteropMiddleware($middleware)) {
-            return new CallableInteropMiddlewareWrapper($middleware);
+            return new CallableMiddlewareDecorator($middleware);
         }
 
         if (is_callable($middleware)) {
-            return new CallableMiddlewareWrapper($middleware, $responsePrototype);
+            return new DoublePassMiddlewareDecorator($middleware, $responsePrototype);
         }
 
         if (is_array($middleware)) {
@@ -112,7 +112,6 @@ trait MarshalMiddlewareTrait
         ContainerInterface $container = null
     ) {
         $middlewarePipe = new MiddlewarePipe();
-        $middlewarePipe->setResponsePrototype($responsePrototype);
 
         foreach ($middlewares as $middleware) {
             $middlewarePipe->pipe(
@@ -149,7 +148,7 @@ trait MarshalMiddlewareTrait
         }
 
         if ($this->isCallableInteropMiddleware($instance)) {
-            return new CallableInteropMiddlewareWrapper($instance);
+            return new CallableMiddlewareDecorator($instance);
         }
 
         if (! is_callable($instance)) {
@@ -160,6 +159,6 @@ trait MarshalMiddlewareTrait
             ));
         }
 
-        return new CallableMiddlewareWrapper($instance, $responsePrototype);
+        return new DoublePassMiddlewareDecorator($instance, $responsePrototype);
     }
 }

--- a/src/MarshalMiddlewareTrait.php
+++ b/src/MarshalMiddlewareTrait.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive;
 
 use Interop\Http\Server\MiddlewareInterface;

--- a/src/MarshalMiddlewareTrait.php
+++ b/src/MarshalMiddlewareTrait.php
@@ -7,9 +7,9 @@
 
 namespace Zend\Expressive;
 
+use Interop\Http\Server\MiddlewareInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
-use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 use Zend\Stratigility\Middleware\CallableInteropMiddlewareWrapper;
 use Zend\Stratigility\Middleware\CallableMiddlewareWrapper;
 use Zend\Stratigility\MiddlewarePipe;
@@ -38,7 +38,7 @@ trait MarshalMiddlewareTrait
      * @param Router\RouterInterface $router
      * @param ResponseInterface $responsePrototype
      * @param null|ContainerInterface $container
-     * @return ServerMiddlewareInterface
+     * @return MiddlewareInterface
      * @throws Exception\InvalidMiddlewareException
      */
     private function prepareMiddleware(
@@ -55,7 +55,7 @@ trait MarshalMiddlewareTrait
             return new Middleware\DispatchMiddleware($router, $responsePrototype, $container);
         }
 
-        if ($middleware instanceof ServerMiddlewareInterface) {
+        if ($middleware instanceof MiddlewareInterface) {
             return $middleware;
         }
 
@@ -82,7 +82,7 @@ trait MarshalMiddlewareTrait
         throw new Exception\InvalidMiddlewareException(sprintf(
             'Unable to resolve middleware "%s" to a callable or %s',
             is_object($middleware) ? get_class($middleware) . '[Object]' : gettype($middleware) . '[Scalar]',
-            ServerMiddlewareInterface::class
+            MiddlewareInterface::class
         ));
     }
 
@@ -128,10 +128,10 @@ trait MarshalMiddlewareTrait
      *
      * @param string $middleware
      * @param ResponseInterface $responsePrototype
-     * @return ServerMiddlewareInterface
+     * @return MiddlewareInterface
      * @throws Exception\InvalidMiddlewareException if $middleware is not a class.
      * @throws Exception\InvalidMiddlewareException if $middleware does not resolve
-     *     to either an invokable class or ServerMiddlewareInterface instance.
+     *     to either an invokable class or MiddlewareInterface instance.
      */
     private function marshalInvokableMiddleware($middleware, ResponseInterface $responsePrototype)
     {
@@ -144,7 +144,7 @@ trait MarshalMiddlewareTrait
 
         $instance = new $middleware();
 
-        if ($instance instanceof ServerMiddlewareInterface) {
+        if ($instance instanceof MiddlewareInterface) {
             return $instance;
         }
 
@@ -156,7 +156,7 @@ trait MarshalMiddlewareTrait
             throw new Exception\InvalidMiddlewareException(sprintf(
                 'Middleware of class "%s" is invalid; neither invokable nor %s',
                 $middleware,
-                ServerMiddlewareInterface::class
+                MiddlewareInterface::class
             ));
         }
 

--- a/src/MarshalMiddlewareTrait.php
+++ b/src/MarshalMiddlewareTrait.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Middleware/DispatchMiddleware.php
+++ b/src/Middleware/DispatchMiddleware.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Middleware;
 
 use Interop\Http\Server\MiddlewareInterface;

--- a/src/Middleware/DispatchMiddleware.php
+++ b/src/Middleware/DispatchMiddleware.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Middleware/ErrorResponseGenerator.php
+++ b/src/Middleware/ErrorResponseGenerator.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Middleware;
 
 use Psr\Http\Message\ResponseInterface;

--- a/src/Middleware/ErrorResponseGenerator.php
+++ b/src/Middleware/ErrorResponseGenerator.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Middleware/ErrorResponseGenerator.php
+++ b/src/Middleware/ErrorResponseGenerator.php
@@ -11,6 +11,7 @@ namespace Zend\Expressive\Middleware;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
 use Zend\Expressive\Template\TemplateRendererInterface;
 use Zend\Stratigility\Utils;
 
@@ -60,12 +61,12 @@ EOT;
     }
 
     /**
-     * @param \Throwable|\Exception $e
+     * @param Throwable $e
      * @param ServerRequestInterface $request
      * @param ResponseInterface $response
      * @return ResponseInterface
      */
-    public function __invoke($e, ServerRequestInterface $request, ResponseInterface $response)
+    public function __invoke(Throwable $e, ServerRequestInterface $request, ResponseInterface $response)
     {
         $response = $response->withStatus(Utils::getStatusCode($e, $response));
 
@@ -77,12 +78,12 @@ EOT;
     }
 
     /**
-     * @param \Throwable|\Exception $e
+     * @param Throwable $e
      * @param ServerRequestInterface $request
      * @param ResponseInterface $response
      * @return ResponseInterface
      */
-    private function prepareTemplatedResponse($e, ServerRequestInterface $request, ResponseInterface $response)
+    private function prepareTemplatedResponse(Throwable $e, ServerRequestInterface $request, ResponseInterface $response)
     {
         $templateData = [
             'response' => $response,
@@ -104,11 +105,11 @@ EOT;
     }
 
     /**
-     * @param \Throwable|\Exception $e
+     * @param Throwable $e
      * @param ResponseInterface $response
      * @return ResponseInterface
      */
-    private function prepareDefaultResponse($e, ResponseInterface $response)
+    private function prepareDefaultResponse(Throwable $e, ResponseInterface $response)
     {
         $message = 'An unexpected error occurred';
 
@@ -124,10 +125,10 @@ EOT;
     /**
      * Prepares a stack trace to display.
      *
-     * @param \Throwable|\Exception $e
+     * @param Throwable $e
      * @return string
      */
-    private function prepareStackTrace($e)
+    private function prepareStackTrace(Throwable $e)
     {
         $message = '';
         do {

--- a/src/Middleware/ImplicitHeadMiddleware.php
+++ b/src/Middleware/ImplicitHeadMiddleware.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Middleware;
 
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;

--- a/src/Middleware/ImplicitHeadMiddleware.php
+++ b/src/Middleware/ImplicitHeadMiddleware.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Middleware/ImplicitOptionsMiddleware.php
+++ b/src/Middleware/ImplicitOptionsMiddleware.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Middleware;
 
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;

--- a/src/Middleware/ImplicitOptionsMiddleware.php
+++ b/src/Middleware/ImplicitOptionsMiddleware.php
@@ -9,14 +9,12 @@ namespace Zend\Expressive\Middleware;
 
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;
 use Fig\Http\Message\StatusCodeInterface as StatusCode;
+use Interop\Http\Server\MiddlewareInterface;
+use Interop\Http\Server\RequestHandlerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
-use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 use Zend\Diactoros\Response;
 use Zend\Expressive\Router\RouteResult;
-
-use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 /**
  * Handle implicit OPTIONS requests.
@@ -41,7 +39,7 @@ use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
  *
  * In all other circumstances, it will return the result of the delegate.
  */
-class ImplicitOptionsMiddleware implements ServerMiddlewareInterface
+class ImplicitOptionsMiddleware implements MiddlewareInterface
 {
     /**
      * @var null|ResponseInterface
@@ -62,22 +60,22 @@ class ImplicitOptionsMiddleware implements ServerMiddlewareInterface
      * Handle an implicit OPTIONS request.
      *
      * @param ServerRequestInterface $request
-     * @param DelegateInterface $delegate
+     * @param RequestHandlerInterface $handler
      * @return ResponseInterface
      */
-    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
     {
         if ($request->getMethod() !== RequestMethod::METHOD_OPTIONS) {
-            return $delegate->{HANDLER_METHOD}($request);
+            return $handler->handle($request);
         }
 
         if (false === ($result = $request->getAttribute(RouteResult::class, false))) {
-            return $delegate->{HANDLER_METHOD}($request);
+            return $handler->handle($request);
         }
 
         $route = $result->getMatchedRoute();
         if (! $route || ! $route->implicitOptions()) {
-            return $delegate->{HANDLER_METHOD}($request);
+            return $handler->handle($request);
         }
 
         $methods = implode(',', $route->getAllowedMethods());

--- a/src/Middleware/ImplicitOptionsMiddleware.php
+++ b/src/Middleware/ImplicitOptionsMiddleware.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Middleware/LazyLoadingMiddleware.php
+++ b/src/Middleware/LazyLoadingMiddleware.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Middleware;
 
 use Interop\Http\Server\MiddlewareInterface;

--- a/src/Middleware/LazyLoadingMiddleware.php
+++ b/src/Middleware/LazyLoadingMiddleware.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Middleware/NotFoundHandler.php
+++ b/src/Middleware/NotFoundHandler.php
@@ -7,13 +7,11 @@
 
 namespace Zend\Expressive\Middleware;
 
+use Interop\Http\Server\MiddlewareInterface;
+use Interop\Http\Server\RequestHandlerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
-use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
 use Zend\Expressive\Delegate\NotFoundDelegate;
-
-use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 class NotFoundHandler implements MiddlewareInterface
 {
@@ -34,11 +32,11 @@ class NotFoundHandler implements MiddlewareInterface
      * Creates and returns a 404 response.
      *
      * @param ServerRequestInterface $request Passed to internal delegate
-     * @param DelegateInterface $delegate Ignored.
+     * @param RequestHandlerInterface $handler Ignored.
      * @return ResponseInterface
      */
-    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
     {
-        return $this->internalDelegate->{HANDLER_METHOD}($request);
+        return $this->internalDelegate->handle($request);
     }
 }

--- a/src/Middleware/NotFoundHandler.php
+++ b/src/Middleware/NotFoundHandler.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Middleware;
 
 use Interop\Http\Server\MiddlewareInterface;

--- a/src/Middleware/NotFoundHandler.php
+++ b/src/Middleware/NotFoundHandler.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Middleware/RouteMiddleware.php
+++ b/src/Middleware/RouteMiddleware.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Middleware;
 
 use Fig\Http\Message\StatusCodeInterface as StatusCode;

--- a/src/Middleware/RouteMiddleware.php
+++ b/src/Middleware/RouteMiddleware.php
@@ -8,14 +8,12 @@
 namespace Zend\Expressive\Middleware;
 
 use Fig\Http\Message\StatusCodeInterface as StatusCode;
+use Interop\Http\Server\MiddlewareInterface;
+use Interop\Http\Server\RequestHandlerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
-use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 use Zend\Expressive\Router\RouteResult;
 use Zend\Expressive\Router\RouterInterface;
-
-use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 /**
  * Default routing middleware.
@@ -32,7 +30,7 @@ use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
  *
  * @internal
  */
-class RouteMiddleware implements ServerMiddlewareInterface
+class RouteMiddleware implements MiddlewareInterface
 {
     /**
      * Response prototype for 405 responses.
@@ -58,10 +56,10 @@ class RouteMiddleware implements ServerMiddlewareInterface
 
     /**
      * @param ServerRequestInterface $request
-     * @param DelegateInterface $delegate
+     * @param RequestHandlerInterface $handler
      * @return ResponseInterface
      */
-    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
     {
         $result = $this->router->match($request);
 
@@ -70,7 +68,7 @@ class RouteMiddleware implements ServerMiddlewareInterface
                 return $this->responsePrototype->withStatus(StatusCode::STATUS_METHOD_NOT_ALLOWED)
                     ->withHeader('Allow', implode(',', $result->getAllowedMethods()));
             }
-            return $delegate->{HANDLER_METHOD}($request);
+            return $handler->handle($request);
         }
 
         // Inject the actual route result, as well as individual matched parameters.
@@ -79,6 +77,6 @@ class RouteMiddleware implements ServerMiddlewareInterface
             $request = $request->withAttribute($param, $value);
         }
 
-        return $delegate->{HANDLER_METHOD}($request);
+        return $handler->handle($request);
     }
 }

--- a/src/Middleware/RouteMiddleware.php
+++ b/src/Middleware/RouteMiddleware.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Middleware/WhoopsErrorResponseGenerator.php
+++ b/src/Middleware/WhoopsErrorResponseGenerator.php
@@ -95,7 +95,7 @@ class WhoopsErrorResponseGenerator
         $request = $request->getAttribute('originalRequest', false) ?: $request;
 
         $serverParams = $request->getServerParams();
-        $scriptName = isset($serverParams['SCRIPT_NAME']) ? $serverParams['SCRIPT_NAME'] : '';
+        $scriptName = $serverParams['SCRIPT_NAME'] ?? '';
 
         $handler->addDataTable('Expressive Application Request', [
             'HTTP Method'            => $request->getMethod(),

--- a/src/Middleware/WhoopsErrorResponseGenerator.php
+++ b/src/Middleware/WhoopsErrorResponseGenerator.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/src/Middleware/WhoopsErrorResponseGenerator.php
+++ b/src/Middleware/WhoopsErrorResponseGenerator.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Middleware;
 
 use InvalidArgumentException;

--- a/test/AppFactoryTest.php
+++ b/test/AppFactoryTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive;
 
 use PHPUnit\Framework\TestCase;

--- a/test/AppFactoryTest.php
+++ b/test/AppFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/Application/ConfigInjectionTest.php
+++ b/test/Application/ConfigInjectionTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Application;
 
 use PHPUnit\Framework\Assert;

--- a/test/Application/ConfigInjectionTest.php
+++ b/test/Application/ConfigInjectionTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace ZendTest\Expressive\Application;
 
+use Interop\Http\Server\MiddlewareInterface;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
@@ -60,7 +61,7 @@ class ConfigInjectionTest extends TestCase
                     return false;
                 }
 
-                if ($route->getMiddleware() !== $spec['middleware']) {
+                if (! $route->getMiddleware() instanceof MiddlewareInterface) {
                     return false;
                 }
 
@@ -117,6 +118,9 @@ class ConfigInjectionTest extends TestCase
      */
     public function testInjectRoutesFromConfigSetsUpRoutesFromConfig($middleware)
     {
+        $this->container->has('HelloWorld')->willReturn(true);
+        $this->container->has('Ping')->willReturn(true);
+
         $config = [
             'routes' => [
                 [

--- a/test/Application/ConfigInjectionTest.php
+++ b/test/Application/ConfigInjectionTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/Application/MarshalMiddlewareTraitTest.php
+++ b/test/Application/MarshalMiddlewareTraitTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Application;
 
 use Interop\Http\Server\MiddlewareInterface;

--- a/test/Application/MarshalMiddlewareTraitTest.php
+++ b/test/Application/MarshalMiddlewareTraitTest.php
@@ -7,6 +7,8 @@
 
 namespace ZendTest\Expressive\Application;
 
+use Interop\Http\Server\MiddlewareInterface;
+use Interop\Http\Server\RequestHandlerInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
@@ -14,8 +16,6 @@ use Psr\Http\Message\ResponseInterface;
 use ReflectionMethod;
 use ReflectionProperty;
 use stdClass;
-use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
-use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 use Zend\Expressive\Application;
 use Zend\Expressive\Exception\InvalidMiddlewareException;
 use Zend\Expressive\Middleware;
@@ -107,21 +107,21 @@ class MarshalMiddlewareTraitTest extends TestCase
 
     public function testPreparingInteropMiddlewareReturnsMiddlewareVerbatim()
     {
-        $base = $this->prophesize(ServerMiddlewareInterface::class)->reveal();
+        $base = $this->prophesize(MiddlewareInterface::class)->reveal();
         $middleware = $this->prepareMiddleware($base);
         $this->assertSame($base, $middleware);
     }
 
     public function testPreparingInteropMiddlewareWithoutContainerReturnsMiddlewareVerbatim()
     {
-        $base = $this->prophesize(ServerMiddlewareInterface::class)->reveal();
+        $base = $this->prophesize(MiddlewareInterface::class)->reveal();
         $middleware = $this->prepareMiddlewareWithoutContainer($base);
         $this->assertSame($base, $middleware);
     }
 
     public function testPreparingDuckTypedInteropMiddlewareReturnsDecoratedInteropMiddleware()
     {
-        $base = function ($request, DelegateInterface $delegate) {
+        $base = function ($request, RequestHandlerInterface $handler) {
         };
         $middleware = $this->prepareMiddleware($base);
         $this->assertInstanceOf(CallableInteropMiddlewareWrapper::class, $middleware);
@@ -130,7 +130,7 @@ class MarshalMiddlewareTraitTest extends TestCase
 
     public function testPreparingDuckTypedInteropMiddlewareWithoutContainerReturnsDecoratedInteropMiddleware()
     {
-        $base = function ($request, DelegateInterface $delegate) {
+        $base = function ($request, RequestHandlerInterface $handler) {
         };
         $middleware = $this->prepareMiddlewareWithoutContainer($base);
         $this->assertInstanceOf(CallableInteropMiddlewareWrapper::class, $middleware);
@@ -159,8 +159,8 @@ class MarshalMiddlewareTraitTest extends TestCase
 
     public function testPreparingArrayOfMiddlewareReturnsMiddlewarePipe()
     {
-        $first  = $this->prophesize(ServerMiddlewareInterface::class)->reveal();
-        $second = function ($request, DelegateInterface $delegate) {
+        $first  = $this->prophesize(MiddlewareInterface::class)->reveal();
+        $second = function ($request, RequestHandlerInterface $handler) {
         };
         $third  = function ($request, $response, callable $next) {
         };
@@ -193,8 +193,8 @@ class MarshalMiddlewareTraitTest extends TestCase
 
     public function testPreparingArrayOfMiddlewareWithoutContainerReturnsMiddlewarePipe()
     {
-        $first  = $this->prophesize(ServerMiddlewareInterface::class)->reveal();
-        $second = function ($request, DelegateInterface $delegate) {
+        $first  = $this->prophesize(MiddlewareInterface::class)->reveal();
+        $second = function ($request, RequestHandlerInterface $handler) {
         };
         $third  = function ($request, $response, callable $next) {
         };
@@ -221,7 +221,7 @@ class MarshalMiddlewareTraitTest extends TestCase
 
     public function testPreparingArrayOfMiddlewareRaisesExceptionWhenContainerMissingAndServiceInvalid()
     {
-        $first  = $this->prophesize(ServerMiddlewareInterface::class)->reveal();
+        $first  = $this->prophesize(MiddlewareInterface::class)->reveal();
         $second = 'second-middleware';
         $third  = 'third-middleware';
 

--- a/test/Application/MarshalMiddlewareTraitTest.php
+++ b/test/Application/MarshalMiddlewareTraitTest.php
@@ -20,8 +20,8 @@ use Zend\Expressive\Application;
 use Zend\Expressive\Exception\InvalidMiddlewareException;
 use Zend\Expressive\Middleware;
 use Zend\Expressive\Router\RouterInterface;
-use Zend\Stratigility\Middleware\CallableInteropMiddlewareWrapper;
-use Zend\Stratigility\Middleware\CallableMiddlewareWrapper;
+use Zend\Stratigility\Middleware\CallableMiddlewareDecorator;
+use Zend\Stratigility\Middleware\DoublePassMiddlewareDecorator;
 use Zend\Stratigility\MiddlewarePipe;
 
 class MarshalMiddlewareTraitTest extends TestCase
@@ -124,7 +124,7 @@ class MarshalMiddlewareTraitTest extends TestCase
         $base = function ($request, RequestHandlerInterface $handler) {
         };
         $middleware = $this->prepareMiddleware($base);
-        $this->assertInstanceOf(CallableInteropMiddlewareWrapper::class, $middleware);
+        $this->assertInstanceOf(CallableMiddlewareDecorator::class, $middleware);
         $this->assertAttributeSame($base, 'middleware', $middleware);
     }
 
@@ -133,7 +133,7 @@ class MarshalMiddlewareTraitTest extends TestCase
         $base = function ($request, RequestHandlerInterface $handler) {
         };
         $middleware = $this->prepareMiddlewareWithoutContainer($base);
-        $this->assertInstanceOf(CallableInteropMiddlewareWrapper::class, $middleware);
+        $this->assertInstanceOf(CallableMiddlewareDecorator::class, $middleware);
         $this->assertAttributeSame($base, 'middleware', $middleware);
     }
 
@@ -142,7 +142,7 @@ class MarshalMiddlewareTraitTest extends TestCase
         $base = function ($request, $response, callable $next) {
         };
         $middleware = $this->prepareMiddleware($base);
-        $this->assertInstanceOf(CallableMiddlewareWrapper::class, $middleware);
+        $this->assertInstanceOf(DoublePassMiddlewareDecorator::class, $middleware);
         $this->assertAttributeSame($base, 'middleware', $middleware);
         $this->assertAttributeSame($this->responsePrototype->reveal(), 'responsePrototype', $middleware);
     }
@@ -152,7 +152,7 @@ class MarshalMiddlewareTraitTest extends TestCase
         $base = function ($request, $response, callable $next) {
         };
         $middleware = $this->prepareMiddlewareWithoutContainer($base);
-        $this->assertInstanceOf(CallableMiddlewareWrapper::class, $middleware);
+        $this->assertInstanceOf(DoublePassMiddlewareDecorator::class, $middleware);
         $this->assertAttributeSame($base, 'middleware', $middleware);
         $this->assertAttributeSame($this->responsePrototype->reveal(), 'responsePrototype', $middleware);
     }
@@ -256,7 +256,7 @@ class MarshalMiddlewareTraitTest extends TestCase
 
         $middleware = $this->prepareMiddleware($base);
 
-        $this->assertInstanceOf(CallableInteropMiddlewareWrapper::class, $middleware);
+        $this->assertInstanceOf(CallableMiddlewareDecorator::class, $middleware);
         $this->assertAttributeInstanceOf(TestAsset\CallableInteropMiddleware::class, 'middleware', $middleware);
     }
 
@@ -265,7 +265,7 @@ class MarshalMiddlewareTraitTest extends TestCase
         $base = TestAsset\CallableMiddleware::class;
         $this->container->has(TestAsset\CallableMiddleware::class)->willReturn(false);
         $middleware = $this->prepareMiddleware($base);
-        $this->assertInstanceOf(CallableMiddlewareWrapper::class, $middleware);
+        $this->assertInstanceOf(DoublePassMiddlewareDecorator::class, $middleware);
         $this->assertAttributeInstanceOf(TestAsset\CallableMiddleware::class, 'middleware', $middleware);
     }
 

--- a/test/Application/MarshalMiddlewareTraitTest.php
+++ b/test/Application/MarshalMiddlewareTraitTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/Application/TestAsset/CallableInteropMiddleware.php
+++ b/test/Application/TestAsset/CallableInteropMiddleware.php
@@ -7,11 +7,11 @@
 
 namespace ZendTest\Expressive\Application\TestAsset;
 
-use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
+use Interop\Http\Server\RequestHandlerInterface;
 
 class CallableInteropMiddleware
 {
-    public function __invoke($request, DelegateInterface $delegate)
+    public function __invoke($request, RequestHandlerInterface $handler)
     {
     }
 }

--- a/test/Application/TestAsset/CallableInteropMiddleware.php
+++ b/test/Application/TestAsset/CallableInteropMiddleware.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/Application/TestAsset/CallableInteropMiddleware.php
+++ b/test/Application/TestAsset/CallableInteropMiddleware.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Application\TestAsset;
 
 use Interop\Http\Server\RequestHandlerInterface;

--- a/test/Application/TestAsset/CallableMiddleware.php
+++ b/test/Application/TestAsset/CallableMiddleware.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Application\TestAsset;
 
 class CallableMiddleware

--- a/test/Application/TestAsset/CallableMiddleware.php
+++ b/test/Application/TestAsset/CallableMiddleware.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/Application/TestAsset/InteropMiddleware.php
+++ b/test/Application/TestAsset/InteropMiddleware.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Application\TestAsset;
 
 use Interop\Http\Server\MiddlewareInterface;

--- a/test/Application/TestAsset/InteropMiddleware.php
+++ b/test/Application/TestAsset/InteropMiddleware.php
@@ -7,13 +7,14 @@
 
 namespace ZendTest\Expressive\Application\TestAsset;
 
+use Interop\Http\Server\MiddlewareInterface;
+use Interop\Http\Server\RequestHandlerInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
-use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
 
 class InteropMiddleware implements MiddlewareInterface
 {
-    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
     {
     }
 }

--- a/test/Application/TestAsset/InteropMiddleware.php
+++ b/test/Application/TestAsset/InteropMiddleware.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -292,7 +292,7 @@ class ApplicationTest extends TestCase
 
     public function testDefaultDelegateIsUsedAtInvocationIfNoOutArgumentIsSupplied()
     {
-        $routeResult = RouteResult::fromRouteFailure();
+        $routeResult = RouteResult::fromRouteFailure([]);
         $this->router->match()->willReturn($routeResult);
 
         $finalResponse = $this->prophesize(ResponseInterface::class)->reveal();
@@ -336,7 +336,7 @@ class ApplicationTest extends TestCase
 
     public function testComposedEmitterIsCalledByRun()
     {
-        $routeResult = RouteResult::fromRouteFailure();
+        $routeResult = RouteResult::fromRouteFailure([]);
         $this->router->match()->willReturn($routeResult);
 
         $finalResponse = $this->prophesize(ResponseInterface::class)->reveal();

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -23,6 +23,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use ReflectionProperty;
 use RuntimeException;
 use Throwable;
+use TypeError;
 use UnexpectedValueException;
 use Zend\Diactoros\Response\EmitterInterface;
 use Zend\Diactoros\Response\SapiEmitter;
@@ -187,7 +188,7 @@ class ApplicationTest extends TestCase
     public function testCallingRouteWithAnInvalidPathTypeRaisesAnException($path)
     {
         $app = $this->getApp();
-        $this->expectException(RouterException\InvalidArgumentException::class);
+        $this->expectException(TypeError::class);
         $app->route($path, new TestAsset\InteropMiddleware());
     }
 

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -22,6 +22,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use ReflectionProperty;
 use RuntimeException;
+use Throwable;
 use UnexpectedValueException;
 use Zend\Diactoros\Response\EmitterInterface;
 use Zend\Diactoros\Response\SapiEmitter;
@@ -534,9 +535,7 @@ class ApplicationTest extends TestCase
             $app = new Application($this->router->reveal(), null, null, $emitter->reveal());
 
             $app->run();
-        } catch (\Throwable $e) {
-            $this->fail($e->getMessage());
-        } catch (\Exception $e) {
+        } catch (Throwable $e) {
             $this->fail($e->getMessage());
         }
     }
@@ -613,9 +612,7 @@ class ApplicationTest extends TestCase
             );
 
             $app->run();
-        } catch (\Throwable $e) {
-            $this->fail(sprintf("(%d) %s:\n%s", $e->getCode(), $e->getMessage(), $e->getTraceAsString()));
-        } catch (\Exception $e) {
+        } catch (Throwable $e) {
             $this->fail(sprintf("(%d) %s:\n%s", $e->getCode(), $e->getMessage(), $e->getTraceAsString()));
         }
     }

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive;
 
 use DomainException;

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -602,8 +602,13 @@ class ApplicationTest extends TestCase
                 return true;
             }))->shouldBeCalled();
 
-            $app = new Application($this->router->reveal(), $container->reveal(), null, $emitter->reveal());
-            $app->setResponsePrototype($expectedResponse);
+            $app = new Application(
+                $this->router->reveal(),
+                $container->reveal(),
+                null,
+                $emitter->reveal(),
+                $expectedResponse
+            );
 
             $app->run();
         } catch (\Throwable $e) {

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -161,8 +161,8 @@ class ApplicationTest extends TestCase
     public function testCallingRouteWithOnlyAPathRaisesAnException()
     {
         $app = $this->getApp();
-        $this->expectException(Exception\InvalidArgumentException::class);
-        $app->route('/path');
+        $this->expectException(Exception\InvalidMiddlewareException::class);
+        $app->route('/path', null);
     }
 
     public function invalidPathTypes()

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/Container/ApplicationFactoryTest.php
+++ b/test/Container/ApplicationFactoryTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace ZendTest\Expressive\Container;
 
 use ArrayObject;
+use Interop\Http\Server\MiddlewareInterface;
 use Interop\Http\Server\RequestHandlerInterface;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
@@ -82,7 +83,7 @@ class ApplicationFactoryTest extends TestCase
                     return false;
                 }
 
-                if ($route->getMiddleware() !== $spec['middleware']) {
+                if (! $route->getMiddleware() instanceof MiddlewareInterface) {
                     return false;
                 }
 
@@ -129,7 +130,6 @@ class ApplicationFactoryTest extends TestCase
             'service-name' => 'HelloWorld',
             'closure' => function () {
             },
-            'callable' => [InvokableMiddleware::class, 'staticallyCallableMiddleware'],
         ];
 
         $configTypes = [
@@ -153,6 +153,9 @@ class ApplicationFactoryTest extends TestCase
      */
     public function testFactorySetsUpRoutesFromConfig($middleware, $configType)
     {
+        $this->container->has('HelloWorld')->willReturn(true);
+        $this->container->has('Ping')->willReturn(true);
+
         $config = [
             'routes' => [
                 [
@@ -233,9 +236,12 @@ class ApplicationFactoryTest extends TestCase
      * @dataProvider configTypes
      *
      * @param null|string $configType
+     * @group xya
      */
     public function testCanSpecifyRouteViaConfigurationWithNoMethods($configType)
     {
+        $this->container->has('HelloWorld')->willReturn(true);
+
         $config = [
             'routes' => [
                 [
@@ -265,6 +271,8 @@ class ApplicationFactoryTest extends TestCase
      */
     public function testCanSpecifyRouteOptionsViaConfiguration($configType)
     {
+        $this->container->has('HelloWorld')->willReturn(true);
+
         $expected = [
             'values' => [
                 'foo' => 'bar',
@@ -331,6 +339,8 @@ class ApplicationFactoryTest extends TestCase
      */
     public function testExceptionIsRaisedInCaseOfInvalidRouteOptionsConfiguration($configType)
     {
+        $this->container->has('HelloWorld')->willReturn(true);
+
         $config = [
             'routes' => [
                 [

--- a/test/Container/ApplicationFactoryTest.php
+++ b/test/Container/ApplicationFactoryTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Container;
 
 use ArrayObject;

--- a/test/Container/ApplicationFactoryTest.php
+++ b/test/Container/ApplicationFactoryTest.php
@@ -8,12 +8,12 @@
 namespace ZendTest\Expressive\Container;
 
 use ArrayObject;
+use Interop\Http\Server\RequestHandlerInterface;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 use ReflectionProperty;
-use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 use Zend\Diactoros\Response\EmitterInterface;
 use Zend\Diactoros\Response\SapiEmitter;
 use Zend\Expressive\Application;
@@ -48,8 +48,8 @@ class ApplicationFactoryTest extends TestCase
     /** @var EmitterInterface|ObjectProphecy */
     protected $emitter;
 
-    /** @var DelegateInterface|ObjectProphecy */
-    protected $delegate;
+    /** @var RequestHandlerInterface|ObjectProphecy */
+    protected $handler;
 
     /** @var RouterInterface|ObjectProphecy */
     protected $router;
@@ -61,11 +61,11 @@ class ApplicationFactoryTest extends TestCase
 
         $this->router = $this->prophesize(RouterInterface::class);
         $this->emitter = $this->prophesize(EmitterInterface::class);
-        $this->delegate = $this->prophesize(DelegateInterface::class)->reveal();
+        $this->handler = $this->prophesize(RequestHandlerInterface::class)->reveal();
 
         $this->injectServiceInContainer($this->container, RouterInterface::class, $this->router->reveal());
         $this->injectServiceInContainer($this->container, EmitterInterface::class, $this->emitter->reveal());
-        $this->injectServiceInContainer($this->container, 'Zend\Expressive\Delegate\DefaultDelegate', $this->delegate);
+        $this->injectServiceInContainer($this->container, 'Zend\Expressive\Delegate\DefaultDelegate', $this->handler);
     }
 
     public static function assertRoute($spec, array $routes)
@@ -118,7 +118,7 @@ class ApplicationFactoryTest extends TestCase
         $this->assertSame($this->router->reveal(), $test);
         $this->assertSame($this->container->reveal(), $app->getContainer());
         $this->assertSame($this->emitter->reveal(), $app->getEmitter());
-        $this->assertSame($this->delegate, $app->getDefaultDelegate());
+        $this->assertSame($this->handler, $app->getDefaultDelegate());
     }
 
     public function callableMiddlewares()

--- a/test/Container/ApplicationFactoryTest.php
+++ b/test/Container/ApplicationFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/Container/ErrorHandlerFactoryTest.php
+++ b/test/Container/ErrorHandlerFactoryTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Container;
 
 use PHPUnit\Framework\TestCase;

--- a/test/Container/ErrorHandlerFactoryTest.php
+++ b/test/Container/ErrorHandlerFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/Container/ErrorResponseGeneratorFactoryTest.php
+++ b/test/Container/ErrorResponseGeneratorFactoryTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Container;
 
 use PHPUnit\Framework\TestCase;

--- a/test/Container/ErrorResponseGeneratorFactoryTest.php
+++ b/test/Container/ErrorResponseGeneratorFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/Container/NotFoundDelegateFactoryTest.php
+++ b/test/Container/NotFoundDelegateFactoryTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Container;
 
 use PHPUnit\Framework\TestCase;

--- a/test/Container/NotFoundDelegateFactoryTest.php
+++ b/test/Container/NotFoundDelegateFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/Container/NotFoundHandlerFactoryTest.php
+++ b/test/Container/NotFoundHandlerFactoryTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Container;
 
 use PHPUnit\Framework\TestCase;

--- a/test/Container/NotFoundHandlerFactoryTest.php
+++ b/test/Container/NotFoundHandlerFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/Container/WhoopsErrorResponseGeneratorFactoryTest.php
+++ b/test/Container/WhoopsErrorResponseGeneratorFactoryTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Container;
 
 use PHPUnit\Framework\TestCase;

--- a/test/Container/WhoopsErrorResponseGeneratorFactoryTest.php
+++ b/test/Container/WhoopsErrorResponseGeneratorFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/Container/WhoopsFactoryTest.php
+++ b/test/Container/WhoopsFactoryTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Container;
 
 use PHPUnit\Framework\TestCase;

--- a/test/Container/WhoopsFactoryTest.php
+++ b/test/Container/WhoopsFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/Container/WhoopsPageHandlerFactoryTest.php
+++ b/test/Container/WhoopsPageHandlerFactoryTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Container;
 
 use PHPUnit\Framework\TestCase;

--- a/test/Container/WhoopsPageHandlerFactoryTest.php
+++ b/test/Container/WhoopsPageHandlerFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/ContainerTrait.php
+++ b/test/ContainerTrait.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive;
 
 use Prophecy\Argument;

--- a/test/ContainerTrait.php
+++ b/test/ContainerTrait.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/Delegate/NotFoundDelegateTest.php
+++ b/test/Delegate/NotFoundDelegateTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive\Delegate;
 
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;

--- a/test/Delegate/NotFoundDelegateTest.php
+++ b/test/Delegate/NotFoundDelegateTest.php
@@ -60,7 +60,7 @@ class NotFoundDelegateTest extends TestCase
 
         $delegate = new NotFoundDelegate($this->response->reveal());
 
-        $response = $delegate->process($request->reveal());
+        $response = $delegate->handle($request->reveal());
 
         $this->assertSame($this->response->reveal(), $response);
     }
@@ -88,7 +88,7 @@ class NotFoundDelegateTest extends TestCase
 
         $delegate = new NotFoundDelegate($this->response->reveal(), $renderer->reveal());
 
-        $response = $delegate->process($request);
+        $response = $delegate->handle($request);
 
         $this->assertSame($this->response->reveal(), $response);
     }

--- a/test/Delegate/NotFoundDelegateTest.php
+++ b/test/Delegate/NotFoundDelegateTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/Emitter/EmitterStackTest.php
+++ b/test/Emitter/EmitterStackTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Emitter;
 
 use InvalidArgumentException;

--- a/test/Emitter/EmitterStackTest.php
+++ b/test/Emitter/EmitterStackTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/IntegrationTest.php
+++ b/test/IntegrationTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive;
 
 use Fig\Http\Message\StatusCodeInterface as StatusCode;

--- a/test/IntegrationTest.php
+++ b/test/IntegrationTest.php
@@ -8,13 +8,13 @@
 namespace ZendTest\Expressive;
 
 use Fig\Http\Message\StatusCodeInterface as StatusCode;
+use Interop\Http\Server\MiddlewareInterface;
+use Interop\Http\Server\RequestHandlerInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Psr\Container\ContainerInterface;
-use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
-use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\Response\EmitterInterface;
 use Zend\Diactoros\ServerRequest;
@@ -88,7 +88,7 @@ class IntegrationTest extends TestCase
         $routedMiddleware
             ->process(
                 Argument::type(ServerRequestInterface::class),
-                Argument::type(DelegateInterface::class)
+                Argument::type(RequestHandlerInterface::class)
             )
             ->willReturn($response);
 

--- a/test/IntegrationTest.php
+++ b/test/IntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/Middleware/DispatchMiddlewareTest.php
+++ b/test/Middleware/DispatchMiddlewareTest.php
@@ -81,49 +81,4 @@ class DispatchMiddlewareTest extends TestCase
 
         $this->assertSame($expected, $response);
     }
-
-    /**
-     * @group 453
-     */
-    public function testCanDispatchCallableDoublePassMiddleware()
-    {
-        $this->handler->handle()->shouldNotBeCalled();
-
-        $expected = $this->prophesize(ResponseInterface::class)->reveal();
-        $routedMiddleware = function ($request, $response, $next) use ($expected) {
-            return $expected;
-        };
-
-        $routeResult = RouteResult::fromRoute(new Route('/', $routedMiddleware));
-
-        $this->request->getAttribute(RouteResult::class, false)->willReturn($routeResult);
-
-        $response = $this->middleware->process($this->request->reveal(), $this->handler->reveal());
-
-        $this->assertSame($expected, $response);
-    }
-
-    /**
-     * @group 453
-     */
-    public function testCanDispatchMiddlewareServices()
-    {
-        $this->handler->handle()->shouldNotBeCalled();
-
-        $expected = $this->prophesize(ResponseInterface::class)->reveal();
-        $routedMiddleware = function ($request, $response, $next) use ($expected) {
-            return $expected;
-        };
-
-        $this->container->has('RoutedMiddleware')->willReturn(true);
-        $this->container->get('RoutedMiddleware')->willReturn($routedMiddleware);
-
-        $routeResult = RouteResult::fromRoute(new Route('/', 'RoutedMiddleware'));
-
-        $this->request->getAttribute(RouteResult::class, false)->willReturn($routeResult);
-
-        $response = $this->middleware->process($this->request->reveal(), $this->handler->reveal());
-
-        $this->assertSame($expected, $response);
-    }
 }

--- a/test/Middleware/DispatchMiddlewareTest.php
+++ b/test/Middleware/DispatchMiddlewareTest.php
@@ -7,27 +7,25 @@
 
 namespace ZendTest\Expressive\Middleware;
 
+use Interop\Http\Server\MiddlewareInterface;
+use Interop\Http\Server\RequestHandlerInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
-use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 use Zend\Expressive\Middleware\DispatchMiddleware;
 use Zend\Expressive\Router\Route;
 use Zend\Expressive\Router\RouteResult;
 use Zend\Expressive\Router\RouterInterface;
-
-use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 class DispatchMiddlewareTest extends TestCase
 {
     /** @var ContainerInterface|ObjectProphecy */
     private $container;
 
-    /** @var DelegateInterface|ObjectProphecy */
-    private $delegate;
+    /** @var RequestHandlerInterface|ObjectProphecy */
+    private $handler;
 
     /** @var DispatchMiddleware */
     private $middleware;
@@ -44,7 +42,7 @@ class DispatchMiddlewareTest extends TestCase
         $this->responsePrototype = $this->prophesize(ResponseInterface::class);
         $this->router            = $this->prophesize(RouterInterface::class);
         $this->request           = $this->prophesize(ServerRequestInterface::class);
-        $this->delegate          = $this->prophesize(DelegateInterface::class);
+        $this->handler          = $this->prophesize(RequestHandlerInterface::class);
         $this->middleware        = new DispatchMiddleware(
             $this->router->reveal(),
             $this->responsePrototype->reveal(),
@@ -56,28 +54,28 @@ class DispatchMiddlewareTest extends TestCase
     {
         $expected = $this->prophesize(ResponseInterface::class)->reveal();
         $this->request->getAttribute(RouteResult::class, false)->willReturn(false);
-        $this->delegate->{HANDLER_METHOD}($this->request->reveal())->willReturn($expected);
+        $this->handler->handle($this->request->reveal())->willReturn($expected);
 
-        $response = $this->middleware->process($this->request->reveal(), $this->delegate->reveal());
+        $response = $this->middleware->process($this->request->reveal(), $this->handler->reveal());
 
         $this->assertSame($expected, $response);
     }
 
     public function testInvokesMatchedMiddlewareWhenRouteResult()
     {
-        $this->delegate->{HANDLER_METHOD}()->shouldNotBeCalled();
+        $this->handler->handle()->shouldNotBeCalled();
 
         $expected = $this->prophesize(ResponseInterface::class)->reveal();
-        $routedMiddleware = $this->prophesize(ServerMiddlewareInterface::class);
+        $routedMiddleware = $this->prophesize(MiddlewareInterface::class);
         $routedMiddleware
-            ->process($this->request->reveal(), $this->delegate->reveal())
+            ->process($this->request->reveal(), $this->handler->reveal())
             ->willReturn($expected);
 
         $routeResult = RouteResult::fromRoute(new Route('/', $routedMiddleware->reveal()));
 
         $this->request->getAttribute(RouteResult::class, false)->willReturn($routeResult);
 
-        $response = $this->middleware->process($this->request->reveal(), $this->delegate->reveal());
+        $response = $this->middleware->process($this->request->reveal(), $this->handler->reveal());
 
         $this->assertSame($expected, $response);
     }
@@ -87,7 +85,7 @@ class DispatchMiddlewareTest extends TestCase
      */
     public function testCanDispatchCallableDoublePassMiddleware()
     {
-        $this->delegate->{HANDLER_METHOD}()->shouldNotBeCalled();
+        $this->handler->handle()->shouldNotBeCalled();
 
         $expected = $this->prophesize(ResponseInterface::class)->reveal();
         $routedMiddleware = function ($request, $response, $next) use ($expected) {
@@ -98,7 +96,7 @@ class DispatchMiddlewareTest extends TestCase
 
         $this->request->getAttribute(RouteResult::class, false)->willReturn($routeResult);
 
-        $response = $this->middleware->process($this->request->reveal(), $this->delegate->reveal());
+        $response = $this->middleware->process($this->request->reveal(), $this->handler->reveal());
 
         $this->assertSame($expected, $response);
     }
@@ -108,7 +106,7 @@ class DispatchMiddlewareTest extends TestCase
      */
     public function testCanDispatchMiddlewareServices()
     {
-        $this->delegate->{HANDLER_METHOD}()->shouldNotBeCalled();
+        $this->handler->handle()->shouldNotBeCalled();
 
         $expected = $this->prophesize(ResponseInterface::class)->reveal();
         $routedMiddleware = function ($request, $response, $next) use ($expected) {
@@ -122,7 +120,7 @@ class DispatchMiddlewareTest extends TestCase
 
         $this->request->getAttribute(RouteResult::class, false)->willReturn($routeResult);
 
-        $response = $this->middleware->process($this->request->reveal(), $this->delegate->reveal());
+        $response = $this->middleware->process($this->request->reveal(), $this->handler->reveal());
 
         $this->assertSame($expected, $response);
     }

--- a/test/Middleware/DispatchMiddlewareTest.php
+++ b/test/Middleware/DispatchMiddlewareTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Middleware;
 
 use Interop\Http\Server\MiddlewareInterface;

--- a/test/Middleware/DispatchMiddlewareTest.php
+++ b/test/Middleware/DispatchMiddlewareTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/Middleware/ErrorResponseGeneratorTest.php
+++ b/test/Middleware/ErrorResponseGeneratorTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Middleware;
 
 use Fig\Http\Message\StatusCodeInterface as StatusCode;

--- a/test/Middleware/ErrorResponseGeneratorTest.php
+++ b/test/Middleware/ErrorResponseGeneratorTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/Middleware/ImplicitHeadMiddlewareTest.php
+++ b/test/Middleware/ImplicitHeadMiddlewareTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Middleware;
 
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;

--- a/test/Middleware/ImplicitHeadMiddlewareTest.php
+++ b/test/Middleware/ImplicitHeadMiddlewareTest.php
@@ -9,18 +9,16 @@ namespace ZendTest\Expressive\Middleware;
 
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;
 use Fig\Http\Message\StatusCodeInterface as StatusCode;
+use Interop\Http\Server\RequestHandlerInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
-use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 use Zend\Diactoros\Response;
 use Zend\Expressive\Middleware\ImplicitHeadMiddleware;
 use Zend\Expressive\Router\Route;
 use Zend\Expressive\Router\RouteResult;
-
-use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 class ImplicitHeadMiddlewareTest extends TestCase
 {
@@ -31,12 +29,12 @@ class ImplicitHeadMiddlewareTest extends TestCase
 
         $response = $this->prophesize(ResponseInterface::class)->reveal();
 
-        $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->{HANDLER_METHOD}($request->reveal())
+        $handler = $this->prophesize(RequestHandlerInterface::class);
+        $handler->handle($request->reveal())
             ->willReturn($response);
 
         $middleware = new ImplicitHeadMiddleware();
-        $result = $middleware->process($request->reveal(), $delegate->reveal());
+        $result = $middleware->process($request->reveal(), $handler->reveal());
 
         $this->assertSame($response, $result);
     }
@@ -49,12 +47,12 @@ class ImplicitHeadMiddlewareTest extends TestCase
 
         $response = $this->prophesize(ResponseInterface::class)->reveal();
 
-        $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->{HANDLER_METHOD}($request->reveal())
+        $handler = $this->prophesize(RequestHandlerInterface::class);
+        $handler->handle($request->reveal())
             ->willReturn($response);
 
         $middleware = new ImplicitHeadMiddleware();
-        $result = $middleware->process($request->reveal(), $delegate->reveal());
+        $result = $middleware->process($request->reveal(), $handler->reveal());
 
         $this->assertSame($response, $result);
     }
@@ -70,12 +68,12 @@ class ImplicitHeadMiddlewareTest extends TestCase
 
         $response = $this->prophesize(ResponseInterface::class)->reveal();
 
-        $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->{HANDLER_METHOD}($request->reveal())
+        $handler = $this->prophesize(RequestHandlerInterface::class);
+        $handler->handle($request->reveal())
             ->willReturn($response);
 
         $middleware = new ImplicitHeadMiddleware();
-        $result = $middleware->process($request->reveal(), $delegate->reveal());
+        $result = $middleware->process($request->reveal(), $handler->reveal());
 
         $this->assertSame($response, $result);
     }
@@ -94,12 +92,12 @@ class ImplicitHeadMiddlewareTest extends TestCase
 
         $response = $this->prophesize(ResponseInterface::class)->reveal();
 
-        $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->{HANDLER_METHOD}($request->reveal())
+        $handler = $this->prophesize(RequestHandlerInterface::class);
+        $handler->handle($request->reveal())
             ->willReturn($response);
 
         $middleware = new ImplicitHeadMiddleware();
-        $result = $middleware->process($request->reveal(), $delegate->reveal());
+        $result = $middleware->process($request->reveal(), $handler->reveal());
 
         $this->assertSame($response, $result);
     }
@@ -119,11 +117,11 @@ class ImplicitHeadMiddlewareTest extends TestCase
 
         $response = $this->prophesize(ResponseInterface::class)->reveal();
 
-        $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->{HANDLER_METHOD}($request->reveal())->shouldNotBeCalled($response);
+        $handler = $this->prophesize(RequestHandlerInterface::class);
+        $handler->handle($request->reveal())->shouldNotBeCalled($response);
 
         $middleware = new ImplicitHeadMiddleware();
-        $result = $middleware->process($request->reveal(), $delegate->reveal());
+        $result = $middleware->process($request->reveal(), $handler->reveal());
 
         $this->assertInstanceOf(Response::class, $result);
         $this->assertEquals(StatusCode::STATUS_OK, $result->getStatusCode());
@@ -145,12 +143,12 @@ class ImplicitHeadMiddlewareTest extends TestCase
 
         $response = $this->prophesize(ResponseInterface::class)->reveal();
 
-        $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->{HANDLER_METHOD}($request->reveal())->shouldNotBeCalled($response);
+        $handler = $this->prophesize(RequestHandlerInterface::class);
+        $handler->handle($request->reveal())->shouldNotBeCalled($response);
 
         $expected   = new Response();
         $middleware = new ImplicitHeadMiddleware($expected);
-        $result     = $middleware->process($request->reveal(), $delegate->reveal());
+        $result     = $middleware->process($request->reveal(), $handler->reveal());
 
         $this->assertSame($expected, $result);
     }
@@ -178,11 +176,11 @@ class ImplicitHeadMiddlewareTest extends TestCase
             }))
             ->will([$response, 'reveal']);
 
-        $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->{HANDLER_METHOD}($request->reveal())->will([$response, 'reveal']);
+        $handler = $this->prophesize(RequestHandlerInterface::class);
+        $handler->handle($request->reveal())->will([$response, 'reveal']);
 
         $middleware = new ImplicitHeadMiddleware();
-        $result = $middleware->process($request->reveal(), $delegate->reveal());
+        $result = $middleware->process($request->reveal(), $handler->reveal());
 
         $this->assertSame($response->reveal(), $result);
     }

--- a/test/Middleware/ImplicitHeadMiddlewareTest.php
+++ b/test/Middleware/ImplicitHeadMiddlewareTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/Middleware/ImplicitOptionsMiddlewareTest.php
+++ b/test/Middleware/ImplicitOptionsMiddlewareTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Middleware;
 
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;

--- a/test/Middleware/ImplicitOptionsMiddlewareTest.php
+++ b/test/Middleware/ImplicitOptionsMiddlewareTest.php
@@ -9,16 +9,14 @@ namespace ZendTest\Expressive\Middleware;
 
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;
 use Fig\Http\Message\StatusCodeInterface as StatusCode;
+use Interop\Http\Server\RequestHandlerInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 use Zend\Diactoros\Response;
 use Zend\Expressive\Middleware\ImplicitOptionsMiddleware;
 use Zend\Expressive\Router\Route;
 use Zend\Expressive\Router\RouteResult;
-
-use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 class ImplicitOptionsMiddlewareTest extends TestCase
 {
@@ -30,11 +28,11 @@ class ImplicitOptionsMiddlewareTest extends TestCase
 
         $response = $this->prophesize(ResponseInterface::class)->reveal();
 
-        $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->{HANDLER_METHOD}($request->reveal())->willReturn($response);
+        $handler = $this->prophesize(RequestHandlerInterface::class);
+        $handler->handle($request->reveal())->willReturn($response);
 
         $middleware = new ImplicitOptionsMiddleware();
-        $result = $middleware->process($request->reveal(), $delegate->reveal());
+        $result = $middleware->process($request->reveal(), $handler->reveal());
         $this->assertSame($response, $result);
     }
 
@@ -46,11 +44,11 @@ class ImplicitOptionsMiddlewareTest extends TestCase
 
         $response = $this->prophesize(ResponseInterface::class)->reveal();
 
-        $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->{HANDLER_METHOD}($request->reveal())->willReturn($response);
+        $handler = $this->prophesize(RequestHandlerInterface::class);
+        $handler->handle($request->reveal())->willReturn($response);
 
         $middleware = new ImplicitOptionsMiddleware();
-        $result = $middleware->process($request->reveal(), $delegate->reveal());
+        $result = $middleware->process($request->reveal(), $handler->reveal());
         $this->assertSame($response, $result);
     }
 
@@ -65,11 +63,11 @@ class ImplicitOptionsMiddlewareTest extends TestCase
 
         $response = $this->prophesize(ResponseInterface::class)->reveal();
 
-        $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->{HANDLER_METHOD}($request->reveal())->willReturn($response);
+        $handler = $this->prophesize(RequestHandlerInterface::class);
+        $handler->handle($request->reveal())->willReturn($response);
 
         $middleware = new ImplicitOptionsMiddleware();
-        $result = $middleware->process($request->reveal(), $delegate->reveal());
+        $result = $middleware->process($request->reveal(), $handler->reveal());
         $this->assertSame($response, $result);
     }
 
@@ -87,11 +85,11 @@ class ImplicitOptionsMiddlewareTest extends TestCase
 
         $response = $this->prophesize(ResponseInterface::class)->reveal();
 
-        $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->{HANDLER_METHOD}($request->reveal())->willReturn($response);
+        $handler = $this->prophesize(RequestHandlerInterface::class);
+        $handler->handle($request->reveal())->willReturn($response);
 
         $middleware = new ImplicitOptionsMiddleware();
-        $result = $middleware->process($request->reveal(), $delegate->reveal());
+        $result = $middleware->process($request->reveal(), $handler->reveal());
         $this->assertSame($response, $result);
     }
 
@@ -112,11 +110,11 @@ class ImplicitOptionsMiddlewareTest extends TestCase
 
         $response = $this->prophesize(ResponseInterface::class)->reveal();
 
-        $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->{HANDLER_METHOD}($request->reveal())->shouldNotBeCalled();
+        $handler = $this->prophesize(RequestHandlerInterface::class);
+        $handler->handle($request->reveal())->shouldNotBeCalled();
 
         $middleware = new ImplicitOptionsMiddleware();
-        $result = $middleware->process($request->reveal(), $delegate->reveal());
+        $result = $middleware->process($request->reveal(), $handler->reveal());
         $this->assertInstanceOf(Response::class, $result);
         $this->assertNotSame($response, $result);
         $this->assertEquals(StatusCode::STATUS_OK, $result->getStatusCode());
@@ -138,14 +136,14 @@ class ImplicitOptionsMiddlewareTest extends TestCase
         $request->getMethod()->willReturn(RequestMethod::METHOD_OPTIONS);
         $request->getAttribute(RouteResult::class, false)->will([$result, 'reveal']);
 
-        $delegate = $this->prophesize(DelegateInterface::class);
-        $delegate->{HANDLER_METHOD}($request->reveal())->shouldNotBeCalled();
+        $handler = $this->prophesize(RequestHandlerInterface::class);
+        $handler->handle($request->reveal())->shouldNotBeCalled();
 
         $expected = $this->prophesize(ResponseInterface::class);
         $expected->withHeader('Allow', implode(',', $allowedMethods))->will([$expected, 'reveal']);
 
         $middleware = new ImplicitOptionsMiddleware($expected->reveal());
-        $result = $middleware->process($request->reveal(), $delegate->reveal());
+        $result = $middleware->process($request->reveal(), $handler->reveal());
         $this->assertSame($expected->reveal(), $result);
     }
 }

--- a/test/Middleware/ImplicitOptionsMiddlewareTest.php
+++ b/test/Middleware/ImplicitOptionsMiddlewareTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/Middleware/LazyLoadingMiddlewareTest.php
+++ b/test/Middleware/LazyLoadingMiddlewareTest.php
@@ -7,13 +7,13 @@
 
 namespace ZendTest\Expressive\Middleware;
 
+use Interop\Http\Server\MiddlewareInterface;
+use Interop\Http\Server\RequestHandlerInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
-use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 use Zend\Expressive\Exception\InvalidMiddlewareException;
 use Zend\Expressive\Middleware\LazyLoadingMiddleware;
 
@@ -28,15 +28,15 @@ class LazyLoadingMiddlewareTest extends TestCase
     /** @var ServerRequestInterface|ObjectProphecy */
     private $request;
 
-    /** @var DelegateInterface|ObjectProphecy */
-    private $delegate;
+    /** @var RequestHandlerInterface|ObjectProphecy */
+    private $handler;
 
     public function setUp()
     {
         $this->container = $this->prophesize(ContainerInterface::class);
         $this->response  = $this->prophesize(ResponseInterface::class);
         $this->request   = $this->prophesize(ServerRequestInterface::class);
-        $this->delegate  = $this->prophesize(DelegateInterface::class);
+        $this->handler   = $this->prophesize(RequestHandlerInterface::class);
     }
 
     public function buildLazyLoadingMiddleware($middlewareName)
@@ -52,11 +52,11 @@ class LazyLoadingMiddlewareTest extends TestCase
     {
         $expected   = $this->prophesize(ResponseInterface::class)->reveal();
 
-        $middleware = $this->prophesize(ServerMiddlewareInterface::class);
+        $middleware = $this->prophesize(MiddlewareInterface::class);
         $middleware
             ->process(
                 $this->request->reveal(),
-                $this->delegate->reveal()
+                $this->handler->reveal()
             )
             ->willReturn($expected);
 
@@ -65,7 +65,7 @@ class LazyLoadingMiddlewareTest extends TestCase
         $lazyLoadingMiddleware = $this->buildLazyLoadingMiddleware('middleware');
         $this->assertSame(
             $expected,
-            $lazyLoadingMiddleware->process($this->request->reveal(), $this->delegate->reveal())
+            $lazyLoadingMiddleware->process($this->request->reveal(), $this->handler->reveal())
         );
     }
 
@@ -73,7 +73,7 @@ class LazyLoadingMiddlewareTest extends TestCase
     {
         $expected   = $this->prophesize(ResponseInterface::class)->reveal();
 
-        $middleware = function ($request, DelegateInterface $delegate) use ($expected) {
+        $middleware = function ($request, RequestHandlerInterface $handler) use ($expected) {
             return $expected;
         };
 
@@ -82,7 +82,7 @@ class LazyLoadingMiddlewareTest extends TestCase
         $lazyLoadingMiddleware = $this->buildLazyLoadingMiddleware('middleware');
         $this->assertSame(
             $expected,
-            $lazyLoadingMiddleware->process($this->request->reveal(), $this->delegate->reveal())
+            $lazyLoadingMiddleware->process($this->request->reveal(), $this->handler->reveal())
         );
     }
 
@@ -99,7 +99,7 @@ class LazyLoadingMiddlewareTest extends TestCase
         $lazyLoadingMiddleware = $this->buildLazyLoadingMiddleware('middleware');
         $this->assertSame(
             $expected,
-            $lazyLoadingMiddleware->process($this->request->reveal(), $this->delegate->reveal())
+            $lazyLoadingMiddleware->process($this->request->reveal(), $this->handler->reveal())
         );
     }
 
@@ -130,6 +130,6 @@ class LazyLoadingMiddlewareTest extends TestCase
         $lazyLoadingMiddleware = $this->buildLazyLoadingMiddleware('middleware');
 
         $this->expectException(InvalidMiddlewareException::class);
-        $lazyLoadingMiddleware->process($this->request->reveal(), $this->delegate->reveal());
+        $lazyLoadingMiddleware->process($this->request->reveal(), $this->handler->reveal());
     }
 }

--- a/test/Middleware/LazyLoadingMiddlewareTest.php
+++ b/test/Middleware/LazyLoadingMiddlewareTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Middleware;
 
 use Interop\Http\Server\MiddlewareInterface;

--- a/test/Middleware/LazyLoadingMiddlewareTest.php
+++ b/test/Middleware/LazyLoadingMiddlewareTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/Middleware/NotFoundHandlerTest.php
+++ b/test/Middleware/NotFoundHandlerTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Middleware;
 
 use Interop\Http\Server\MiddlewareInterface;

--- a/test/Middleware/NotFoundHandlerTest.php
+++ b/test/Middleware/NotFoundHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/Middleware/RouteMiddlewareTest.php
+++ b/test/Middleware/RouteMiddlewareTest.php
@@ -67,7 +67,7 @@ class RouteMiddlewareTest extends TestCase
 
     public function testGeneralRoutingFailureInvokesDelegateWithSameRequest()
     {
-        $result = RouteResult::fromRouteFailure([]);
+        $result = RouteResult::fromRouteFailure(Route::HTTP_METHOD_ANY);
 
         $this->router->match($this->request->reveal())->willReturn($result);
         $this->response->withStatus()->shouldNotBeCalled();

--- a/test/Middleware/RouteMiddlewareTest.php
+++ b/test/Middleware/RouteMiddlewareTest.php
@@ -67,7 +67,7 @@ class RouteMiddlewareTest extends TestCase
 
     public function testGeneralRoutingFailureInvokesDelegateWithSameRequest()
     {
-        $result = RouteResult::fromRouteFailure();
+        $result = RouteResult::fromRouteFailure([]);
 
         $this->router->match($this->request->reveal())->willReturn($result);
         $this->response->withStatus()->shouldNotBeCalled();

--- a/test/Middleware/RouteMiddlewareTest.php
+++ b/test/Middleware/RouteMiddlewareTest.php
@@ -8,18 +8,16 @@
 namespace ZendTest\Expressive\Middleware;
 
 use Fig\Http\Message\StatusCodeInterface as StatusCode;
+use Interop\Http\Server\MiddlewareInterface;
+use Interop\Http\Server\RequestHandlerInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
-use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 use Zend\Expressive\Middleware\RouteMiddleware;
 use Zend\Expressive\Router\Route;
 use Zend\Expressive\Router\RouteResult;
 use Zend\Expressive\Router\RouterInterface;
-
-use const Webimpress\HttpMiddlewareCompatibility\HANDLER_METHOD;
 
 class RouteMiddlewareTest extends TestCase
 {
@@ -35,8 +33,8 @@ class RouteMiddlewareTest extends TestCase
     /** @var ServerRequestInterface|ObjectProphecy */
     private $request;
 
-    /** @var DelegateInterface|ObjectProphecy */
-    private $delegate;
+    /** @var RequestHandlerInterface|ObjectProphecy */
+    private $handler;
 
     public function setUp()
     {
@@ -48,7 +46,7 @@ class RouteMiddlewareTest extends TestCase
         );
 
         $this->request  = $this->prophesize(ServerRequestInterface::class);
-        $this->delegate = $this->prophesize(DelegateInterface::class);
+        $this->handler = $this->prophesize(RequestHandlerInterface::class);
     }
 
     public function testRoutingFailureDueToHttpMethodCallsNextWithNotAllowedResponseAndError()
@@ -56,12 +54,12 @@ class RouteMiddlewareTest extends TestCase
         $result = RouteResult::fromRouteFailure(['GET', 'POST']);
 
         $this->router->match($this->request->reveal())->willReturn($result);
-        $this->delegate->{HANDLER_METHOD}()->shouldNotBeCalled();
+        $this->handler->handle()->shouldNotBeCalled();
         $this->request->withAttribute()->shouldNotBeCalled();
         $this->response->withStatus(StatusCode::STATUS_METHOD_NOT_ALLOWED)->will([$this->response, 'reveal']);
         $this->response->withHeader('Allow', 'GET,POST')->will([$this->response, 'reveal']);
 
-        $response = $this->middleware->process($this->request->reveal(), $this->delegate->reveal());
+        $response = $this->middleware->process($this->request->reveal(), $this->handler->reveal());
         $this->assertSame($response, $this->response->reveal());
     }
 
@@ -75,15 +73,15 @@ class RouteMiddlewareTest extends TestCase
         $this->request->withAttribute()->shouldNotBeCalled();
 
         $expected = $this->prophesize(ResponseInterface::class)->reveal();
-        $this->delegate->{HANDLER_METHOD}($this->request->reveal())->willReturn($expected);
+        $this->handler->handle($this->request->reveal())->willReturn($expected);
 
-        $response = $this->middleware->process($this->request->reveal(), $this->delegate->reveal());
+        $response = $this->middleware->process($this->request->reveal(), $this->handler->reveal());
         $this->assertSame($expected, $response);
     }
 
     public function testRoutingSuccessDelegatesToNextAfterFirstInjectingRouteResultAndAttributesInRequest()
     {
-        $middleware = $this->prophesize(ServerMiddlewareInterface::class)->reveal();
+        $middleware = $this->prophesize(MiddlewareInterface::class)->reveal();
         $parameters = ['foo' => 'bar', 'baz' => 'bat'];
         $result = RouteResult::fromRoute(
             new Route('/foo', $middleware),
@@ -103,11 +101,11 @@ class RouteMiddlewareTest extends TestCase
         $this->response->withHeader()->shouldNotBeCalled();
 
         $expected = $this->prophesize(ResponseInterface::class)->reveal();
-        $this->delegate
-            ->{HANDLER_METHOD}($this->request->reveal())
+        $this->handler
+            ->handle($this->request->reveal())
             ->willReturn($expected);
 
-        $response = $this->middleware->process($this->request->reveal(), $this->delegate->reveal());
+        $response = $this->middleware->process($this->request->reveal(), $this->handler->reveal());
         $this->assertSame($expected, $response);
     }
 }

--- a/test/Middleware/RouteMiddlewareTest.php
+++ b/test/Middleware/RouteMiddlewareTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Middleware;
 
 use Fig\Http\Message\StatusCodeInterface as StatusCode;

--- a/test/Middleware/RouteMiddlewareTest.php
+++ b/test/Middleware/RouteMiddlewareTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/Middleware/WhoopsErrorResponseGeneratorTest.php
+++ b/test/Middleware/WhoopsErrorResponseGeneratorTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Middleware;
 
 use Fig\Http\Message\StatusCodeInterface as StatusCode;

--- a/test/Middleware/WhoopsErrorResponseGeneratorTest.php
+++ b/test/Middleware/WhoopsErrorResponseGeneratorTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/RouteResultTrait.php
+++ b/test/RouteResultTrait.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive;
 
 use Zend\Expressive\Router\Route;

--- a/test/RouteResultTrait.php
+++ b/test/RouteResultTrait.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/Router/IntegrationTest.php
+++ b/test/Router/IntegrationTest.php
@@ -430,6 +430,7 @@ class IntegrationTest extends TestCase
 
             Assert::assertInstanceOf(RouteResult::class, $routeResult);
             Assert::assertTrue($routeResult->isSuccess());
+            Assert::assertFalse($routeResult->isMethodFailure());
 
             return true;
         }), Argument::any())->will(function (array $args) {

--- a/test/Router/IntegrationTest.php
+++ b/test/Router/IntegrationTest.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\Router;
 
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;

--- a/test/Router/IntegrationTest.php
+++ b/test/Router/IntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/TestAsset/CallableInteropMiddleware.php
+++ b/test/TestAsset/CallableInteropMiddleware.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\TestAsset;
 
 use Interop\Http\Server\RequestHandlerInterface;

--- a/test/TestAsset/CallableInteropMiddleware.php
+++ b/test/TestAsset/CallableInteropMiddleware.php
@@ -7,14 +7,15 @@
 
 namespace ZendTest\Expressive\TestAsset;
 
+use Interop\Http\Server\RequestHandlerInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
 
 class CallableInteropMiddleware
 {
-    public function __invoke(ServerRequestInterface $request, DelegateInterface $delegate)
+    public function __invoke(ServerRequestInterface $request, RequestHandlerInterface $handler)
     {
-        $response = $delegate->process($request);
+        $response = $handler->handle($request);
+
         return $response->withHeader('X-Callable-Interop-Middleware', __CLASS__);
     }
 }

--- a/test/TestAsset/CallableInteropMiddleware.php
+++ b/test/TestAsset/CallableInteropMiddleware.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/TestAsset/ContainerException.php
+++ b/test/TestAsset/ContainerException.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\TestAsset;
 
 use Psr\Container\ContainerExceptionInterface;

--- a/test/TestAsset/ContainerException.php
+++ b/test/TestAsset/ContainerException.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/TestAsset/InteropMiddleware.php
+++ b/test/TestAsset/InteropMiddleware.php
@@ -7,13 +7,14 @@
 
 namespace ZendTest\Expressive\TestAsset;
 
+use Interop\Http\Server\MiddlewareInterface;
+use Interop\Http\Server\RequestHandlerInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Webimpress\HttpMiddlewareCompatibility\HandlerInterface as DelegateInterface;
-use Webimpress\HttpMiddlewareCompatibility\MiddlewareInterface as ServerMiddlewareInterface;
 
-class InteropMiddleware implements ServerMiddlewareInterface
+class InteropMiddleware implements MiddlewareInterface
 {
-    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $delegate) : ResponseInterface
     {
     }
 }

--- a/test/TestAsset/InteropMiddleware.php
+++ b/test/TestAsset/InteropMiddleware.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\TestAsset;
 
 use Interop\Http\Server\MiddlewareInterface;

--- a/test/TestAsset/InteropMiddleware.php
+++ b/test/TestAsset/InteropMiddleware.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/TestAsset/InvokableMiddleware.php
+++ b/test/TestAsset/InvokableMiddleware.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace ZendTest\Expressive\TestAsset;
 
 class InvokableMiddleware

--- a/test/TestAsset/InvokableMiddleware.php
+++ b/test/TestAsset/InvokableMiddleware.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2015-2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 

--- a/test/class_exists.php
+++ b/test/class_exists.php
@@ -5,6 +5,8 @@
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
+declare(strict_types=1);
+
 namespace Zend\Expressive;
 
 use ZendTest\Expressive\AppFactoryTest;

--- a/test/class_exists.php
+++ b/test/class_exists.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 


### PR DESCRIPTION
- dropped PHP 5.6 and 7.0
- updated Travis CI configuration

Requires:
- [x] https://github.com/zendframework/zend-expressive-router/pull/39
- [x] https://github.com/zendframework/zend-stratigility/pull/122

We need update the docs, and remove probably some functionality like double-pass middlewares.