### PR TITLE
Make the ServerRequestFactory service compatible with all containers

### DIFF
--- a/src/Container/ServerRequestFactoryFactory.php
+++ b/src/Container/ServerRequestFactoryFactory.php
@@ -12,10 +12,21 @@ namespace Zend\Expressive\Container;
 use Psr\Container\ContainerInterface;
 use Zend\Diactoros\ServerRequestFactory;
 
+/**
+ * Return a factory for generating a server request.
+ *
+ * We cannot return just `ServerRequestFactory::fromGlobals` or
+ * `[ServerRequestFactory::class, 'fromGlobals']` as not all containers
+ * allow vanilla PHP callable services. Instead, we wrap it in an
+ * anonymous function here, which is allowed by all containers tested
+ * at this time.
+ */
 class ServerRequestFactoryFactory
 {
     public function __invoke(ContainerInterface $container) : callable
     {
-        return [ServerRequestFactory::class, 'fromGlobals'];
+        return function () {
+            return ServerRequestFactory::fromGlobals();
+        };
     }
 }

--- a/test/Container/ServerRequestFactoryFactoryTest.php
+++ b/test/Container/ServerRequestFactoryFactoryTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace ZendTest\Expressive\Container;
 
+use Closure;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Zend\Diactoros\ServerRequestFactory;
@@ -29,10 +30,18 @@ class ServerRequestFactoryFactoryTest extends TestCase
     }
 
     /**
+     * Some containers do not allow returning generic PHP callables, and will
+     * error when one is returned; one example is Auryn. As such, the factory
+     * cannot simply return a callable referencing the
+     * ServerRequestFactory::fromGlobals method, but must be decorated as a
+     * closure.
+     *
      * @depends testFactoryReturnsCallable
      */
-    public function testFactoryUsesDiactorosFromGlobals(callable $factory)
+    public function testFactoryIsAClosure(callable $factory)
     {
-        $this->assertSame([ServerRequestFactory::class, 'fromGlobals'], $factory);
+        $this->assertNotSame([ServerRequestFactory::class, 'fromGlobals'], $factory);
+        $this->assertNotSame(ServerRequestFactory::class . '::fromGlobals', $factory);
+        $this->assertInstanceOf(Closure::class, $factory);
     }
 }


### PR DESCRIPTION
We cannot return just `ServerRequestFactory::fromGlobals` or `[ServerRequestFactory::class, 'fromGlobals']` as not all containers allow vanilla PHP callable services. Instead, we wrap it in an anonymous function here, which is allowed by all containers tested at this time.