### PR TITLE
Fix zend-expressive-template dev-dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "psr/http-message": "^1.0.1",
         "zendframework/zend-diactoros": "^1.3.10",
         "zendframework/zend-expressive-router": "^3.0.0-dev",
-        "zendframework/zend-expressive-template": "^1.0.4",
+        "zendframework/zend-expressive-template": "^2.0.0-dev",
         "zendframework/zend-stratigility": "^3.0.0-dev"
     },
     "require-dev": {


### PR DESCRIPTION
The zendframework/zend-expressive-template dependency was not yet updated.
