### PR TITLE
Provides more robust is_callable logic

### DIFF
--- a/src/IsCallableInteropMiddlewareTrait.php
+++ b/src/IsCallableInteropMiddlewareTrait.php
@@ -14,6 +14,35 @@ use ReflectionMethod;
 trait IsCallableInteropMiddlewareTrait
 {
     /**
+     * Is the provided $middleware argument callable?
+     *
+     * Runs the argument against is_callable(). If that returns true, and the
+     * value is an array with two elements, tests to ensure that the second
+     * element is a method of the first.
+     *
+     * @param mixed $middleware
+     * @return bool
+     */
+    private function isCallable($middleware)
+    {
+        if (! is_callable($middleware)) {
+            return false;
+        }
+
+        if (! is_array($middleware)) {
+            return true;
+        }
+
+        $classOrObject = array_shift($middleware);
+        if (! is_object($classOrObject) && ! class_exists($classOrObject)) {
+            return false;
+        }
+
+        $method = array_shift($middleware);
+        return method_exists($classOrObject, $method);
+    }
+
+    /**
      * Is callable middleware interop middleware?
      *
      * @param mixed $middleware
@@ -21,7 +50,7 @@ trait IsCallableInteropMiddlewareTrait
      */
     private function isCallableInteropMiddleware($middleware)
     {
-        if (! is_callable($middleware)) {
+        if (! $this->isCallable($middleware)) {
             return false;
         }
 

--- a/src/MarshalMiddlewareTrait.php
+++ b/src/MarshalMiddlewareTrait.php
@@ -63,7 +63,7 @@ trait MarshalMiddlewareTrait
             return new CallableInteropMiddlewareWrapper($middleware);
         }
 
-        if (is_callable($middleware)) {
+        if ($this->isCallable($middleware)) {
             return new CallableMiddlewareWrapper($middleware, $responsePrototype);
         }
 


### PR DESCRIPTION
Provides a new method, `IsCallableInteropMiddlewareTrait::isCallable()`, which runs its argument through `is_callable()`. If the value passes, it then checks to see if it is an array, and, if so, if:

- the first argument is an object or valid class name, AND
- the second argument is a valid method of the first argument.

This is done because `is_callable()` returns a false positive when a two-element array is passed where the first argument is an object and the second a string; the function does not verify that the second element is a valid method of the first.

Fixes #527 