### PR TITLE
Updates to zend-stratigility 3.0.0alpha4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "zendframework/zend-expressive-router": "^3.0.0alpha3",
         "zendframework/zend-expressive-template": "^2.0.0alpha1",
         "zendframework/zend-httphandlerrunner": "^1.0.1",
-        "zendframework/zend-stratigility": "3.0.0alpha3"
+        "zendframework/zend-stratigility": "3.0.0alpha4"
     },
     "require-dev": {
         "filp/whoops": "^1.1.10 || ^2.1.13",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "924f3c60fc27a96ea6427012d2e31d56",
+    "content-hash": "d8bf4a32854c53e641d9f2cb85fbee01",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -531,19 +531,20 @@
         },
         {
             "name": "zendframework/zend-stratigility",
-            "version": "3.0.0alpha3",
+            "version": "3.0.0alpha4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-stratigility.git",
-                "reference": "e346801682bad999320ee89285b62643f27735a9"
+                "reference": "68efddda34fa8b1a9d58b0e7c02c4182800b89f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-stratigility/zipball/e346801682bad999320ee89285b62643f27735a9",
-                "reference": "e346801682bad999320ee89285b62643f27735a9",
+                "url": "https://api.github.com/repos/zendframework/zend-stratigility/zipball/68efddda34fa8b1a9d58b0e7c02c4182800b89f0",
+                "reference": "68efddda34fa8b1a9d58b0e7c02c4182800b89f0",
                 "shasum": ""
             },
             "require": {
+                "fig/http-message-util": "^1.1",
                 "php": "^7.1",
                 "psr/http-message": "^1.0",
                 "psr/http-server-middleware": "^1.0",
@@ -551,7 +552,7 @@
             },
             "require-dev": {
                 "malukenho/docheader": "^0.1.6",
-                "phpunit/phpunit": "^6.5.5",
+                "phpunit/phpunit": "^7.0.1",
                 "zendframework/zend-coding-standard": "~1.0.0",
                 "zendframework/zend-diactoros": "^1.0"
             },
@@ -590,7 +591,7 @@
                 "psr-7",
                 "zf"
             ],
-            "time": "2018-02-05T21:18:43+00:00"
+            "time": "2018-02-22T20:09:31+00:00"
         }
     ],
     "packages-dev": [

--- a/src/Container/ErrorHandlerFactory.php
+++ b/src/Container/ErrorHandlerFactory.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Zend\Expressive\Container;
 
 use Psr\Container\ContainerInterface;
-use Zend\Diactoros\Response;
+use Psr\Http\Message\ResponseInterface;
 use Zend\Expressive\Middleware\ErrorResponseGenerator;
 use Zend\Stratigility\Middleware\ErrorHandler;
 
@@ -22,6 +22,6 @@ class ErrorHandlerFactory
             ? $container->get(ErrorResponseGenerator::class)
             : null;
 
-        return new ErrorHandler(new Response(), $generator);
+        return new ErrorHandler($container->get(ResponseInterface::class), $generator);
     }
 }


### PR DESCRIPTION
The major change is that the stratigility `ErrorHandler` now expects a callable response factory as the first argument, and not a response _instance_. This patch updates the `ErrorHandlerFactory` to use the `ResponseInterface` service to seed the first argument, as that service resolves to a callable factory.

Tests are also updated to demosntrate that the response service is required, and that it cannot return an actual response.