### PR TITLE
Rename StreamFactory, and have it return a callable

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,12 +6,12 @@
     <testsuites>
         <testsuite name="zend-expressive-response-factory">
             <file>./test/Container/ResponseFactoryWithoutDiactorosTest.php</file>
-            <file>./test/Container/StreamFactoryWithoutDiactorosTest.php</file>
+            <file>./test/Container/StreamFactoryFactoryWithoutDiactorosTest.php</file>
         </testsuite>
         <testsuite name="zend-expressive">
             <directory>./test</directory>
             <exclude>./test/Container/ResponseFactoryWithoutDiactorosTest.php</exclude>
-            <exclude>./test/Container/StreamFactoryWithoutDiactorosTest.php</exclude>
+            <exclude>./test/Container/StreamFactoryFactoryWithoutDiactorosTest.php</exclude>
         </testsuite>
     </testsuites>
 

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -50,7 +50,7 @@ class ConfigProvider
                 NOT_FOUND_RESPONSE                             => Container\ResponseFactory::class,
                 RequestHandlerRunner::class                    => Container\RequestHandlerRunnerFactory::class,
                 Router\IMPLICIT_HEAD_MIDDLEWARE_RESPONSE       => Container\ResponseFactory::class,
-                Router\IMPLICIT_HEAD_MIDDLEWARE_STREAM_FACTORY => Container\StreamFactory::class,
+                Router\IMPLICIT_HEAD_MIDDLEWARE_STREAM_FACTORY => Container\StreamFactoryFactory::class,
                 Router\IMPLICIT_OPTIONS_MIDDLEWARE_RESPONSE    => Container\ResponseFactory::class,
                 Router\METHOD_NOT_ALLOWED_MIDDLEWARE_RESPONSE  => Container\ResponseFactory::class,
                 SERVER_REQUEST_ERROR_RESPONSE_GENERATOR        => Container\ServerRequestErrorResponseGeneratorFactory::class,

--- a/src/Container/StreamFactoryFactory.php
+++ b/src/Container/StreamFactoryFactory.php
@@ -10,18 +10,15 @@ declare(strict_types=1);
 namespace Zend\Expressive\Container;
 
 use Psr\Container\ContainerInterface;
-use Psr\Http\Message\StreamInterface;
 use Zend\Diactoros\Stream;
 
 /**
- * Produces an empty stream for use with services that need to produce a stream
- * for use with a request or a response. This service should be non-shared, if
- * your container supports that possibility, to ensure that the stream it
- * composes cannot be written to by any other consumer.
+ * Produces a callable capable of producing an empty stream for use with
+ * services that need to produce a stream for use with a request or a response.
  */
-class StreamFactory
+class StreamFactoryFactory
 {
-    public function __invoke(ContainerInterface $container) : StreamInterface
+    public function __invoke(ContainerInterface $container) : callable
     {
         if (! class_exists(Stream::class)) {
             throw new Exception\InvalidServiceException(sprintf(
@@ -35,6 +32,8 @@ class StreamFactory
             ));
         }
 
-        return new Stream('php://temp', 'wb+');
+        return function () : Stream {
+            return new Stream('php://temp', 'wb+');
+        };
     }
 }

--- a/test/Container/StreamFactoryFactoryTest.php
+++ b/test/Container/StreamFactoryFactoryTest.php
@@ -12,17 +12,20 @@ namespace ZendTest\Expressive\Container;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Zend\Diactoros\Stream;
-use Zend\Expressive\Container\StreamFactory;
+use Zend\Expressive\Container\StreamFactoryFactory;
 
-class StreamFactoryTest extends TestCase
+class StreamFactoryFactoryTest extends TestCase
 {
-    public function testFactoryProducesAStreamWhenDiactorosIsInstalled()
+    public function testFactoryProducesACallableCapableOfGeneratingAStreamWhenDiactorosIsInstalled()
     {
         $container = $this->prophesize(ContainerInterface::class)->reveal();
-        $factory = new StreamFactory();
+        $factory = new StreamFactoryFactory();
 
-        $response = $factory($container);
+        $result = $factory($container);
 
-        $this->assertInstanceOf(Stream::class, $response);
+        $this->assertInternalType('callable', $result);
+
+        $stream = $result();
+        $this->assertInstanceOf(Stream::class, $stream);
     }
 }

--- a/test/Container/StreamFactoryFactoryWithoutDiactorosTest.php
+++ b/test/Container/StreamFactoryFactoryWithoutDiactorosTest.php
@@ -13,9 +13,9 @@ use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Throwable;
 use Zend\Expressive\Container\Exception\InvalidServiceException;
-use Zend\Expressive\Container\StreamFactory;
+use Zend\Expressive\Container\StreamFactoryFactory;
 
-class StreamFactoryWithoutDiactorosTest extends TestCase
+class StreamFactoryFactoryWithoutDiactorosTest extends TestCase
 {
     private $autoloadFunctions = [];
 
@@ -24,7 +24,7 @@ class StreamFactoryWithoutDiactorosTest extends TestCase
         class_exists(InvalidServiceException::class);
 
         $this->container = $this->prophesize(ContainerInterface::class)->reveal();
-        $this->factory = new StreamFactory();
+        $this->factory = new StreamFactoryFactory();
 
         foreach (spl_autoload_functions() as $autoloader) {
             if (! is_array($autoloader)) {


### PR DESCRIPTION
The factory was originally intended to return a callable, and not the stream itself. As such, it needs to be renamed to `StreamFactoryFactory`, and wrap its return value in a closure.

The IMPLICIT_HEAD_MIDDLEWARE_STREAM_FACTORY factory entry was updated to refer to the renamed class.

Fixes #552