### PR TITLE
Revert usage of ROUTE_MIDDLEWARE constant in ApplicationFactory

### DIFF
--- a/src/Container/ApplicationFactory.php
+++ b/src/Container/ApplicationFactory.php
@@ -13,9 +13,8 @@ use Psr\Container\ContainerInterface;
 use Zend\Expressive\Application;
 use Zend\Expressive\ApplicationPipeline;
 use Zend\Expressive\MiddlewareFactory;
+use Zend\Expressive\Router\Middleware\PathBasedRoutingMiddleware;
 use Zend\HttpHandlerRunner\RequestHandlerRunner;
-
-use const Zend\Expressive\ROUTE_MIDDLEWARE;
 
 /**
  * Create an Application instance.
@@ -36,7 +35,7 @@ class ApplicationFactory
         return new Application(
             $container->get(MiddlewareFactory::class),
             $container->get(ApplicationPipeline::class),
-            $container->get(ROUTE_MIDDLEWARE),
+            $container->get(PathBasedRoutingMiddleware::class),
             $container->get(RequestHandlerRunner::class)
         );
     }

--- a/src/constants.php
+++ b/src/constants.php
@@ -70,6 +70,7 @@ const NOT_FOUND_RESPONSE = __NAMESPACE__ . '\Response\NotFoundResponseInterface'
  * Should resolve to the Zend\Expressive\Router\Middleware\PathBasedRoutingMiddleware
  * service.
  *
+ * @deprecated To remove in version 4.0.0.
  * @var string
  */
 const ROUTE_MIDDLEWARE = __NAMESPACE__ . '\Middleware\RouteMiddleware';

--- a/test/Container/ApplicationFactoryTest.php
+++ b/test/Container/ApplicationFactoryTest.php
@@ -19,8 +19,6 @@ use Zend\Expressive\Router\Middleware\PathBasedRoutingMiddleware;
 use Zend\HttpHandlerRunner\RequestHandlerRunner;
 use Zend\Stratigility\MiddlewarePipeInterface;
 
-use const Zend\Expressive\ROUTE_MIDDLEWARE;
-
 class ApplicationFactoryTest extends TestCase
 {
     public function testFactoryProducesAnApplication()
@@ -33,7 +31,7 @@ class ApplicationFactoryTest extends TestCase
         $container = $this->prophesize(ContainerInterface::class);
         $container->get(MiddlewareFactory::class)->willReturn($middlewareFactory);
         $container->get(ApplicationPipeline::class)->willReturn($pipeline);
-        $container->get(ROUTE_MIDDLEWARE)->willReturn($routeMiddleware);
+        $container->get(PathBasedRoutingMiddleware::class)->willReturn($routeMiddleware);
         $container->get(RequestHandlerRunner::class)->willReturn($runner);
 
         $factory = new ApplicationFactory();


### PR DESCRIPTION
This reverts #556.

The reversion is due to the fact that @webimpress has discovered that all supported containers resolve aliases to the target service BEFORE determining if the service has already been created. As such, pulling a service by its alias will retrieve the same instance as pulling it by its canonical name.

As such, we can use the canonical name in the `ApplicationFactory` when retrieving the routing middleware for use with the `Application`.