### PR TITLE
Fix import for ErrorResponseGenerator service in ConfigProvider

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -13,7 +13,6 @@ use Psr\Http\Message\ResponseInterface;
 use Zend\HttpHandlerRunner\Emitter\EmitterInterface;
 use Zend\HttpHandlerRunner\RequestHandlerRunner;
 use Zend\Stratigility\Middleware\ErrorHandler;
-use Zend\Stratigility\Middleware\ErrorResponseGenerator;
 
 /**
  * Provide initial configuration for zend-expressive.
@@ -43,10 +42,10 @@ class ConfigProvider
                 ApplicationPipeline::class                 => Container\ApplicationPipelineFactory::class,
                 EmitterInterface::class                    => Container\EmitterFactory::class,
                 ErrorHandler::class                        => Container\ErrorHandlerFactory::class,
-                // Change the following in development to the WhoopsErrorResponseGeneratorFactory:
-                ErrorResponseGenerator::class              => Container\ErrorResponseGeneratorFactory::class,
                 MiddlewareContainer::class                 => Container\MiddlewareContainerFactory::class,
                 MiddlewareFactory::class                   => Container\MiddlewareFactoryFactory::class,
+                // Change the following in development to the WhoopsErrorResponseGeneratorFactory:
+                Middleware\ErrorResponseGenerator::class   => Container\ErrorResponseGeneratorFactory::class,
                 Middleware\NotFoundMiddleware::class       => Container\NotFoundMiddlewareFactory::class,
                 RequestHandlerRunner::class                => Container\RequestHandlerRunnerFactory::class,
                 ResponseInterface::class                   => Container\ResponseFactory::class,

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -25,7 +25,6 @@ use Zend\Expressive\ServerRequestFactory;
 use Zend\HttpHandlerRunner\Emitter\EmitterInterface;
 use Zend\HttpHandlerRunner\RequestHandlerRunner;
 use Zend\Stratigility\Middleware\ErrorHandler;
-use Zend\Stratigility\Middleware\ErrorResponseGenerator;
 
 class ConfigProviderTest extends TestCase
 {
@@ -52,10 +51,10 @@ class ConfigProviderTest extends TestCase
         $this->assertArrayHasKey(ApplicationPipeline::class, $factories);
         $this->assertArrayHasKey(EmitterInterface::class, $factories);
         $this->assertArrayHasKey(ErrorHandler::class, $factories);
-        $this->assertArrayHasKey(ErrorResponseGenerator::class, $factories);
         $this->assertArrayHasKey(MiddlewareContainer::class, $factories);
         $this->assertArrayHasKey(MiddlewareFactory::class, $factories);
         $this->assertArrayHasKey(DispatchMiddleware::class, $factories);
+        $this->assertArrayHasKey(Middleware\ErrorResponseGenerator::class, $factories);
         $this->assertArrayHasKey(Middleware\NotFoundMiddleware::class, $factories);
         $this->assertArrayHasKey(PathBasedRoutingMiddleware::class, $factories);
         $this->assertArrayHasKey(RequestHandlerRunner::class, $factories);


### PR DESCRIPTION
The `ErrorResponseGenerator` service should be in the `Zend\Expressive\Middleware` namespace, not in the `Zend\Stratigility\Middleware` namespace.