### PR TITLE
Use the `Zend\Expressive\ROUTE_MIDDLEWARE` to retrieve the path-based routing middleware.

### DIFF
--- a/src/Container/ApplicationFactory.php
+++ b/src/Container/ApplicationFactory.php
@@ -13,8 +13,9 @@ use Psr\Container\ContainerInterface;
 use Zend\Expressive\Application;
 use Zend\Expressive\ApplicationPipeline;
 use Zend\Expressive\MiddlewareFactory;
-use Zend\Expressive\Router\Middleware\PathBasedRoutingMiddleware;
 use Zend\HttpHandlerRunner\RequestHandlerRunner;
+
+use const Zend\Expressive\ROUTE_MIDDLEWARE;
 
 /**
  * Create an Application instance.
@@ -35,7 +36,7 @@ class ApplicationFactory
         return new Application(
             $container->get(MiddlewareFactory::class),
             $container->get(ApplicationPipeline::class),
-            $container->get(PathBasedRoutingMiddleware::class),
+            $container->get(ROUTE_MIDDLEWARE),
             $container->get(RequestHandlerRunner::class)
         );
     }

--- a/src/constants.php
+++ b/src/constants.php
@@ -70,7 +70,6 @@ const NOT_FOUND_RESPONSE = __NAMESPACE__ . '\Response\NotFoundResponseInterface'
  * Should resolve to the Zend\Expressive\Router\Middleware\PathBasedRoutingMiddleware
  * service.
  *
- * @deprecated To remove in version 4.0.0.
  * @var string
  */
 const ROUTE_MIDDLEWARE = __NAMESPACE__ . '\Middleware\RouteMiddleware';

--- a/test/Container/ApplicationFactoryTest.php
+++ b/test/Container/ApplicationFactoryTest.php
@@ -19,6 +19,8 @@ use Zend\Expressive\Router\Middleware\PathBasedRoutingMiddleware;
 use Zend\HttpHandlerRunner\RequestHandlerRunner;
 use Zend\Stratigility\MiddlewarePipeInterface;
 
+use const Zend\Expressive\ROUTE_MIDDLEWARE;
+
 class ApplicationFactoryTest extends TestCase
 {
     public function testFactoryProducesAnApplication()
@@ -31,7 +33,7 @@ class ApplicationFactoryTest extends TestCase
         $container = $this->prophesize(ContainerInterface::class);
         $container->get(MiddlewareFactory::class)->willReturn($middlewareFactory);
         $container->get(ApplicationPipeline::class)->willReturn($pipeline);
-        $container->get(PathBasedRoutingMiddleware::class)->willReturn($routeMiddleware);
+        $container->get(ROUTE_MIDDLEWARE)->willReturn($routeMiddleware);
         $container->get(RequestHandlerRunner::class)->willReturn($runner);
 
         $factory = new ApplicationFactory();


### PR DESCRIPTION
In order to make upgrading from v2 easier, we need to ensure that we use the same service name in the application factory as we use in the bootstrap. Since changing the bootstrap requires manual intervention, using the `Zend\Expressive\ROUTE_MIDDLEWARE` constant will present a simpler upgrade, as it resolves to a string matching the v2 middleware service name.

See https://github.com/zendframework/zend-expressive-skeleton/pull/222#issuecomment-365748178 for more details.