### PR TITLE
Avoid object creation by class name

### DIFF
--- a/src/MiddlewareContainer.php
+++ b/src/MiddlewareContainer.php
@@ -27,22 +27,16 @@ class MiddlewareContainer implements ContainerInterface
     }
 
     /**
-     * Returns true if the service is in the container, or resolves to an
-     * autoloadable class name.
+     * Returns true if the service is in the container.
      * {@inheritDocs}
      */
     public function has($service) : bool
     {
-        if ($this->container->has($service)) {
-            return true;
-        }
-
-        return class_exists($service);
+        return $this->container->has($service);
     }
 
     /**
-     * Returns middleware pulled from container, or directly instantiated if
-     * not managed by the container.
+     * Returns middleware pulled from container.
      * {@inheritDocs}
      * @throws Exception\MissingDependencyException if the service does not
      *     exist, or is not a valid class name.
@@ -53,13 +47,11 @@ class MiddlewareContainer implements ContainerInterface
             throw Exception\MissingDependencyException::forMiddlewareService($service);
         }
 
-        $middleware = $this->container->has($service)
-            ? $this->container->get($service)
-            : new $service();
+        $middleware = $this->container->get($service);
 
-        $middleware = $middleware instanceof RequestHandlerInterface
-            ? new RequestHandlerMiddleware($middleware)
-            : $middleware;
+        if ($middleware instanceof RequestHandlerInterface) {
+            return new RequestHandlerMiddleware($middleware);
+        }
 
         if (! $middleware instanceof MiddlewareInterface) {
             throw Exception\InvalidMiddlewareException::forMiddlewareService($service, $middleware);

--- a/test/MiddlewareContainerTest.php
+++ b/test/MiddlewareContainerTest.php
@@ -55,15 +55,6 @@ class MiddlewareContainerTest extends TestCase
         $this->container->get(__CLASS__);
     }
 
-    public function testGetRaisesExceptionIfClassSpecifiedDoesNotImplementMiddlewareInterface()
-    {
-        $this->originContainer->has(__CLASS__)->willReturn(false);
-        $this->originContainer->get(__CLASS__)->shouldNotBeCalled();
-
-        $this->expectException(Exception\InvalidMiddlewareException::class);
-        $this->container->get(__CLASS__);
-    }
-
     public function testGetReturnsServiceFromOriginContainer()
     {
         $middleware = $this->prophesize(MiddlewareInterface::class)->reveal();

--- a/test/MiddlewareContainerTest.php
+++ b/test/MiddlewareContainerTest.php
@@ -32,12 +32,6 @@ class MiddlewareContainerTest extends TestCase
         $this->assertTrue($this->container->has('foo'));
     }
 
-    public function testHasReturnsTrueIfOriginContainerDoesNotHaveServiceButClassExists()
-    {
-        $this->originContainer->has(__CLASS__)->willReturn(false);
-        $this->assertTrue($this->container->has(__CLASS__));
-    }
-
     public function testHasReturnsFalseIfOriginContainerDoesNotHaveServiceAndClassDoesNotExist()
     {
         $this->originContainer->has('not-a-class')->willReturn(false);
@@ -77,15 +71,6 @@ class MiddlewareContainerTest extends TestCase
         $this->originContainer->get('middleware-service')->willReturn($middleware);
 
         $this->assertSame($middleware, $this->container->get('middleware-service'));
-    }
-
-    public function testGetReturnsInstantiatedClass()
-    {
-        $this->originContainer->has(DispatchMiddleware::class)->willReturn(false);
-        $this->originContainer->get(DispatchMiddleware::class)->shouldNotBeCalled();
-
-        $middleware = $this->container->get(DispatchMiddleware::class);
-        $this->assertInstanceOf(DispatchMiddleware::class, $middleware);
     }
 
     public function testGetWillDecorateARequestHandlerAsMiddleware()


### PR DESCRIPTION
Why?
* it's error-prone,
* hard to debug,
* it add to much responsibility to one class

We should move responsibility of service creation to decorated container and user. I make this PR because I had a lot of real life problems with this magic.