### PR TITLE
Add aliases for v2 `Implicit*Middleware` classes

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -32,10 +32,12 @@ class ConfigProvider
         // @codingStandardsIgnoreStart
         return [
             'aliases' => [
-                DEFAULT_DELEGATE     => Handler\NotFoundHandler::class,
-                DISPATCH_MIDDLEWARE  => Router\Middleware\DispatchMiddleware::class,
-                NOT_FOUND_MIDDLEWARE => Handler\NotFoundHandler::class,
-                ROUTE_MIDDLEWARE     => Router\Middleware\PathBasedRoutingMiddleware::class,
+                DEFAULT_DELEGATE            => Handler\NotFoundHandler::class,
+                DISPATCH_MIDDLEWARE         => Router\Middleware\DispatchMiddleware::class,
+                IMPLICIT_HEAD_MIDDLEWARE    => Router\Middleware\ImplicitHeadMiddleware::class,
+                IMPLICIT_OPTIONS_MIDDLEWARE => Router\Middleware\ImplicitOptionsMiddleware::class,
+                NOT_FOUND_MIDDLEWARE        => Handler\NotFoundHandler::class,
+                ROUTE_MIDDLEWARE            => Router\Middleware\PathBasedRoutingMiddleware::class,
             ],
             'factories' => [
                 Application::class                             => Container\ApplicationFactory::class,

--- a/src/constants.php
+++ b/src/constants.php
@@ -29,6 +29,26 @@ const DEFAULT_DELEGATE = __NAMESPACE__ . '\Delegate\DefaultDelegate';
 const DISPATCH_MIDDLEWARE = __NAMESPACE__ . '\Middleware\DispatchMiddleware';
 
 /**
+ * Legacy service name for the ImplicitHeadMiddleware referenced in version 2.
+ * Should resolve to the Zend\Expressive\Router\Middleware\ImplicitHeadMiddleware
+ * service.
+ *
+ * @deprecated To remove in version 4.0.0.
+ * @var string
+ */
+const IMPLICIT_HEAD_MIDDLEWARE = __NAMESPACE__ . '\Middleware\ImplicitHeadMiddleware';
+
+/**
+ * Legacy service name for the ImplicitOptionsMiddleware referenced in version 2.
+ * Should resolve to the Zend\Expressive\Router\Middleware\ImplicitOptionsMiddleware
+ * service.
+ *
+ * @deprecated To remove in version 4.0.0.
+ * @var string
+ */
+const IMPLICIT_OPTIONS_MIDDLEWARE = __NAMESPACE__ . '\Middleware\ImplicitOptionsMiddleware';
+
+/**
  * Legacy/transitional service name for the NotFoundMiddleware introduced in
  * 3.0.0alpha2. Should resolve to the Handler\NotFoundHandler class.
  *

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -26,6 +26,8 @@ use Zend\Stratigility\Middleware\ErrorHandler;
 
 use const Zend\Expressive\DEFAULT_DELEGATE;
 use const Zend\Expressive\DISPATCH_MIDDLEWARE;
+use const Zend\Expressive\IMPLICIT_HEAD_MIDDLEWARE;
+use const Zend\Expressive\IMPLICIT_OPTIONS_MIDDLEWARE;
 use const Zend\Expressive\NOT_FOUND_MIDDLEWARE;
 use const Zend\Expressive\NOT_FOUND_RESPONSE;
 use const Zend\Expressive\ROUTE_MIDDLEWARE;
@@ -49,6 +51,8 @@ class ConfigProviderTest extends TestCase
         $aliases = $config['aliases'];
         $this->assertArrayHasKey(DEFAULT_DELEGATE, $aliases);
         $this->assertArrayHasKey(DISPATCH_MIDDLEWARE, $aliases);
+        $this->assertArrayHasKey(IMPLICIT_HEAD_MIDDLEWARE, $aliases);
+        $this->assertArrayHasKey(IMPLICIT_OPTIONS_MIDDLEWARE, $aliases);
         $this->assertArrayHasKey(NOT_FOUND_MIDDLEWARE, $aliases);
         $this->assertArrayHasKey(ROUTE_MIDDLEWARE, $aliases);
     }


### PR DESCRIPTION
These were defined as invokables in v2, and had no dependency entries.  However, they were referenced in the pipeline. Having an alias for each allows them to now resolve to the correct factories.