### PR TITLE
ensure $path to be string on path() call

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -104,7 +104,7 @@ class Application implements MiddlewareInterface, RequestHandlerInterface
         $middleware = $middleware ?: $middlewareOrPath;
         $path = $middleware === $middlewareOrPath ? '/' : $middlewareOrPath;
 
-        $middleware = is_string($path) && $path !== '/'
+        $middleware = $path !== '/'
             ? path($path, $this->factory->prepare($middleware))
             : $this->factory->prepare($middleware);
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -104,7 +104,7 @@ class Application implements MiddlewareInterface, RequestHandlerInterface
         $middleware = $middleware ?: $middlewareOrPath;
         $path = $middleware === $middlewareOrPath ? '/' : $middlewareOrPath;
 
-        $middleware = $path !== '/'
+        $middleware = is_string($path) && $path !== '/'
             ? path($path, $this->factory->prepare($middleware))
             : $this->factory->prepare($middleware);
 

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -16,6 +16,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use TypeError;
 use Zend\Expressive\Application;
 use Zend\Expressive\MiddlewareFactory;
 use Zend\Expressive\Router\Middleware\PathBasedRoutingMiddleware as RouteMiddleware;
@@ -128,19 +129,18 @@ class ApplicationTest extends TestCase
         $this->assertNull($this->app->pipe('/foo', $middleware));
     }
 
-    public function testPipeNonSlashPathOnNonStringPipe()
+    public function testPipeNonSlashPathOnNonStringPipeProduceTypeError()
     {
         // @codingStandardsIgnoreStart
         $middleware1 = function ($request, $response) {};
         // @codingStandardsIgnoreEnd
         $middleware2 = $this->createMockMiddleware();
 
-        $preparedMiddleware = $this->createMockMiddleware();
-        $this->factory
-            ->prepare($middleware2)
-            ->willReturn($preparedMiddleware);
-
-        $this->assertNull($this->app->pipe($middleware1, $middleware2));
+        try {
+            $this->app->pipe($middleware1, $middleware2);
+        } catch (TypeError $t) {
+            $this->assertInstanceOf(TypeError::class, $t);
+        }
     }
 
     /**

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -128,7 +128,7 @@ class ApplicationTest extends TestCase
         $this->assertNull($this->app->pipe('/foo', $middleware));
     }
 
-    public function testPipeNonSlashPathOnStringPipe()
+    public function testPipeNonSlashPathOnNonStringPipe()
     {
         $middleware1 = function ($request, $response) {};
         $middleware2 = $this->createMockMiddleware();

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -131,16 +131,14 @@ class ApplicationTest extends TestCase
 
     public function testPipeNonSlashPathOnNonStringPipeProduceTypeError()
     {
+        $this->expectException(TypeError::class);
+
         // @codingStandardsIgnoreStart
         $middleware1 = function ($request, $response) {};
         // @codingStandardsIgnoreEnd
         $middleware2 = $this->createMockMiddleware();
 
-        try {
-            $this->app->pipe($middleware1, $middleware2);
-        } catch (TypeError $t) {
-            $this->assertInstanceOf(TypeError::class, $t);
-        }
+        $this->app->pipe($middleware1, $middleware2);
     }
 
     /**

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -133,9 +133,9 @@ class ApplicationTest extends TestCase
     {
         $this->expectException(TypeError::class);
 
-        // @codingStandardsIgnoreStart
-        $middleware1 = function ($request, $response) {};
-        // @codingStandardsIgnoreEnd
+        $middleware1 = function ($request, $response) {
+            return $response;
+        };
         $middleware2 = $this->createMockMiddleware();
 
         $this->app->pipe($middleware1, $middleware2);

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -130,7 +130,9 @@ class ApplicationTest extends TestCase
 
     public function testPipeNonSlashPathOnNonStringPipe()
     {
+        // @codingStandardsIgnoreStart
         $middleware1 = function ($request, $response) {};
+        // @codingStandardsIgnoreEnd
         $middleware2 = $this->createMockMiddleware();
 
         $preparedMiddleware = $this->createMockMiddleware();

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -131,13 +131,12 @@ class ApplicationTest extends TestCase
 
     public function testPipeNonSlashPathOnNonStringPipeProduceTypeError()
     {
-        $this->expectException(TypeError::class);
-
         $middleware1 = function ($request, $response) {
             return $response;
         };
         $middleware2 = $this->createMockMiddleware();
 
+        $this->expectException(TypeError::class);
         $this->app->pipe($middleware1, $middleware2);
     }
 

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -128,6 +128,19 @@ class ApplicationTest extends TestCase
         $this->assertNull($this->app->pipe('/foo', $middleware));
     }
 
+    public function testPipeNonSlashPathOnStringPipe()
+    {
+        $middleware1 = function ($request, $response) {};
+        $middleware2 = $this->createMockMiddleware();
+
+        $preparedMiddleware = $this->createMockMiddleware();
+        $this->factory
+            ->prepare($middleware2)
+            ->willReturn($preparedMiddleware);
+
+        $this->assertNull($this->app->pipe($middleware1, $middleware2));
+    }
+
     /**
      * @dataProvider validMiddleware
      * @param string|array|callable|MiddlewareInterface $middleware


### PR DESCRIPTION
- [x] Is this related to quality assurance?

The `Zend\Stratigility\path()` function require 1st parameter to string, while `$path` can be `array|callable|Psr\Http\Server\MiddlewareInterface|Psr\Http\Server\RequestHandlerInterface|string` with compare to `/` string.