### PR TITLE
Expressive 3.0 fixes

### DIFF
--- a/docs/book/cookbook/setting-locale-depending-routing-parameter.md
+++ b/docs/book/cookbook/setting-locale-depending-routing-parameter.md
@@ -152,7 +152,7 @@ use Psr\Http\Message\ServerRequestInterface;
 
 class LocalizationMiddleware implements MiddlewareInterface
 {
-    const LOCALIZATION_ATTRIBUTE = 'locale';
+    public const LOCALIZATION_ATTRIBUTE = 'locale';
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
     {

--- a/src/Container/ApplicationFactory.php
+++ b/src/Container/ApplicationFactory.php
@@ -15,7 +15,6 @@ use Zend\Expressive\ApplicationPipeline;
 use Zend\Expressive\MiddlewareFactory;
 use Zend\Expressive\Router\PathBasedRoutingMiddleware;
 use Zend\HttpHandlerRunner\RequestHandlerRunner;
-use Zend\Stratigility\MiddlewarePipe;
 
 /**
  * Create an Application instance.

--- a/src/Container/RequestHandlerRunnerFactory.php
+++ b/src/Container/RequestHandlerRunnerFactory.php
@@ -10,10 +10,9 @@ declare(strict_types=1);
 namespace Zend\Expressive\Container;
 
 use Psr\Container\ContainerInterface;
-use Zend\Expressive\Application;
 use Zend\Expressive\ApplicationPipeline;
-use Zend\Expressive\ServerRequestFactory;
 use Zend\Expressive\ServerRequestErrorResponseGenerator;
+use Zend\Expressive\ServerRequestFactory;
 use Zend\HttpHandlerRunner\Emitter\EmitterInterface;
 use Zend\HttpHandlerRunner\RequestHandlerRunner;
 

--- a/src/Handler/NotFoundHandler.php
+++ b/src/Handler/NotFoundHandler.php
@@ -17,8 +17,8 @@ use Zend\Expressive\Template\TemplateRendererInterface;
 
 class NotFoundHandler implements RequestHandlerInterface
 {
-    const TEMPLATE_DEFAULT = 'error::404';
-    const LAYOUT_DEFAULT = 'layout::default';
+    public const TEMPLATE_DEFAULT = 'error::404';
+    public const LAYOUT_DEFAULT = 'layout::default';
 
     /**
      * @var TemplateRendererInterface

--- a/src/Middleware/ErrorResponseGenerator.php
+++ b/src/Middleware/ErrorResponseGenerator.php
@@ -17,7 +17,7 @@ use Zend\Stratigility\Utils;
 
 class ErrorResponseGenerator
 {
-    const TEMPLATE_DEFAULT = 'error::error';
+    public const TEMPLATE_DEFAULT = 'error::error';
 
     /**
      * @var bool

--- a/src/Middleware/ErrorResponseGenerator.php
+++ b/src/Middleware/ErrorResponseGenerator.php
@@ -50,7 +50,7 @@ EOT;
         TemplateRendererInterface $renderer = null,
         string $template = self::TEMPLATE_DEFAULT
     ) {
-        $this->debug     = (bool) $isDevelopmentMode;
+        $this->debug     = $isDevelopmentMode;
         $this->renderer  = $renderer;
         $this->template  = $template;
     }

--- a/src/Middleware/ErrorResponseGenerator.php
+++ b/src/Middleware/ErrorResponseGenerator.php
@@ -22,7 +22,7 @@ class ErrorResponseGenerator
     /**
      * @var bool
      */
-    private $debug = false;
+    private $debug;
 
     /**
      * @var TemplateRendererInterface

--- a/src/Middleware/ImplicitHeadMiddleware.php
+++ b/src/Middleware/ImplicitHeadMiddleware.php
@@ -45,7 +45,7 @@ use Zend\Expressive\Router\RouteResult;
  */
 class ImplicitHeadMiddleware implements MiddlewareInterface
 {
-    const FORWARDED_HTTP_METHOD_ATTRIBUTE = 'forwarded_http_method';
+    public const FORWARDED_HTTP_METHOD_ATTRIBUTE = 'forwarded_http_method';
 
     /**
      * @var null|ResponseInterface

--- a/src/Middleware/LazyLoadingMiddleware.php
+++ b/src/Middleware/LazyLoadingMiddleware.php
@@ -13,8 +13,8 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Zend\Expressive\MiddlewareContainer;
 use Zend\Expressive\Exception\InvalidMiddlewareException;
+use Zend\Expressive\MiddlewareContainer;
 
 class LazyLoadingMiddleware implements MiddlewareInterface
 {

--- a/src/MiddlewareContainer.php
+++ b/src/MiddlewareContainer.php
@@ -10,8 +10,6 @@ declare(strict_types=1);
 namespace Zend\Expressive;
 
 use Psr\Container\ContainerInterface;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Zend\Stratigility\Middleware\RequestHandlerMiddleware;

--- a/src/MiddlewareFactory.php
+++ b/src/MiddlewareFactory.php
@@ -9,12 +9,11 @@ declare(strict_types=1);
 
 namespace Zend\Expressive;
 
-use Psr\Container\ContainerInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Zend\Stratigility\MiddlewarePipe;
 use Zend\Stratigility\Middleware\CallableMiddlewareDecorator;
 use Zend\Stratigility\Middleware\RequestHandlerMiddleware;
+use Zend\Stratigility\MiddlewarePipe;
 
 /**
  * Marshal middleware for use in the application.

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -21,9 +21,9 @@ use Zend\Expressive\MiddlewareFactory;
 use Zend\Expressive\Router\PathBasedRoutingMiddleware as RouteMiddleware;
 use Zend\Expressive\Router\Route;
 use Zend\HttpHandlerRunner\RequestHandlerRunner;
+use Zend\Stratigility\Middleware\PathMiddlewareDecorator;
 use Zend\Stratigility\MiddlewarePipe;
 use Zend\Stratigility\MiddlewarePipeInterface;
-use Zend\Stratigility\Middleware\PathMiddlewareDecorator;
 
 class ApplicationTest extends TestCase
 {

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -16,16 +16,16 @@ use Zend\Expressive\Application;
 use Zend\Expressive\ApplicationPipeline;
 use Zend\Expressive\ConfigProvider;
 use Zend\Expressive\Handler;
+use Zend\Expressive\Middleware;
 use Zend\Expressive\MiddlewareContainer;
 use Zend\Expressive\MiddlewareFactory;
-use Zend\Expressive\Middleware;
 use Zend\Expressive\Router\DispatchMiddleware;
 use Zend\Expressive\Router\PathBasedRoutingMiddleware;
 use Zend\Expressive\ServerRequestErrorResponseGenerator;
 use Zend\Expressive\ServerRequestFactory;
+use Zend\HttpHandlerRunner\RequestHandlerRunner;
 use Zend\Stratigility\Middleware\ErrorHandler;
 use Zend\Stratigility\Middleware\ErrorResponseGenerator;
-use Zend\HttpHandlerRunner\RequestHandlerRunner;
 
 class ConfigProviderTest extends TestCase
 {

--- a/test/Container/ApplicationConfigInjectionDelegatorTest.php
+++ b/test/Container/ApplicationConfigInjectionDelegatorTest.php
@@ -15,7 +15,6 @@ use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use ReflectionProperty;
-use SplQueue;
 use Zend\Diactoros\Response;
 use Zend\Expressive\Application;
 use Zend\Expressive\Container\ApplicationConfigInjectionDelegator;

--- a/test/Container/EmitterFactoryTest.php
+++ b/test/Container/EmitterFactoryTest.php
@@ -11,7 +11,6 @@ namespace Zend\Expressive\Container;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
-use Zend\Expressive\Container\EmitterFactory;
 use Zend\HttpHandlerRunner\Emitter\EmitterStack;
 use Zend\HttpHandlerRunner\Emitter\SapiEmitter;
 

--- a/test/Container/RequestHandlerRunnerFactoryTest.php
+++ b/test/Container/RequestHandlerRunnerFactoryTest.php
@@ -14,8 +14,8 @@ use Psr\Container\ContainerInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Zend\Expressive\ApplicationPipeline;
 use Zend\Expressive\Container\RequestHandlerRunnerFactory;
-use Zend\Expressive\ServerRequestFactory;
 use Zend\Expressive\ServerRequestErrorResponseGenerator;
+use Zend\Expressive\ServerRequestFactory;
 use Zend\HttpHandlerRunner\Emitter\EmitterInterface;
 use Zend\HttpHandlerRunner\RequestHandlerRunner;
 

--- a/test/Container/ResponseFactoryTest.php
+++ b/test/Container/ResponseFactoryTest.php
@@ -11,9 +11,7 @@ namespace ZendTest\Expressive\Container;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
-use Throwable;
 use Zend\Diactoros\Response;
-use Zend\Expressive\Container\Exception\InvalidServiceException;
 use Zend\Expressive\Container\ResponseFactory;
 
 class ResponseFactoryTest extends TestCase

--- a/test/Container/ServerRequestErrorResponseGeneratorFactoryTest.php
+++ b/test/Container/ServerRequestErrorResponseGeneratorFactoryTest.php
@@ -10,9 +10,9 @@ declare(strict_types=1);
 namespace ZendTest\Expressive\Container;
 
 use Exception;
-use Psr\Container\ContainerInterface;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 use Throwable;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequest;

--- a/test/Middleware/ImplicitHeadMiddlewareTest.php
+++ b/test/Middleware/ImplicitHeadMiddlewareTest.php
@@ -15,7 +15,6 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Message\StreamInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequest;

--- a/test/Middleware/LazyLoadingMiddlewareTest.php
+++ b/test/Middleware/LazyLoadingMiddlewareTest.php
@@ -11,14 +11,13 @@ namespace ZendTest\Expressive\Middleware;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
-use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Zend\Expressive\Exception\InvalidMiddlewareException;
-use Zend\Expressive\MiddlewareContainer;
 use Zend\Expressive\Middleware\LazyLoadingMiddleware;
+use Zend\Expressive\MiddlewareContainer;
 
 class LazyLoadingMiddlewareTest extends TestCase
 {

--- a/test/MiddlewareContainerTest.php
+++ b/test/MiddlewareContainerTest.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace ZendTest\Expressive;
 
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;

--- a/test/MiddlewareFactoryTest.php
+++ b/test/MiddlewareFactoryTest.php
@@ -14,13 +14,13 @@ use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use ReflectionProperty;
 use Zend\Expressive\Exception;
+use Zend\Expressive\Middleware\LazyLoadingMiddleware;
 use Zend\Expressive\MiddlewareContainer;
 use Zend\Expressive\MiddlewareFactory;
-use Zend\Expressive\Middleware\LazyLoadingMiddleware;
 use Zend\Expressive\Router\DispatchMiddleware;
-use Zend\Stratigility\MiddlewarePipe;
 use Zend\Stratigility\Middleware\CallableMiddlewareDecorator;
 use Zend\Stratigility\Middleware\RequestHandlerMiddleware;
+use Zend\Stratigility\MiddlewarePipe;
 
 class MiddlewareFactoryTest extends TestCase
 {


### PR DESCRIPTION
Fixes:

- added constants visibility (to `public`)
- removed unnecessary type casting
- removed default property value
- optimized imports