### PR TITLE
Update setting-locale-without-routing-parameter.md

### DIFF
--- a/docs/book/cookbook/setting-locale-without-routing-parameter.md
+++ b/docs/book/cookbook/setting-locale-without-routing-parameter.md
@@ -60,7 +60,7 @@ class SetLocaleMiddleware implements MiddlewareInterface
         $this->helper->setBasePath($locale);
 
         return $delegate->process($request->withUri(
-            $uri->withPath(substr($path, 3))
+            $uri->withPath(substr($path, strlen($locale)+1))
         ));
     }
 }


### PR DESCRIPTION
Documentation update : [How can I setup the locale without routing parameters?](https://docs.zendframework.com/zend-expressive/cookbook/setting-locale-without-routing-parameter/)

Fix the removing the locale segment so it works with both formats : `de` **and** `de_DE`

