### PR TITLE
Provide a dedicated service for server request error response generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- [#562](https://github.com/zendframework/zend-expressive/pull/562) adds the
+  class `Zend\Expressive\Response\ServerRequestErrorResponseGenerator`, and maps
+  it to the `Zend\Expressive\Container\ServerRequestErrorResponseGeneratorFactory`.
+  The class generates an error response when an exeption occurs producing a
+  server request instance, and can be optionally templated.
 
 ### Changed
 
@@ -20,13 +24,28 @@ All notable changes to this project will be documented in this file, in reverse 
   creates, as that class changes in 3.0.0alpha4 such that it now expects a
   factory instead of an instance.
 
+- [#562](https://github.com/zendframework/zend-expressive/pull/562) modifies the
+  `Zend\Expressive\Container\RequestHandlerRunnerFactory` to depend on the
+  `Zend\Expressive\Response\ServerRequestErrorResponseGenerator` service instead
+  of the `Zend\Expressive\SERVER_REQUEST_ERROR_RESPONSE_GENERATOR` virtual
+  service.
+
+- [#562](https://github.com/zendframework/zend-expressive/pull/562) extracts
+  most logic from `Zend\Expressive\Middleware\ErrorResponseGenerator` to a new
+  trait, `Zend\Expressive\Response\ErrorResponseGeneratorTrait`. A trait was
+  used as the classes consuming it are from different namespaces, and thus
+  different inheritance trees. The trait is used by both the
+  `ErrorResponseGenerator` and the new `ServerRequestErrorResponseGenerator`.
+
 ### Deprecated
 
 - Nothing.
 
 ### Removed
 
-- Nothing.
+- [#562](https://github.com/zendframework/zend-expressive/pull/562) removes the
+  constant `Zend\Expressive\SERVER_REQUEST_ERROR_RESPONSE_GENERATOR`. It was
+  only used internally previously.
 
 ### Fixed
 

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -32,6 +32,7 @@ class ConfigProvider
 
     public function getDependencies() : array
     {
+        // @codingStandardsIgnoreStart
         return [
             'aliases' => [
                 DEFAULT_DELEGATE            => Handler\NotFoundHandler::class,
@@ -53,10 +54,11 @@ class ConfigProvider
                 Middleware\ErrorResponseGenerator::class => Container\ErrorResponseGeneratorFactory::class,
                 RequestHandlerRunner::class              => Container\RequestHandlerRunnerFactory::class,
                 ResponseInterface::class                 => Container\ResponseFactoryFactory::class,
-                SERVER_REQUEST_ERROR_RESPONSE_GENERATOR  => Container\ServerRequestErrorResponseGeneratorFactory::class,
+                Response\ServerRequestErrorResponseGenerator::class  => Container\ServerRequestErrorResponseGeneratorFactory::class,
                 ServerRequestInterface::class            => Container\ServerRequestFactoryFactory::class,
                 StreamInterface::class                   => Container\StreamFactoryFactory::class,
             ],
         ];
+        // @codingStandardsIgnoreEnd
     }
 }

--- a/src/Container/RequestHandlerRunnerFactory.php
+++ b/src/Container/RequestHandlerRunnerFactory.php
@@ -12,27 +12,26 @@ namespace Zend\Expressive\Container;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Zend\Expressive\ApplicationPipeline;
-use Zend\Expressive\ServerRequestErrorResponseGenerator;
+use Zend\Expressive\Response\ServerRequestErrorResponseGenerator;
 use Zend\HttpHandlerRunner\Emitter\EmitterInterface;
 use Zend\HttpHandlerRunner\RequestHandlerRunner;
 
 /**
  * Create an ApplicationRunner instance.
  *
- * This class consumes three pseudo-services (services that look like class
- * names, but resolve to other artifacts):
+ * This class consumes two pseudo-services (services that look like class
+ * names, but resolve to other artifacts) and two services provided within
+ * this package:
  *
  * - Zend\Expressive\ApplicationPipeline, which should resolve to a
  *   Zend\Stratigility\MiddlewarePipeInterface and/or
  *   Psr\Http\Server\RequestHandlerInterface instance.
+ * - Zend\HttpHandlerRunner\Emitter\EmitterInterface.
  * - Psr\Http\Message\ServerRequestInterface, which should resolve to a PHP
  *   callable that will return a Psr\Http\Message\ServerRequestInterface
  *   instance.
- * - Zend\Expressive\ServerRequestErrorResponseGenerator, which should resolve
- *   to a PHP callable that accepts a Throwable argument, and which will return
- *   a Psr\Http\Message\ResponseInterface instance.
+ * - Zend\Expressive\Response\ServerRequestErrorResponseGeneratorFactory,
  *
- * It also consumes the service Zend\HttpHandlerRunner\Emitter\EmitterInterface.
  */
 class RequestHandlerRunnerFactory
 {

--- a/src/Middleware/ErrorResponseGenerator.php
+++ b/src/Middleware/ErrorResponseGenerator.php
@@ -40,15 +40,21 @@ class ErrorResponseGenerator
         $response = $response->withStatus(Utils::getStatusCode($e, $response));
 
         if ($this->renderer) {
-            return $this->prepareTemplatedResponse($e, $response, [
-                'response' => $response,
-                'request'  => $request,
-                'uri'      => (string) $request->getUri(),
-                'status'   => $response->getStatusCode(),
-                'reason'   => $response->getReasonPhrase(),
-            ]);
+            return $this->prepareTemplatedResponse(
+                $e,
+                $this->renderer,
+                [
+                    'response' => $response,
+                    'request'  => $request,
+                    'uri'      => (string) $request->getUri(),
+                    'status'   => $response->getStatusCode(),
+                    'reason'   => $response->getReasonPhrase(),
+                ],
+                $this->debug,
+                $response
+            );
         }
 
-        return $this->prepareDefaultResponse($e, $response);
+        return $this->prepareDefaultResponse($e, $this->debug, $response);
     }
 }

--- a/src/Response/ErrorResponseGeneratorTrait.php
+++ b/src/Response/ErrorResponseGeneratorTrait.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Response;
+
+use Psr\Http\Message\ResponseInterface;
+use Throwable;
+use Zend\Expressive\Template\TemplateRendererInterface;
+
+trait ErrorResponseGeneratorTrait
+{
+    /**
+     * Whether or not we are in debug/development mode.
+     *
+     * @var bool
+     */
+    private $debug;
+
+    /**
+     * @param TemplateRendererInterface
+     */
+    private $renderer;
+
+    /**
+     * @var string
+     */
+    private $stackTraceTemplate = <<<'EOT'
+%s raised in file %s line %d:
+Message: %s
+Stack Trace:
+%s
+
+EOT;
+
+    /**
+     * Name of the template to render.
+     *
+     * @var string
+     */
+    private $template;
+
+    private function prepareTemplatedResponse(
+        Throwable $e,
+        ResponseInterface $response,
+        array $templateData
+    ) : ResponseInterface {
+        if ($this->debug) {
+            $templateData['error'] = $e;
+        }
+
+        $response->getBody()
+            ->write($this->renderer->render($this->template, $templateData));
+
+        return $response;
+    }
+
+    private function prepareDefaultResponse(Throwable $e, ResponseInterface $response) : ResponseInterface
+    {
+        $message = 'An unexpected error occurred';
+
+        if ($this->debug) {
+            $message .= "; strack trace:\n\n" . $this->prepareStackTrace($e);
+        }
+
+        $response->getBody()->write($message);
+
+        return $response;
+    }
+
+    /**
+     * Prepares a stack trace to display.
+     */
+    private function prepareStackTrace(Throwable $e) : string
+    {
+        $message = '';
+        do {
+            $message .= sprintf(
+                $this->stackTraceTemplate,
+                get_class($e),
+                $e->getFile(),
+                $e->getLine(),
+                $e->getMessage(),
+                $e->getTraceAsString()
+            );
+        } while ($e = $e->getPrevious());
+
+        return $message;
+    }
+}

--- a/src/Response/ErrorResponseGeneratorTrait.php
+++ b/src/Response/ErrorResponseGeneratorTrait.php
@@ -47,24 +47,29 @@ EOT;
 
     private function prepareTemplatedResponse(
         Throwable $e,
-        ResponseInterface $response,
-        array $templateData
+        TemplateRendererInterface $renderer,
+        array $templateData,
+        bool $debug,
+        ResponseInterface $response
     ) : ResponseInterface {
-        if ($this->debug) {
+        if ($debug) {
             $templateData['error'] = $e;
         }
 
         $response->getBody()
-            ->write($this->renderer->render($this->template, $templateData));
+            ->write($renderer->render($this->template, $templateData));
 
         return $response;
     }
 
-    private function prepareDefaultResponse(Throwable $e, ResponseInterface $response) : ResponseInterface
-    {
+    private function prepareDefaultResponse(
+        Throwable $e,
+        bool $debug,
+        ResponseInterface $response
+    ) : ResponseInterface {
         $message = 'An unexpected error occurred';
 
-        if ($this->debug) {
+        if ($debug) {
             $message .= "; stack trace:\n\n" . $this->prepareStackTrace($e);
         }
 

--- a/src/Response/ErrorResponseGeneratorTrait.php
+++ b/src/Response/ErrorResponseGeneratorTrait.php
@@ -65,7 +65,7 @@ EOT;
         $message = 'An unexpected error occurred';
 
         if ($this->debug) {
-            $message .= "; strack trace:\n\n" . $this->prepareStackTrace($e);
+            $message .= "; stack trace:\n\n" . $this->prepareStackTrace($e);
         }
 
         $response->getBody()->write($message);

--- a/src/Response/ServerRequestErrorResponseGenerator.php
+++ b/src/Response/ServerRequestErrorResponseGenerator.php
@@ -45,10 +45,10 @@ class ServerRequestErrorResponseGenerator
         $this->template  = $template;
     }
 
-    public function __invoke(Throwable $e)
+    public function __invoke(Throwable $e) : ResponseInterface
     {
-        $response = ($this->responseFactory)()
-            ->withStatus(Utils::getStatusCode($e, $response));
+        $response = ($this->responseFactory)();
+        $response = $response->withStatus(Utils::getStatusCode($e, $response));
 
         if ($this->renderer) {
             return $this->prepareTemplatedResponse($e, $response, [

--- a/src/Response/ServerRequestErrorResponseGenerator.php
+++ b/src/Response/ServerRequestErrorResponseGenerator.php
@@ -51,13 +51,19 @@ class ServerRequestErrorResponseGenerator
         $response = $response->withStatus(Utils::getStatusCode($e, $response));
 
         if ($this->renderer) {
-            return $this->prepareTemplatedResponse($e, $response, [
-                'response' => $response,
-                'status'   => $response->getStatusCode(),
-                'reason'   => $response->getReasonPhrase(),
-            ]);
+            return $this->prepareTemplatedResponse(
+                $e,
+                $this->renderer,
+                [
+                    'response' => $response,
+                    'status'   => $response->getStatusCode(),
+                    'reason'   => $response->getReasonPhrase(),
+                ],
+                $this->debug,
+                $response
+            );
         }
 
-        return $this->prepareDefaultResponse($e, $response);
+        return $this->prepareDefaultResponse($e, $this->debug, $response);
     }
 }

--- a/src/Response/ServerRequestErrorResponseGenerator.php
+++ b/src/Response/ServerRequestErrorResponseGenerator.php
@@ -1,49 +1,58 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
- * @copyright Copyright (c) 2016-2017 Zend Technologies USA Inc. (https://www.zend.com)
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
  */
 
 declare(strict_types=1);
 
-namespace Zend\Expressive\Middleware;
+namespace Zend\Expressive\Response;
 
 use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
-use Zend\Expressive\Response\ErrorResponseGeneratorTrait;
 use Zend\Expressive\Template\TemplateRendererInterface;
 use Zend\Stratigility\Utils;
 
-class ErrorResponseGenerator
+/**
+ * Generates a response for use when the server request factory fails.
+ */
+class ServerRequestErrorResponseGenerator
 {
     use ErrorResponseGeneratorTrait;
 
     public const TEMPLATE_DEFAULT = 'error::error';
 
+    /**
+     * Factory capable of generating a ResponseInterface instance.
+     *
+     * @param callable
+     */
+    private $responseFactory;
+
     public function __construct(
+        callable $responseFactory,
         bool $isDevelopmentMode = false,
         TemplateRendererInterface $renderer = null,
         string $template = self::TEMPLATE_DEFAULT
     ) {
+        $this->responseFactory = function () use ($responseFactory) : ResponseInterface {
+            return $responseFactory();
+        };
+
         $this->debug     = $isDevelopmentMode;
         $this->renderer  = $renderer;
         $this->template  = $template;
     }
 
-    public function __invoke(
-        Throwable $e,
-        ServerRequestInterface $request,
-        ResponseInterface $response
-    ) : ResponseInterface {
-        $response = $response->withStatus(Utils::getStatusCode($e, $response));
+    public function __invoke(Throwable $e)
+    {
+        $response = ($this->responseFactory)()
+            ->withStatus(Utils::getStatusCode($e, $response));
 
         if ($this->renderer) {
             return $this->prepareTemplatedResponse($e, $response, [
                 'response' => $response,
-                'request'  => $request,
-                'uri'      => (string) $request->getUri(),
                 'status'   => $response->getStatusCode(),
                 'reason'   => $response->getReasonPhrase(),
             ]);

--- a/src/constants.php
+++ b/src/constants.php
@@ -70,15 +70,6 @@ const NOT_FOUND_MIDDLEWARE = __NAMESPACE__ . '\Middleware\NotFoundMiddleware';
 const ROUTE_MIDDLEWARE = __NAMESPACE__ . '\Middleware\RouteMiddleware';
 
 /**
- * Virtual service name that should resolve to a service returning a response
- * based on a `Throwable` argument produced when generating the application
- * request.
- *
- * @var string
- */
-const SERVER_REQUEST_ERROR_RESPONSE_GENERATOR = __NAMESPACE__ . '\ServerRequestErrorResponseGenerator';
-
-/**
  * Legacy/transitional service name for the ServerRequestFactory virtual
  * service introduced in 3.0.0alpha6. Should resolve to the
  * Psr\Http\Message\ServerRequestInterface service.

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -20,6 +20,7 @@ use Zend\Expressive\Handler\NotFoundHandler;
 use Zend\Expressive\Middleware;
 use Zend\Expressive\MiddlewareContainer;
 use Zend\Expressive\MiddlewareFactory;
+use Zend\Expressive\Response\ServerRequestErrorResponseGenerator;
 use Zend\Expressive\Router\RouterInterface;
 use Zend\HttpHandlerRunner\Emitter\EmitterInterface;
 use Zend\HttpHandlerRunner\RequestHandlerRunner;
@@ -33,7 +34,6 @@ use const Zend\Expressive\IMPLICIT_HEAD_MIDDLEWARE;
 use const Zend\Expressive\IMPLICIT_OPTIONS_MIDDLEWARE;
 use const Zend\Expressive\NOT_FOUND_MIDDLEWARE;
 use const Zend\Expressive\ROUTE_MIDDLEWARE;
-use const Zend\Expressive\SERVER_REQUEST_ERROR_RESPONSE_GENERATOR;
 
 class ConfigProviderTest extends TestCase
 {
@@ -73,7 +73,7 @@ class ConfigProviderTest extends TestCase
         $this->assertArrayHasKey(RequestHandlerRunner::class, $factories);
         $this->assertArrayHasKey(ResponseInterface::class, $factories);
         $this->assertArrayHasKey(ServerRequestInterface::class, $factories);
-        $this->assertArrayHasKey(SERVER_REQUEST_ERROR_RESPONSE_GENERATOR, $factories);
+        $this->assertArrayHasKey(ServerRequestErrorResponseGenerator::class, $factories);
         $this->assertArrayHasKey(StreamInterface::class, $factories);
     }
 

--- a/test/Container/RequestHandlerRunnerFactoryTest.php
+++ b/test/Container/RequestHandlerRunnerFactoryTest.php
@@ -19,7 +19,7 @@ use RuntimeException;
 use Throwable;
 use Zend\Expressive\ApplicationPipeline;
 use Zend\Expressive\Container\RequestHandlerRunnerFactory;
-use Zend\Expressive\ServerRequestErrorResponseGenerator;
+use Zend\Expressive\Response\ServerRequestErrorResponseGenerator;
 use Zend\HttpHandlerRunner\Emitter\EmitterInterface;
 use Zend\HttpHandlerRunner\RequestHandlerRunner;
 
@@ -83,10 +83,9 @@ class RequestHandlerRunnerFactoryTest extends TestCase
     public function registerServerRequestErrorResponseGeneratorInContainer($container) : callable
     {
         $response = $this->prophesize(ResponseInterface::class)->reveal();
-        $generator = function (Throwable $e) use ($response) {
-            return $response;
-        };
-        $container->get(ServerRequestErrorResponseGenerator::class)->willReturn($generator);
-        return $generator;
+        $generator = $this->prophesize(ServerRequestErrorResponseGenerator::class);
+        $generator->__invoke(Argument::type(Throwable::class))->willReturn($response);
+        $container->get(ServerRequestErrorResponseGenerator::class)->willReturn($generator->reveal());
+        return $generator->reveal();
     }
 }

--- a/test/Container/RequestHandlerRunnerFactoryTest.php
+++ b/test/Container/RequestHandlerRunnerFactoryTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace ZendTest\Expressive\Container;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;

--- a/test/Container/ServerRequestErrorResponseGeneratorFactoryTest.php
+++ b/test/Container/ServerRequestErrorResponseGeneratorFactoryTest.php
@@ -9,47 +9,91 @@ declare(strict_types=1);
 
 namespace ZendTest\Expressive\Container;
 
-use Exception;
-use PHPUnit\Framework\Assert;
+use Closure;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
-use Throwable;
-use Zend\Diactoros\Response;
-use Zend\Diactoros\ServerRequest;
+use Psr\Http\Message\ResponseInterface;
+use RuntimeException;
 use Zend\Expressive\Container\ServerRequestErrorResponseGeneratorFactory;
-use Zend\Expressive\Middleware\ErrorResponseGenerator;
+use Zend\Expressive\Response\ServerRequestErrorResponseGenerator;
+use Zend\Expressive\Template\TemplateRendererInterface;
 
 class ServerRequestErrorResponseGeneratorFactoryTest extends TestCase
 {
-    public function testFactoryGeneratesCallable()
+    public function testFactoryOnlyRequiresResponseService()
     {
         $container = $this->prophesize(ContainerInterface::class);
+        $container->has('config')->willReturn(false);
+        $container->get('config')->shouldNotBeCalled();
+        $container->has(TemplateRendererInterface::class)->willReturn(false);
+        $container->get(TemplateRendererInterface::class)->shouldNotBeCalled();
+
+        $exception = new RuntimeException();
+        $container->get(ResponseInterface::class)->willThrow($exception);
+
+        $factory = new ServerRequestErrorResponseGeneratorFactory();
+
+        $this->expectException(RuntimeException::class);
+        $factory($container->reveal());
+    }
+
+    public function testFactoryCreatesGeneratorWhenOnlyResponseServiceIsPresent()
+    {
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->has('config')->willReturn(false);
+        $container->get('config')->shouldNotBeCalled();
+        $container->has(TemplateRendererInterface::class)->willReturn(false);
+        $container->get(TemplateRendererInterface::class)->shouldNotBeCalled();
+
+        $responseFactory = function () {
+        };
+        $container->get(ResponseInterface::class)->willReturn($responseFactory);
+
         $factory = new ServerRequestErrorResponseGeneratorFactory();
 
         $generator = $factory($container->reveal());
 
-        $this->assertInternalType('callable', $generator);
-
-        return [$generator, $container];
+        $this->assertAttributeNotSame($responseFactory, 'responseFactory', $generator);
+        $this->assertAttributeInstanceOf(Closure::class, 'responseFactory', $generator);
+        $this->assertAttributeSame(false, 'debug', $generator);
+        $this->assertAttributeEmpty('renderer', $generator);
+        $this->assertAttributeSame(ServerRequestErrorResponseGenerator::TEMPLATE_DEFAULT, 'template', $generator);
     }
 
-    /**
-     * @depends testFactoryGeneratesCallable
-     */
-    public function testGeneratedCallableWrapsErrorResponseGeneratorService(array $deps)
+    public function testFactoryCreatesGeneratorUsingConfiguredServices()
     {
-        $generator = array_shift($deps);
-        $container = array_shift($deps);
+        $config = [
+            'debug' => true,
+            'zend-expressive' => [
+                'error_handler' => [
+                    'template_error' => 'some::template',
+                ],
+            ],
+        ];
+        $renderer = $this->prophesize(TemplateRendererInterface::class)->reveal();
 
-        $exception = new Exception();
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->has('config')->willReturn(true);
+        $container->get('config')->willReturn($config);
+        $container->has(TemplateRendererInterface::class)->willReturn(true);
+        $container->get(TemplateRendererInterface::class)->willReturn($renderer);
 
-        $proxiedGenerator = function (Throwable $e, ServerRequest $request, Response $response) use ($exception) {
-            Assert::assertSame($exception, $e);
-            return $response;
+        $responseFactory = function () {
         };
+        $container->get(ResponseInterface::class)->willReturn($responseFactory);
 
-        $container->get(ErrorResponseGenerator::class)->willReturn($proxiedGenerator);
+        $factory = new ServerRequestErrorResponseGeneratorFactory();
 
-        $this->assertInstanceOf(Response::class, $generator($exception));
+        $generator = $factory($container->reveal());
+
+        $this->assertAttributeNotSame($responseFactory, 'responseFactory', $generator);
+        $this->assertAttributeInstanceOf(Closure::class, 'responseFactory', $generator);
+        $this->assertAttributeSame(true, 'debug', $generator);
+        $this->assertAttributeSame($renderer, 'renderer', $generator);
+        $this->assertAttributeSame(
+            $config['zend-expressive']['error_handler']['template_error'],
+            'template',
+            $generator
+        );
     }
 }

--- a/test/Response/ServerRequestErrorResponseGeneratorTest.php
+++ b/test/Response/ServerRequestErrorResponseGeneratorTest.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Response;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+use Throwable;
+use RuntimeException;
+use Zend\Expressive\Response\ServerRequestErrorResponseGenerator;
+use Zend\Expressive\Template\TemplateRendererInterface;
+use Zend\Stratigility\Utils;
+
+class ServerRequestErrorResponseGeneratorTest extends TestCase
+{
+    /** @var TemplateRendererInterface|ObjectProphecy */
+    private $renderer;
+
+    /** @var ResponseInterface|ObjectProphecy */
+    private $response;
+
+    /** @var callable */
+    private $responseFactory;
+
+    public function setUp()
+    {
+        $this->response = $this->prophesize(ResponseInterface::class);
+        $this->responseFactory = function () {
+            return $this->response->reveal();
+        };
+
+        $this->renderer = $this->prophesize(TemplateRendererInterface::class);
+    }
+
+    public function testPreparesTemplatedResponseWhenRendererPresent()
+    {
+        $stream = $this->prophesize(StreamInterface::class);
+        $stream->write('data from template')->shouldBeCalled();
+
+        $this->response->withStatus(422)->will([$this->response, 'reveal']);
+        $this->response->getBody()->will([$stream, 'reveal']);
+        $this->response->getStatusCode()->willReturn(422);
+        $this->response->getReasonPhrase()->willReturn('Unexpected entity');
+
+        $template = 'some::template';
+        $e = new RuntimeException('This is the exception message', 422);
+        $this->renderer
+            ->render($template, [
+                'response' => $this->response->reveal(),
+                'status'   => 422,
+                'reason'   => 'Unexpected entity',
+                'error'    => $e,
+            ])
+            ->willReturn('data from template');
+
+        $generator = new ServerRequestErrorResponseGenerator(
+            $this->responseFactory,
+            true,
+            $this->renderer->reveal(),
+            $template
+        );
+
+        $this->assertSame($this->response->reveal(), $generator($e));
+    }
+
+    public function testPreparesResponseWithDefaultMessageOnlyWhenNoRendererPresentAndNotInDebugMode()
+    {
+        $stream = $this->prophesize(StreamInterface::class);
+        $stream->write('An unexpected error occurred')->shouldBeCalled();
+
+        $this->response->withStatus(422)->will([$this->response, 'reveal']);
+        $this->response->getBody()->will([$stream, 'reveal']);
+        $this->response->getStatusCode()->shouldNotBeCalled();
+        $this->response->getReasonPhrase()->shouldNotBeCalled();
+
+        $e = new RuntimeException('This is the exception message', 422);
+
+        $generator = new ServerRequestErrorResponseGenerator($this->responseFactory);
+
+        $this->assertSame($this->response->reveal(), $generator($e));
+    }
+
+    public function testPreparesResponseWithDefaultMessageAndStackTraceWhenNoRendererPresentAndInDebugMode()
+    {
+        $stream = $this->prophesize(StreamInterface::class);
+        $stream
+            ->write(Argument::that(function ($message) {
+                if (! preg_match('/^An unexpected error occurred; stack trace:/', $message)) {
+                    echo "Failed first assertion: $message\n";
+                    return false;
+                }
+                if (false === strpos($message, 'Stack Trace:')) {
+                    echo "Failed second assertion: $message\n";
+                    return false;
+                }
+                return $message;
+            }))
+            ->shouldBeCalled();
+
+        $this->response->withStatus(422)->will([$this->response, 'reveal']);
+        $this->response->getBody()->will([$stream, 'reveal']);
+        $this->response->getStatusCode()->shouldNotBeCalled();
+        $this->response->getReasonPhrase()->shouldNotBeCalled();
+
+        $e = new RuntimeException('This is the exception message', 422);
+
+        $generator = new ServerRequestErrorResponseGenerator($this->responseFactory, true);
+
+        $this->assertSame($this->response->reveal(), $generator($e));
+    }
+}


### PR DESCRIPTION
Provide a dedicated service for the server request error response generator

Instead of re-using the existing `ErrorResponseGenerator`, this patch does the following:

- Separates functionality for generating the error response into a trait, `Zend\Expressive\Response\ErrorResponseGeneratorTrait`. The method `prepareTemplatedResponse()` now expects the error, the response, and an array of data to provide to the template.
- Updates `Zend\Expressive\Middleware\ErrorResponseGenerator` to use the new trait.
- Creates a new class, `Zend\Expressive\Response\ServerRequestErrorResponseGenerator`, which expects a response factory, and optionally the debug flag, renderer, and template to render to. It composes the trait, and generates a response on-the-fly to pass to the trait methods.

The `RequestHandlerRunnerFactory` has been updated to use this new service, and the `ServerRequestErrorResponseGeneratorFactory` was updated to generate an instance of the new class.

These changes mean the constant SERVER_REQUEST_ERROR_RESPONSE_GENERATOR is no longer needed, and was thus removed.