### PR TITLE
Made middlewareName somwhat accessible in LazyLoadingMiddleware

### DIFF
--- a/src/Middleware/LazyLoadingMiddleware.php
+++ b/src/Middleware/LazyLoadingMiddleware.php
@@ -79,4 +79,13 @@ class LazyLoadingMiddleware implements ServerMiddlewareInterface
             return $delegate->process($request);
         });
     }
+
+    /**
+     * Getter for name of underlying Middleware
+     * @return string name of underlying middleware
+     */
+    public function getMiddlewareName()
+    {
+        return $this->middlewareName;
+    }
 }


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:

- [x] Are you creating a new feature?
  - [x] Why is the new feature needed? What purpose does it serve?

    I needed to access middleware for current rote in my StrategyInterface implementation. I have some information provided as annotations on action (it provides some context and is easy to be found). The problem is, middleware is set as LazyLoadingMiddleware in action. If I could have class name, I could access annotations.

  - [ ] How will users use the new feature?

    Anyware user will get `LazyLoadingMiddleware` instance he may get underlying middleware name to get it from container by himself.

  - [ ] Base your feature on the `develop` branch, and submit against that branch.
  - [x] Add only one feature per pull request; split multiple features over multiple pull requests
  - [ ] Add tests for the new feature.

    It is just simple getter so test would act just as cover.

  - [x] Add documentation for the new feature.

    method is documented

  - [ ] Add a `CHANGELOG.md` entry for the new feature.