### PR TITLE
$serviceName is not used.

### DIFF
--- a/src/Container/ApplicationConfigInjectionDelegator.php
+++ b/src/Container/ApplicationConfigInjectionDelegator.php
@@ -28,7 +28,7 @@ class ApplicationConfigInjectionDelegator
      *     something other than an `Application` instance, as the delegator cannot
      *     proceed with its operations.
      */
-    public function __invoke(ContainerInterface $container, string $serviceName, callable $callback) : Application
+    public function __invoke(ContainerInterface $container, callable $callback) : Application
     {
         $application = $callback();
         if (! $application instanceof Application) {


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:

- [x] Are you fixing a bug?
  - [ ] Detail how the bug is invoked currently.
  - [ ] Detail the original, incorrect behavior.
  - [ ] Detail the new, expected behavior.
  - [ ] Base your feature on the `master` branch, and submit against that branch.
  - [ ] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.

- [x] Is this related to quality assurance?

The `$serviceName` is never used.

I was trying to test the aplha version of zend-expressive on https://github.com/harikt/dms-expressive-example . I came across a strange issue that there is no longer `injectRoutesFromConfig` in `Application` and recommends using `Zend\Expressive\Container\ApplicationConfigInjectionDelegator`.

I missed to see how to use it, so this is how I modified 

```php
    // config/routes.php
    $delegator = new \Zend\Expressive\Container\ApplicationConfigInjectionDelegator();
    $delegator($container, null, function () use ($app) {
        return $app;
    });
```
I have not seen anything searching on the code base `ApplicationConfigInjectionDelegator` whether it is used. Only one instance of file is seen currently.

So the parameter seems not needed here.

Thank you.