### PR TITLE
Response factories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,6 @@
         "slack": "https://zendframework-slack.herokuapp.com",
         "forum": "https://discourse.zendframework.com/c/questions/expressive"
     },
-    "repositories": [
-        {
-            "type": "git",
-            "url": "https://github.com/webimpress/zend-expressive-router"
-        }
-    ],
     "require": {
         "php": "^7.1",
         "fig/http-message-util": "^1.1.2",
@@ -34,7 +28,7 @@
         "psr/http-message": "^1.0.1",
         "psr/http-server-middleware": "^1.0",
         "zendframework/zend-diactoros": "^1.3.10",
-        "zendframework/zend-expressive-router": "dev-response-factory as 3.0.0alpha3",
+        "zendframework/zend-expressive-router": "^3.0.0alpha3",
         "zendframework/zend-expressive-template": "^2.0.0alpha1",
         "zendframework/zend-httphandlerrunner": "^1.0",
         "zendframework/zend-stratigility": "3.0.0alpha3"

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,12 @@
         "slack": "https://zendframework-slack.herokuapp.com",
         "forum": "https://discourse.zendframework.com/c/questions/expressive"
     },
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/webimpress/zend-expressive-router"
+        }
+    ],
     "require": {
         "php": "^7.1",
         "fig/http-message-util": "^1.1.2",
@@ -28,7 +34,7 @@
         "psr/http-message": "^1.0.1",
         "psr/http-server-middleware": "^1.0",
         "zendframework/zend-diactoros": "^1.3.10",
-        "zendframework/zend-expressive-router": "^3.0.0alpha2",
+        "zendframework/zend-expressive-router": "dev-response-factory as 3.0.0alpha3",
         "zendframework/zend-expressive-template": "^2.0.0alpha1",
         "zendframework/zend-httphandlerrunner": "^1.0",
         "zendframework/zend-stratigility": "3.0.0alpha3"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "9b1d9c164b626dcb35668bcebf529f51",
+    "content-hash": "52e5bdb5f380c2f57b65768bf879f43d",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -359,17 +359,11 @@
         },
         {
             "name": "zendframework/zend-expressive-router",
-            "version": "3.0.0alpha2",
+            "version": "dev-response-factory",
             "source": {
                 "type": "git",
-                "url": "https://github.com/zendframework/zend-expressive-router.git",
-                "reference": "b407fede07a1e3c48c7b3034c6258c9a0ed47b76"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/b407fede07a1e3c48c7b3034c6258c9a0ed47b76",
-                "reference": "b407fede07a1e3c48c7b3034c6258c9a0ed47b76",
-                "shasum": ""
+                "url": "https://github.com/webimpress/zend-expressive-router",
+                "reference": "139e3f3f4e91bcfa24106e6fa953df0edfc7a47e"
             },
             "require": {
                 "fig/http-message-util": "^1.1.2",
@@ -400,29 +394,59 @@
                 }
             },
             "autoload": {
-                "files": [
-                    "src/constants.php"
-                ],
                 "psr-4": {
                     "Zend\\Expressive\\Router\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "ZendTest\\Expressive\\Router\\": "test/"
+                }
+            },
+            "scripts": {
+                "check": [
+                    "@license-check",
+                    "@cs-check",
+                    "@test"
+                ],
+                "cs-check": [
+                    "phpcs"
+                ],
+                "cs-fix": [
+                    "phpcbf"
+                ],
+                "test": [
+                    "phpunit --colors=always"
+                ],
+                "test-coverage": [
+                    "phpunit --colors=always --coverage-clover clover.xml"
+                ],
+                "license-check": [
+                    "docheader check src/ test/"
+                ]
+            },
             "license": [
                 "BSD-3-Clause"
             ],
             "description": "Router subcomponent for Expressive",
             "keywords": [
-                "ZendFramework",
                 "expressive",
                 "http",
                 "middleware",
                 "psr",
                 "psr-7",
                 "zend-expressive",
+                "zendframework",
                 "zf"
             ],
-            "time": "2018-02-13T20:44:18+00:00"
+            "support": {
+                "issues": "https://github.com/zendframework/zend-expressive-router/issues",
+                "source": "https://github.com/zendframework/zend-expressive-router",
+                "rss": "https://github.com/zendframework/zend-expressive-router/releases.atom",
+                "slack": "https://zendframework-slack.herokuapp.com",
+                "forum": "https://discourse.zendframework.com/c/questions/expressive"
+            },
+            "time": "2018-02-21T17:10:25+00:00"
         },
         {
             "name": "zendframework/zend-expressive-template",
@@ -3362,10 +3386,17 @@
             "time": "2018-02-01T17:05:33+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "alias": "3.0.0alpha3",
+            "alias_normalized": "3.0.0.0-alpha3",
+            "version": "dev-response-factory",
+            "package": "zendframework/zend-expressive-router"
+        }
+    ],
     "minimum-stability": "stable",
     "stability-flags": {
-        "zendframework/zend-expressive-router": 15,
+        "zendframework/zend-expressive-router": 20,
         "zendframework/zend-expressive-template": 15,
         "zendframework/zend-stratigility": 15,
         "zendframework/zend-expressive-aurarouter": 15,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "52e5bdb5f380c2f57b65768bf879f43d",
+    "content-hash": "c602b615a23337d4485482ff4d79a367",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -359,11 +359,17 @@
         },
         {
             "name": "zendframework/zend-expressive-router",
-            "version": "dev-response-factory",
+            "version": "3.0.0alpha3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webimpress/zend-expressive-router",
-                "reference": "139e3f3f4e91bcfa24106e6fa953df0edfc7a47e"
+                "url": "https://github.com/zendframework/zend-expressive-router.git",
+                "reference": "737f79bffa8900388367d02e66dc0d0bcdba1eed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/737f79bffa8900388367d02e66dc0d0bcdba1eed",
+                "reference": "737f79bffa8900388367d02e66dc0d0bcdba1eed",
+                "shasum": ""
             },
             "require": {
                 "fig/http-message-util": "^1.1.2",
@@ -398,55 +404,22 @@
                     "Zend\\Expressive\\Router\\": "src/"
                 }
             },
-            "autoload-dev": {
-                "psr-4": {
-                    "ZendTest\\Expressive\\Router\\": "test/"
-                }
-            },
-            "scripts": {
-                "check": [
-                    "@license-check",
-                    "@cs-check",
-                    "@test"
-                ],
-                "cs-check": [
-                    "phpcs"
-                ],
-                "cs-fix": [
-                    "phpcbf"
-                ],
-                "test": [
-                    "phpunit --colors=always"
-                ],
-                "test-coverage": [
-                    "phpunit --colors=always --coverage-clover clover.xml"
-                ],
-                "license-check": [
-                    "docheader check src/ test/"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
             ],
             "description": "Router subcomponent for Expressive",
             "keywords": [
+                "ZendFramework",
                 "expressive",
                 "http",
                 "middleware",
                 "psr",
                 "psr-7",
                 "zend-expressive",
-                "zendframework",
                 "zf"
             ],
-            "support": {
-                "issues": "https://github.com/zendframework/zend-expressive-router/issues",
-                "source": "https://github.com/zendframework/zend-expressive-router",
-                "rss": "https://github.com/zendframework/zend-expressive-router/releases.atom",
-                "slack": "https://zendframework-slack.herokuapp.com",
-                "forum": "https://discourse.zendframework.com/c/questions/expressive"
-            },
-            "time": "2018-02-21T17:10:25+00:00"
+            "time": "2018-02-21T18:39:37+00:00"
         },
         {
             "name": "zendframework/zend-expressive-template",
@@ -3386,17 +3359,10 @@
             "time": "2018-02-01T17:05:33+00:00"
         }
     ],
-    "aliases": [
-        {
-            "alias": "3.0.0alpha3",
-            "alias_normalized": "3.0.0.0-alpha3",
-            "version": "dev-response-factory",
-            "package": "zendframework/zend-expressive-router"
-        }
-    ],
+    "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "zendframework/zend-expressive-router": 20,
+        "zendframework/zend-expressive-router": 15,
         "zendframework/zend-expressive-template": 15,
         "zendframework/zend-stratigility": 15,
         "zendframework/zend-expressive-aurarouter": 15,

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,12 +5,12 @@
          colors="true">
     <testsuites>
         <testsuite name="zend-expressive-response-factory">
-            <file>./test/Container/ResponseFactoryWithoutDiactorosTest.php</file>
+            <file>./test/Container/ResponseFactoryFactoryWithoutDiactorosTest.php</file>
             <file>./test/Container/StreamFactoryFactoryWithoutDiactorosTest.php</file>
         </testsuite>
         <testsuite name="zend-expressive">
             <directory>./test</directory>
-            <exclude>./test/Container/ResponseFactoryWithoutDiactorosTest.php</exclude>
+            <exclude>./test/Container/ResponseFactoryFactoryWithoutDiactorosTest.php</exclude>
             <exclude>./test/Container/StreamFactoryFactoryWithoutDiactorosTest.php</exclude>
         </testsuite>
     </testsuites>

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Zend\Expressive;
 
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
 use Zend\HttpHandlerRunner\Emitter\EmitterInterface;
 use Zend\HttpHandlerRunner\RequestHandlerRunner;
 use Zend\Stratigility\Middleware\ErrorHandler;
@@ -29,7 +31,6 @@ class ConfigProvider
 
     public function getDependencies() : array
     {
-        // @codingStandardsIgnoreStart
         return [
             'aliases' => [
                 DEFAULT_DELEGATE            => Handler\NotFoundHandler::class,
@@ -40,25 +41,21 @@ class ConfigProvider
                 ROUTE_MIDDLEWARE            => Router\Middleware\PathBasedRoutingMiddleware::class,
             ],
             'factories' => [
-                Application::class                             => Container\ApplicationFactory::class,
-                ApplicationPipeline::class                     => Container\ApplicationPipelineFactory::class,
-                EmitterInterface::class                        => Container\EmitterFactory::class,
-                ErrorHandler::class                            => Container\ErrorHandlerFactory::class,
-                Handler\NotFoundHandler::class                 => Container\NotFoundHandlerFactory::class,
-                MiddlewareContainer::class                     => Container\MiddlewareContainerFactory::class,
-                MiddlewareFactory::class                       => Container\MiddlewareFactoryFactory::class,
+                Application::class                       => Container\ApplicationFactory::class,
+                ApplicationPipeline::class               => Container\ApplicationPipelineFactory::class,
+                EmitterInterface::class                  => Container\EmitterFactory::class,
+                ErrorHandler::class                      => Container\ErrorHandlerFactory::class,
+                Handler\NotFoundHandler::class           => Container\NotFoundHandlerFactory::class,
+                MiddlewareContainer::class               => Container\MiddlewareContainerFactory::class,
+                MiddlewareFactory::class                 => Container\MiddlewareFactoryFactory::class,
                 // Change the following in development to the WhoopsErrorResponseGeneratorFactory:
-                Middleware\ErrorResponseGenerator::class       => Container\ErrorResponseGeneratorFactory::class,
-                NOT_FOUND_RESPONSE                             => Container\ResponseFactory::class,
-                RequestHandlerRunner::class                    => Container\RequestHandlerRunnerFactory::class,
-                Router\IMPLICIT_HEAD_MIDDLEWARE_RESPONSE       => Container\ResponseFactory::class,
-                Router\IMPLICIT_HEAD_MIDDLEWARE_STREAM_FACTORY => Container\StreamFactoryFactory::class,
-                Router\IMPLICIT_OPTIONS_MIDDLEWARE_RESPONSE    => Container\ResponseFactory::class,
-                Router\METHOD_NOT_ALLOWED_MIDDLEWARE_RESPONSE  => Container\ResponseFactory::class,
-                SERVER_REQUEST_ERROR_RESPONSE_GENERATOR        => Container\ServerRequestErrorResponseGeneratorFactory::class,
-                SERVER_REQUEST_FACTORY                         => Container\ServerRequestFactoryFactory::class,
+                Middleware\ErrorResponseGenerator::class => Container\ErrorResponseGeneratorFactory::class,
+                RequestHandlerRunner::class              => Container\RequestHandlerRunnerFactory::class,
+                ResponseInterface::class                 => Container\ResponseFactoryFactory::class,
+                SERVER_REQUEST_ERROR_RESPONSE_GENERATOR  => Container\ServerRequestErrorResponseGeneratorFactory::class,
+                SERVER_REQUEST_FACTORY                   => Container\ServerRequestFactoryFactory::class,
+                StreamInterface::class                   => Container\StreamFactoryFactory::class,
             ],
         ];
-        // @codingStandardsIgnoreEnd
     }
 }

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Zend\Expressive;
 
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Zend\HttpHandlerRunner\Emitter\EmitterInterface;
 use Zend\HttpHandlerRunner\RequestHandlerRunner;
@@ -53,7 +54,7 @@ class ConfigProvider
                 RequestHandlerRunner::class              => Container\RequestHandlerRunnerFactory::class,
                 ResponseInterface::class                 => Container\ResponseFactoryFactory::class,
                 SERVER_REQUEST_ERROR_RESPONSE_GENERATOR  => Container\ServerRequestErrorResponseGeneratorFactory::class,
-                SERVER_REQUEST_FACTORY                   => Container\ServerRequestFactoryFactory::class,
+                ServerRequestInterface::class            => Container\ServerRequestFactoryFactory::class,
                 StreamInterface::class                   => Container\StreamFactoryFactory::class,
             ],
         ];

--- a/src/Container/NotFoundHandlerFactory.php
+++ b/src/Container/NotFoundHandlerFactory.php
@@ -10,11 +10,9 @@ declare(strict_types=1);
 namespace Zend\Expressive\Container;
 
 use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
 use Zend\Expressive\Handler\NotFoundHandler;
-use Zend\Expressive\Response\NotFoundResponseInterface;
 use Zend\Expressive\Template\TemplateRendererInterface;
-
-use const Zend\Expressive\NOT_FOUND_RESPONSE;
 
 class NotFoundHandlerFactory
 {
@@ -30,7 +28,7 @@ class NotFoundHandlerFactory
             ?? NotFoundHandler::LAYOUT_DEFAULT;
 
         return new NotFoundHandler(
-            $container->get(NOT_FOUND_RESPONSE),
+            $container->get(ResponseInterface::class),
             $renderer,
             $template,
             $layout

--- a/src/Container/RequestHandlerRunnerFactory.php
+++ b/src/Container/RequestHandlerRunnerFactory.php
@@ -10,9 +10,9 @@ declare(strict_types=1);
 namespace Zend\Expressive\Container;
 
 use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Zend\Expressive\ApplicationPipeline;
 use Zend\Expressive\ServerRequestErrorResponseGenerator;
-use Zend\Expressive\ServerRequestFactory;
 use Zend\HttpHandlerRunner\Emitter\EmitterInterface;
 use Zend\HttpHandlerRunner\RequestHandlerRunner;
 
@@ -25,7 +25,7 @@ use Zend\HttpHandlerRunner\RequestHandlerRunner;
  * - Zend\Expressive\ApplicationPipeline, which should resolve to a
  *   Zend\Stratigility\MiddlewarePipeInterface and/or
  *   Psr\Http\Server\RequestHandlerInterface instance.
- * - Zend\Expressive\ServerRequestFactory, which should resolve to a PHP
+ * - Psr\Http\Message\ServerRequestInterface, which should resolve to a PHP
  *   callable that will return a Psr\Http\Message\ServerRequestInterface
  *   instance.
  * - Zend\Expressive\ServerRequestErrorResponseGenerator, which should resolve
@@ -41,7 +41,7 @@ class RequestHandlerRunnerFactory
         return new RequestHandlerRunner(
             $container->get(ApplicationPipeline::class),
             $container->get(EmitterInterface::class),
-            $container->get(ServerRequestFactory::class),
+            $container->get(ServerRequestInterface::class),
             $container->get(ServerRequestErrorResponseGenerator::class)
         );
     }

--- a/src/Container/ResponseFactoryFactory.php
+++ b/src/Container/ResponseFactoryFactory.php
@@ -14,29 +14,27 @@ use Psr\Http\Message\ResponseInterface;
 use Zend\Diactoros\Response;
 
 /**
- * Produces a response prototype for use with services that need to
- * produce a response. This service should be non-shared, if your
- * container supports that possibility, to ensure that the stream
- * it composes cannot be written to by any other consumer.
+ * Produces a callable capable of producing a response prototype for use with
+ * services that need to produce a response.
  */
-class ResponseFactory
+class ResponseFactoryFactory
 {
-    public function __invoke(ContainerInterface $container) : ResponseInterface
+    public function __invoke(ContainerInterface $container) : callable
     {
         if (! class_exists(Response::class)) {
             throw new Exception\InvalidServiceException(sprintf(
-                'The %s service must map to a factory capable of returning an'
+                'The %1$s service must map to a factory capable of returning an'
                 . ' implementation instance. By default, we assume usage of'
                 . ' zend-diactoros for PSR-7, but it does not appear to be'
                 . ' present on your system. Please install zendframework/zend-diactoros'
-                . ' or provide an alternate factory for the %s service that'
-                . ' can produce an appropriate %s instance.',
-                ResponseInterface::class,
-                ResponseInterface::class,
+                . ' or provide an alternate factory for the %1$s service that'
+                . ' can produce an appropriate %1$s instance.',
                 ResponseInterface::class
             ));
         }
 
-        return new Response();
+        return function () : Response {
+            return new Response();
+        };
     }
 }

--- a/src/constants.php
+++ b/src/constants.php
@@ -58,14 +58,6 @@ const IMPLICIT_OPTIONS_MIDDLEWARE = __NAMESPACE__ . '\Middleware\ImplicitOptions
 const NOT_FOUND_MIDDLEWARE = __NAMESPACE__ . '\Middleware\NotFoundMiddleware';
 
 /**
- * Virtual service name that should resolve to a service returning a PSR-7
- * ResponseInterface instance for use with the Handler\NotFoundHandler class.
- *
- * @var string
- */
-const NOT_FOUND_RESPONSE = __NAMESPACE__ . '\Response\NotFoundResponseInterface';
-
-/**
  * Legacy service name for the RouteMiddleware referenced in version 2.
  * Should resolve to the Zend\Expressive\Router\Middleware\PathBasedRoutingMiddleware
  * service.

--- a/src/constants.php
+++ b/src/constants.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Zend\Expressive;
 
+use Psr\Http\Message\ServerRequestInterface;
+
 /**
  * Legacy service name for the default delegate referenced in version 2.
  * Should resolve to the Handler\NotFoundHandler class.
@@ -77,9 +79,11 @@ const ROUTE_MIDDLEWARE = __NAMESPACE__ . '\Middleware\RouteMiddleware';
 const SERVER_REQUEST_ERROR_RESPONSE_GENERATOR = __NAMESPACE__ . '\ServerRequestErrorResponseGenerator';
 
 /**
- * Virtual service name that should resolve to a service capable of producing
- * a PSR-7 ServerRequestInterface instance for the application.
+ * Legacy/transitional service name for the ServerRequestFactory virtual
+ * service introduced in 3.0.0alpha6. Should resolve to the
+ * Psr\Http\Message\ServerRequestInterface service.
  *
+ * @deprecated To remove in version 4.0.0.
  * @var string
  */
-const SERVER_REQUEST_FACTORY = __NAMESPACE__ . '\ServerRequestFactory';
+const SERVER_REQUEST_FACTORY = ServerRequestInterface::class;

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -10,18 +10,16 @@ declare(strict_types=1);
 namespace ZendTest\Expressive;
 
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
 use Zend\Expressive\Application;
 use Zend\Expressive\ApplicationPipeline;
 use Zend\Expressive\ConfigProvider;
-use Zend\Expressive\Delegate\DefaultDelegate;
 use Zend\Expressive\Handler\NotFoundHandler;
 use Zend\Expressive\Middleware;
 use Zend\Expressive\MiddlewareContainer;
 use Zend\Expressive\MiddlewareFactory;
-use Zend\Expressive\Router\ConfigProvider as RouterConfigProvider;
 use Zend\Expressive\Router\RouterInterface;
-use Zend\Expressive\ServerRequestErrorResponseGenerator;
-use Zend\Expressive\ServerRequestFactory;
 use Zend\HttpHandlerRunner\Emitter\EmitterInterface;
 use Zend\HttpHandlerRunner\RequestHandlerRunner;
 use Zend\ServiceManager\Config;
@@ -33,14 +31,9 @@ use const Zend\Expressive\DISPATCH_MIDDLEWARE;
 use const Zend\Expressive\IMPLICIT_HEAD_MIDDLEWARE;
 use const Zend\Expressive\IMPLICIT_OPTIONS_MIDDLEWARE;
 use const Zend\Expressive\NOT_FOUND_MIDDLEWARE;
-use const Zend\Expressive\NOT_FOUND_RESPONSE;
 use const Zend\Expressive\ROUTE_MIDDLEWARE;
 use const Zend\Expressive\SERVER_REQUEST_ERROR_RESPONSE_GENERATOR;
 use const Zend\Expressive\SERVER_REQUEST_FACTORY;
-use const Zend\Expressive\Router\IMPLICIT_HEAD_MIDDLEWARE_RESPONSE;
-use const Zend\Expressive\Router\IMPLICIT_HEAD_MIDDLEWARE_STREAM_FACTORY;
-use const Zend\Expressive\Router\IMPLICIT_OPTIONS_MIDDLEWARE_RESPONSE;
-use const Zend\Expressive\Router\METHOD_NOT_ALLOWED_MIDDLEWARE_RESPONSE;
 
 class ConfigProviderTest extends TestCase
 {
@@ -73,18 +66,15 @@ class ConfigProviderTest extends TestCase
         $this->assertArrayHasKey(ApplicationPipeline::class, $factories);
         $this->assertArrayHasKey(EmitterInterface::class, $factories);
         $this->assertArrayHasKey(ErrorHandler::class, $factories);
-        $this->assertArrayHasKey(IMPLICIT_HEAD_MIDDLEWARE_RESPONSE, $factories);
-        $this->assertArrayHasKey(IMPLICIT_HEAD_MIDDLEWARE_STREAM_FACTORY, $factories);
-        $this->assertArrayHasKey(IMPLICIT_OPTIONS_MIDDLEWARE_RESPONSE, $factories);
-        $this->assertArrayHasKey(METHOD_NOT_ALLOWED_MIDDLEWARE_RESPONSE, $factories);
         $this->assertArrayHasKey(MiddlewareContainer::class, $factories);
         $this->assertArrayHasKey(MiddlewareFactory::class, $factories);
         $this->assertArrayHasKey(Middleware\ErrorResponseGenerator::class, $factories);
         $this->assertArrayHasKey(NotFoundHandler::class, $factories);
-        $this->assertArrayHasKey(NOT_FOUND_RESPONSE, $factories);
         $this->assertArrayHasKey(RequestHandlerRunner::class, $factories);
+        $this->assertArrayHasKey(ResponseInterface::class, $factories);
         $this->assertArrayHasKey(SERVER_REQUEST_ERROR_RESPONSE_GENERATOR, $factories);
         $this->assertArrayHasKey(SERVER_REQUEST_FACTORY, $factories);
+        $this->assertArrayHasKey(StreamInterface::class, $factories);
     }
 
     public function testInvocationReturnsArrayWithDependencies()

--- a/test/Container/NotFoundHandlerFactoryTest.php
+++ b/test/Container/NotFoundHandlerFactoryTest.php
@@ -15,7 +15,6 @@ use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Zend\Expressive\Container\NotFoundHandlerFactory;
 use Zend\Expressive\Handler\NotFoundHandler;
-use Zend\Expressive\Response\NotFoundResponseInterface;
 use Zend\Expressive\Template\TemplateRendererInterface;
 
 class NotFoundHandlerFactoryTest extends TestCase
@@ -30,7 +29,9 @@ class NotFoundHandlerFactoryTest extends TestCase
     {
         $this->response = $this->prophesize(ResponseInterface::class)->reveal();
         $this->container = $this->prophesize(ContainerInterface::class);
-        $this->container->get(NotFoundResponseInterface::class)->willReturn($this->response);
+        $this->container->get(ResponseInterface::class)->willReturn(function () {
+            return $this->response;
+        });
     }
 
     public function testFactoryCreatesInstanceWithoutRendererIfRendererServiceIsMissing()
@@ -41,7 +42,7 @@ class NotFoundHandlerFactoryTest extends TestCase
 
         $handler = $factory($this->container->reveal());
         $this->assertInstanceOf(NotFoundHandler::class, $handler);
-        $this->assertAttributeSame($this->response, 'responsePrototype', $handler);
+        $this->assertAttributeInternalType('callable', 'responseFactory', $handler);
         $this->assertAttributeEmpty('renderer', $handler);
     }
 

--- a/test/Container/RequestHandlerRunnerFactoryTest.php
+++ b/test/Container/RequestHandlerRunnerFactoryTest.php
@@ -11,11 +11,11 @@ namespace ZendTest\Expressive\Container;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Zend\Expressive\ApplicationPipeline;
 use Zend\Expressive\Container\RequestHandlerRunnerFactory;
 use Zend\Expressive\ServerRequestErrorResponseGenerator;
-use Zend\Expressive\ServerRequestFactory;
 use Zend\HttpHandlerRunner\Emitter\EmitterInterface;
 use Zend\HttpHandlerRunner\RequestHandlerRunner;
 
@@ -58,7 +58,7 @@ class RequestHandlerRunnerFactoryTest extends TestCase
     {
         $factory = function () {
         };
-        $container->get(ServerRequestFactory::class)->willReturn($factory);
+        $container->get(ServerRequestInterface::class)->willReturn($factory);
         return $factory;
     }
 

--- a/test/Container/ResponseFactoryFactoryTest.php
+++ b/test/Container/ResponseFactoryFactoryTest.php
@@ -12,17 +12,20 @@ namespace ZendTest\Expressive\Container;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Zend\Diactoros\Response;
-use Zend\Expressive\Container\ResponseFactory;
+use Zend\Expressive\Container\ResponseFactoryFactory;
 
-class ResponseFactoryTest extends TestCase
+class ResponseFactoryFactoryTest extends TestCase
 {
-    public function testFactoryProducesAResponseWhenDiactorosIsInstalled()
+    public function testFactoryProducesACallableCapableOfGeneratingAResponseWhenDiactorosIsInstalled()
     {
         $container = $this->prophesize(ContainerInterface::class)->reveal();
-        $factory = new ResponseFactory();
+        $factory = new ResponseFactoryFactory();
 
-        $response = $factory($container);
+        $result = $factory($container);
 
+        $this->assertInternalType('callable', $result);
+
+        $response = $result();
         $this->assertInstanceOf(Response::class, $response);
     }
 }

--- a/test/Handler/NotFoundHandlerTest.php
+++ b/test/Handler/NotFoundHandlerTest.php
@@ -30,23 +30,28 @@ class NotFoundHandlerTest extends TestCase
     /** @var ResponseInterface|ObjectProphecy */
     private $response;
 
+    /** @var callable */
+    private $responseFactory;
+
     public function setUp()
     {
         $this->request  = $this->prophesize(ServerRequestInterface::class);
         $this->response = $this->prophesize(ResponseInterface::class);
+        $this->responseFactory = function () {
+            return $this->response->reveal();
+        };
     }
 
     public function testImplementsRequesthandler()
     {
-        $handler = new NotFoundHandler($this->response->reveal());
+        $handler = new NotFoundHandler($this->responseFactory);
         $this->assertInstanceOf(RequestHandlerInterface::class, $handler);
     }
 
     public function testConstructorDoesNotRequireARenderer()
     {
-        $handler = new NotFoundHandler($this->response->reveal());
+        $handler = new NotFoundHandler($this->responseFactory);
         $this->assertInstanceOf(NotFoundHandler::class, $handler);
-        $this->assertAttributeSame($this->response->reveal(), 'responsePrototype', $handler);
     }
 
     public function testConstructorCanAcceptRendererAndTemplate()
@@ -55,7 +60,7 @@ class NotFoundHandlerTest extends TestCase
         $template = 'foo::bar';
         $layout = 'layout::error';
 
-        $handler = new NotFoundHandler($this->response->reveal(), $renderer, $template, $layout);
+        $handler = new NotFoundHandler($this->responseFactory, $renderer, $template, $layout);
 
         $this->assertInstanceOf(NotFoundHandler::class, $handler);
         $this->assertAttributeSame($renderer, 'renderer', $handler);
@@ -74,7 +79,7 @@ class NotFoundHandlerTest extends TestCase
         $this->response->withStatus(StatusCode::STATUS_NOT_FOUND)->will([$this->response, 'reveal']);
         $this->response->getBody()->will([$stream, 'reveal']);
 
-        $handler = new NotFoundHandler($this->response->reveal());
+        $handler = new NotFoundHandler($this->responseFactory);
 
         $response = $handler->handle($request->reveal());
 
@@ -102,7 +107,7 @@ class NotFoundHandlerTest extends TestCase
         $this->response->withStatus(StatusCode::STATUS_NOT_FOUND)->will([$this->response, 'reveal']);
         $this->response->getBody()->will([$stream, 'reveal']);
 
-        $handler = new NotFoundHandler($this->response->reveal(), $renderer->reveal());
+        $handler = new NotFoundHandler($this->responseFactory, $renderer->reveal());
 
         $response = $handler->handle($request);
 

--- a/test/Router/IntegrationTest.php
+++ b/test/Router/IntegrationTest.php
@@ -47,6 +47,9 @@ class IntegrationTest extends TestCase
     /** @var Response */
     private $response;
 
+    /** @var callable */
+    private $responseFactory;
+
     /** @var RouterInterface|ObjectProphecy */
     private $router;
 
@@ -56,6 +59,9 @@ class IntegrationTest extends TestCase
     public function setUp()
     {
         $this->response  = new Response();
+        $this->responseFactory = function () {
+            return $this->response;
+        };
         $this->router    = $this->prophesize(RouterInterface::class);
         $this->container = $this->mockContainerInterface();
     }
@@ -106,7 +112,7 @@ class IntegrationTest extends TestCase
         $router = new $adapter();
         $app = $this->createApplicationFromRouter($router);
         $app->pipe(new RouteMiddleware($router));
-        $app->pipe(new MethodNotAllowedMiddleware($this->response));
+        $app->pipe(new MethodNotAllowedMiddleware($this->responseFactory));
 
         $app->get('/foo', function ($req, $handler) {
             $stream = new Stream('php://temp', 'w+');
@@ -136,7 +142,7 @@ class IntegrationTest extends TestCase
         $router = new $adapter();
         $app = $this->createApplicationFromRouter($router);
         $app->pipe(new RouteMiddleware($router));
-        $app->pipe(new MethodNotAllowedMiddleware($this->response));
+        $app->pipe(new MethodNotAllowedMiddleware($this->responseFactory));
 
         $app->route('/foo', function ($req, $handler) {
             $stream = new Stream('php://temp', 'w+');
@@ -298,7 +304,7 @@ class IntegrationTest extends TestCase
         $router = new $adapter();
         $app = $this->createApplicationFromRouter($router);
         $app->pipe(new RouteMiddleware($router));
-        $app->pipe(new MethodNotAllowedMiddleware($this->response));
+        $app->pipe(new MethodNotAllowedMiddleware($this->responseFactory));
         $app->pipe(new DispatchMiddleware());
 
         $response = clone $this->response;
@@ -364,7 +370,7 @@ class IntegrationTest extends TestCase
         $router = new $adapter();
         $app = $this->createApplicationFromRouter($router);
         $app->pipe(new RouteMiddleware($router));
-        $app->pipe(new MethodNotAllowedMiddleware($this->response));
+        $app->pipe(new MethodNotAllowedMiddleware($this->responseFactory));
         $app->pipe(new DispatchMiddleware());
 
         // Add a route with Zend\Expressive\Router\Route::HTTP_METHOD_ANY
@@ -428,10 +434,10 @@ class IntegrationTest extends TestCase
         $router = new $adapter();
         $app = $this->createApplicationFromRouter($router);
         $app->pipe(new RouteMiddleware($router));
-        $app->pipe(new MethodNotAllowedMiddleware($this->response));
-        $app->pipe(new ImplicitHeadMiddleware($this->response, function () {
+        $app->pipe(new MethodNotAllowedMiddleware($this->responseFactory));
+        $app->pipe(new ImplicitHeadMiddleware($this->responseFactory, function () {
         }));
-        $app->pipe(new ImplicitOptionsMiddleware($this->response));
+        $app->pipe(new ImplicitOptionsMiddleware($this->responseFactory));
         $app->pipe(new DispatchMiddleware());
 
         // Add a PUT route
@@ -463,7 +469,7 @@ class IntegrationTest extends TestCase
         $router = new $adapter();
         $app = $this->createApplicationFromRouter($router);
         $app->pipe(new RouteMiddleware($router));
-        $app->pipe(new MethodNotAllowedMiddleware($this->response));
+        $app->pipe(new MethodNotAllowedMiddleware($this->responseFactory));
 
         // This middleware is used just to check that request has successful RouteResult
         $middleware = $this->prophesize(MiddlewareInterface::class);
@@ -482,11 +488,11 @@ class IntegrationTest extends TestCase
         $app->pipe($middleware->reveal());
 
         if ($method === 'HEAD') {
-            $app->pipe(new ImplicitHeadMiddleware($this->response, function () {
+            $app->pipe(new ImplicitHeadMiddleware($this->responseFactory, function () {
             }));
         }
         if ($method === 'OPTIONS') {
-            $app->pipe(new ImplicitOptionsMiddleware($this->response));
+            $app->pipe(new ImplicitOptionsMiddleware($this->responseFactory));
         }
         $app->pipe(new DispatchMiddleware());
 
@@ -519,7 +525,7 @@ class IntegrationTest extends TestCase
         $router = new $adapter();
         $app = $this->createApplicationFromRouter($router);
         $app->pipe(new RouteMiddleware($router));
-        $app->pipe(new MethodNotAllowedMiddleware($this->response));
+        $app->pipe(new MethodNotAllowedMiddleware($this->responseFactory));
         $app->pipe(new DispatchMiddleware());
 
         // Add a route with empty array - NO HTTP methods


### PR DESCRIPTION
Refactors the `ResponseFactory` to be a `ResponseFactoryFactory`. Any class that needs a response instance should compose a `callable` response factory instead, which can then be invoked in order to produce a response. This ensures we generate a new instance every time, and eliminates the need for mapping discrete "virtual" services to the response factory; we can use the same service everywhere.

The name chosen for the `ResponseFactoryFactory` service is the PSR-7 `ResponseInterface`; this allows us to use an existing name instead of a constant evaluating to an arbitrary string name.