### PR TITLE
Fixed redirection links in versioned documentation

### DIFF
--- a/docs/book/cookbook/autowiring-routes-and-pipelines.md
+++ b/docs/book/cookbook/autowiring-routes-and-pipelines.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/cookbook/autowiring-routes-and-pipelines/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/cookbook/autowiring-routes-and-pipelines/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/cookbook/autowiring-routes-and-pipelines/';
+    window.location.pathname = '/zend-expressive/v2/cookbook/autowiring-routes-and-pipelines/';
   });
 </script>

--- a/docs/book/cookbook/common-prefix-for-routes.md
+++ b/docs/book/cookbook/common-prefix-for-routes.md
@@ -1,8 +1,8 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/cookbook/common-prefix-for-routes/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/cookbook/common-prefix-for-routes/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
     var uri = new URL(window.location.href);
-    uri.pathname = 'v2/cookbook/common-prefix-for-routes/';
+    uri.pathname = '/zend-expressive/v2/cookbook/common-prefix-for-routes/';
     window.location = uri.href;
   });
 </script>

--- a/docs/book/cookbook/debug-toolbars.md
+++ b/docs/book/cookbook/debug-toolbars.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/cookbook/debug-toolbars/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/cookbook/debug-toolbars/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/cookbook/debug-toolbars/';
+    window.location.pathname = '/zend-expressive/v2/cookbook/debug-toolbars/';
   });
 </script>

--- a/docs/book/cookbook/flash-messengers.md
+++ b/docs/book/cookbook/flash-messengers.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/cookbook/flash-messengers/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/cookbook/flash-messengers/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/cookbook/flash-messengers/';
+    window.location.pathname = '/zend-expressive/v2/cookbook/flash-messengers/';
   });
 </script>

--- a/docs/book/cookbook/passing-data-between-middleware.md
+++ b/docs/book/cookbook/passing-data-between-middleware.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/cookbook/passing-data-between-middleware/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/cookbook/passing-data-between-middleware/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/cookbook/passing-data-between-middleware/';
+    window.location.pathname = '/zend-expressive/v2/cookbook/passing-data-between-middleware/';
   });
 </script>

--- a/docs/book/cookbook/route-specific-pipeline.md
+++ b/docs/book/cookbook/route-specific-pipeline.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/cookbook/route-specific-pipeline/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/cookbook/route-specific-pipeline/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/cookbook/route-specific-pipeline/';
+    window.location.pathname = '/zend-expressive/v2/cookbook/route-specific-pipeline/';
   });
 </script>

--- a/docs/book/cookbook/setting-locale-depending-routing-parameter.md
+++ b/docs/book/cookbook/setting-locale-depending-routing-parameter.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/cookbook/setting-locale-depending-routing-parameter/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/cookbook/setting-locale-depending-routing-parameter/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/cookbook/setting-locale-depending-routing-parameter/';
+    window.location.pathname = '/zend-expressive/v2/cookbook/setting-locale-depending-routing-parameter/';
   });
 </script>

--- a/docs/book/cookbook/setting-locale-without-routing-parameter.md
+++ b/docs/book/cookbook/setting-locale-without-routing-parameter.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/cookbook/setting-locale-without-routing-parameter/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/cookbook/setting-locale-without-routing-parameter/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/cookbook/setting-locale-without-routing-parameter/';
+    window.location.pathname = '/zend-expressive/v2/cookbook/setting-locale-without-routing-parameter/';
   });
 </script>

--- a/docs/book/cookbook/using-a-base-path.md
+++ b/docs/book/cookbook/using-a-base-path.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/cookbook/using-a-base-path/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/cookbook/using-a-base-path/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/cookbook/using-a-base-path/';
+    window.location.pathname = '/zend-expressive/v2/cookbook/using-a-base-path/';
   });
 </script>

--- a/docs/book/cookbook/using-custom-view-helpers.md
+++ b/docs/book/cookbook/using-custom-view-helpers.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/cookbook/using-custom-view-helpers/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/cookbook/using-custom-view-helpers/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/cookbook/using-custom-view-helpers/';
+    window.location.pathname = '/zend-expressive/v2/cookbook/using-custom-view-helpers/';
   });
 </script>

--- a/docs/book/cookbook/using-routed-middleware-class-as-controller.md
+++ b/docs/book/cookbook/using-routed-middleware-class-as-controller.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/cookbook/using-routed-middleware-class-as-controller/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/cookbook/using-routed-middleware-class-as-controller/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/cookbook/using-routed-middleware-class-as-controller/';
+    window.location.pathname = '/zend-expressive/v2/cookbook/using-routed-middleware-class-as-controller/';
   });
 </script>

--- a/docs/book/cookbook/using-zend-form-view-helpers.md
+++ b/docs/book/cookbook/using-zend-form-view-helpers.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/cookbook/using-zend-form-view-helpers/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/cookbook/using-zend-form-view-helpers/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/cookbook/using-zend-form-view-helpers/';
+    window.location.pathname = '/zend-expressive/v2/cookbook/using-zend-form-view-helpers/';
   });
 </script>

--- a/docs/book/features/application.md
+++ b/docs/book/features/application.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/features/application/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/features/application/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/features/application/';
+    window.location.pathname = '/zend-expressive/v2/features/application/';
   });
 </script>

--- a/docs/book/features/container/aura-di.md
+++ b/docs/book/features/container/aura-di.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/features/container/aura-di/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/features/container/aura-di/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/features/container/aura-di/';
+    window.location.pathname = '/zend-expressive/v2/features/container/aura-di/';
   });
 </script>

--- a/docs/book/features/container/delegator-factories.md
+++ b/docs/book/features/container/delegator-factories.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/features/container/delegator-factories/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/features/container/delegator-factories/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/features/container/delegator-factories/';
+    window.location.pathname = '/zend-expressive/v2/features/container/delegator-factories/';
   });
 </script>

--- a/docs/book/features/container/factories.md
+++ b/docs/book/features/container/factories.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/features/container/factories/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/features/container/factories/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/features/container/factories/';
+    window.location.pathname = '/zend-expressive/v2/features/container/factories/';
   });
 </script>

--- a/docs/book/features/container/intro.md
+++ b/docs/book/features/container/intro.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/features/container/intro/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/features/container/intro/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/features/container/intro/';
+    window.location.pathname = '/zend-expressive/v2/features/container/intro/';
   });
 </script>

--- a/docs/book/features/container/pimple.md
+++ b/docs/book/features/container/pimple.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/features/container/pimple/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/features/container/pimple/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/features/container/pimple/';
+    window.location.pathname = '/zend-expressive/v2/features/container/pimple/';
   });
 </script>

--- a/docs/book/features/container/zend-servicemanager.md
+++ b/docs/book/features/container/zend-servicemanager.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/features/container/zend-servicemanager/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/features/container/zend-servicemanager/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/features/container/zend-servicemanager/';
+    window.location.pathname = '/zend-expressive/v2/features/container/zend-servicemanager/';
   });
 </script>

--- a/docs/book/features/emitters.md
+++ b/docs/book/features/emitters.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/features/emitters/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/features/emitters/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/features/emitters/';
+    window.location.pathname = '/zend-expressive/v2/features/emitters/';
   });
 </script>

--- a/docs/book/features/error-handling.md
+++ b/docs/book/features/error-handling.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/features/error-handling/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/features/error-handling/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/features/error-handling/';
+    window.location.pathname = '/zend-expressive/v2/features/error-handling/';
   });
 </script>

--- a/docs/book/features/helpers/body-parse.md
+++ b/docs/book/features/helpers/body-parse.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/features/helpers/body-parse/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/features/helpers/body-parse/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/features/helpers/body-parse/';
+    window.location.pathname = '/zend-expressive/v2/features/helpers/body-parse/';
   });
 </script>

--- a/docs/book/features/helpers/content-length.md
+++ b/docs/book/features/helpers/content-length.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/features/helpers/content-length/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/features/helpers/content-length/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/features/helpers/content-length/';
+    window.location.pathname = '/zend-expressive/v2/features/helpers/content-length/';
   });
 </script>

--- a/docs/book/features/helpers/intro.md
+++ b/docs/book/features/helpers/intro.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/features/helpers/intro/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/features/helpers/intro/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/features/helpers/intro/';
+    window.location.pathname = '/zend-expressive/v2/features/helpers/intro/';
   });
 </script>

--- a/docs/book/features/helpers/server-url-helper.md
+++ b/docs/book/features/helpers/server-url-helper.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/features/helpers/server-url-helper/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/features/helpers/server-url-helper/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/features/helpers/server-url-helper/';
+    window.location.pathname = '/zend-expressive/v2/features/helpers/server-url-helper/';
   });
 </script>

--- a/docs/book/features/helpers/url-helper.md
+++ b/docs/book/features/helpers/url-helper.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/features/helpers/url-helper/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/features/helpers/url-helper/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/features/helpers/url-helper/';
+    window.location.pathname = '/zend-expressive/v2/features/helpers/url-helper/';
   });
 </script>

--- a/docs/book/features/middleware-types.md
+++ b/docs/book/features/middleware-types.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/features/middleware-types/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/features/middleware-types/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/features/middleware-types/';
+    window.location.pathname = '/zend-expressive/v2/features/middleware-types/';
   });
 </script>

--- a/docs/book/features/middleware/implicit-methods-middleware.md
+++ b/docs/book/features/middleware/implicit-methods-middleware.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/features/middleware/implicit-methods-middleware/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/features/middleware/implicit-methods-middleware/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/features/middleware/implicit-methods-middleware/';
+    window.location.pathname = '/zend-expressive/v2/features/middleware/implicit-methods-middleware/';
   });
 </script>

--- a/docs/book/features/modular-applications.md
+++ b/docs/book/features/modular-applications.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/features/modular-applications/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/features/modular-applications/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/features/modular-applications/';
+    window.location.pathname = '/zend-expressive/v2/features/modular-applications/';
   });
 </script>

--- a/docs/book/features/router/aura.md
+++ b/docs/book/features/router/aura.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/features/router/aura/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/features/router/aura/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/features/router/aura/';
+    window.location.pathname = '/zend-expressive/v2/features/router/aura/';
   });
 </script>

--- a/docs/book/features/router/fast-route.md
+++ b/docs/book/features/router/fast-route.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/features/router/fast-route/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/features/router/fast-route/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/features/router/fast-route/';
+    window.location.pathname = '/zend-expressive/v2/features/router/fast-route/';
   });
 </script>

--- a/docs/book/features/router/interface.md
+++ b/docs/book/features/router/interface.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/features/router/interface/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/features/router/interface/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/features/router/interface/';
+    window.location.pathname = '/zend-expressive/v2/features/router/interface/';
   });
 </script>

--- a/docs/book/features/router/intro.md
+++ b/docs/book/features/router/intro.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/features/router/intro/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/features/router/intro/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/features/router/intro/';
+    window.location.pathname = '/zend-expressive/v2/features/router/intro/';
   });
 </script>

--- a/docs/book/features/router/piping.md
+++ b/docs/book/features/router/piping.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/features/router/piping/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/features/router/piping/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/features/router/piping/';
+    window.location.pathname = '/zend-expressive/v2/features/router/piping/';
   });
 </script>

--- a/docs/book/features/router/uri-generation.md
+++ b/docs/book/features/router/uri-generation.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/features/router/uri-generation/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/features/router/uri-generation/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/features/router/uri-generation/';
+    window.location.pathname = '/zend-expressive/v2/features/router/uri-generation/';
   });
 </script>

--- a/docs/book/features/router/zf2.md
+++ b/docs/book/features/router/zf2.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/features/router/zf2/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/features/router/zf2/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/features/router/zf2/';
+    window.location.pathname = '/zend-expressive/v2/features/router/zf2/';
   });
 </script>

--- a/docs/book/features/template/interface.md
+++ b/docs/book/features/template/interface.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/features/template/interface/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/features/template/interface/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/features/template/interface/';
+    window.location.pathname = '/zend-expressive/v2/features/template/interface/';
   });
 </script>

--- a/docs/book/features/template/intro.md
+++ b/docs/book/features/template/intro.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/features/template/intro/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/features/template/intro/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/features/template/intro/';
+    window.location.pathname = '/zend-expressive/v2/features/template/intro/';
   });
 </script>

--- a/docs/book/features/template/middleware.md
+++ b/docs/book/features/template/middleware.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/features/template/middleware/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/features/template/middleware/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/features/template/middleware/';
+    window.location.pathname = '/zend-expressive/v2/features/template/middleware/';
   });
 </script>

--- a/docs/book/features/template/plates.md
+++ b/docs/book/features/template/plates.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/features/template/plates/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/features/template/plates/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/features/template/plates/';
+    window.location.pathname = '/zend-expressive/v2/features/template/plates/';
   });
 </script>

--- a/docs/book/features/template/twig.md
+++ b/docs/book/features/template/twig.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/features/template/twig/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/features/template/twig/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/features/template/twig/';
+    window.location.pathname = '/zend-expressive/v2/features/template/twig/';
   });
 </script>

--- a/docs/book/features/template/zend-view.md
+++ b/docs/book/features/template/zend-view.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/features/template/zend-view/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/features/template/zend-view/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/features/template/zend-view/';
+    window.location.pathname = '/zend-expressive/v2/features/template/zend-view/';
   });
 </script>

--- a/docs/book/getting-started/features.md
+++ b/docs/book/getting-started/features.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/getting-started/features/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/getting-started/features/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/getting-started/features/';
+    window.location.pathname = '/zend-expressive/v2/getting-started/features/';
   });
 </script>

--- a/docs/book/getting-started/skeleton.md
+++ b/docs/book/getting-started/skeleton.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/getting-started/skeleton/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/getting-started/skeleton/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/getting-started/skeleton/';
+    window.location.pathname = '/zend-expressive/v2/getting-started/skeleton/';
   });
 </script>

--- a/docs/book/getting-started/standalone.md
+++ b/docs/book/getting-started/standalone.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/getting-started/standalone/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/getting-started/standalone/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/getting-started/standalone/';
+    window.location.pathname = '/zend-expressive/v2/getting-started/standalone/';
   });
 </script>

--- a/docs/book/index.md
+++ b/docs/book/index.md
@@ -1,8 +1,0 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/"></noscript>
-<script>
-  document.addEventListener("DOMContentLoaded", function (event) {
-    var uri = new URL(window.location.href);
-    uri.pathname = 'v2/';
-    window.location = uri.href;
-  });
-</script>

--- a/docs/book/reference/cli-tooling.md
+++ b/docs/book/reference/cli-tooling.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/reference/cli-tooling/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/reference/cli-tooling/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/reference/cli-tooling/';
+    window.location.pathname = '/zend-expressive/v2/reference/cli-tooling/';
   });
 </script>

--- a/docs/book/reference/expressive-projects.md
+++ b/docs/book/reference/expressive-projects.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/reference/expressive-projects/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/reference/expressive-projects/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/reference/expressive-projects/';
+    window.location.pathname = '/zend-expressive/v2/reference/expressive-projects/';
   });
 </script>

--- a/docs/book/reference/migration/to-v2.md
+++ b/docs/book/reference/migration/to-v2.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/reference/migration/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/reference/migration/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/reference/migration/';
+    window.location.pathname = '/zend-expressive/v2/reference/migration/';
   });
 </script>

--- a/docs/book/reference/usage-examples.md
+++ b/docs/book/reference/usage-examples.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/reference/usage-examples/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/reference/usage-examples/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/reference/usage-examples/';
+    window.location.pathname = '/zend-expressive/v2/reference/usage-examples/';
   });
 </script>

--- a/docs/book/why-expressive.md
+++ b/docs/book/why-expressive.md
@@ -1,6 +1,6 @@
-<noscript><meta http-equiv="refresh" content="0; url=v2/why-expressive/"></noscript>
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v2/why-expressive/"></noscript>
 <script>
   document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = 'v2/why-expressive/';
+    window.location.pathname = '/zend-expressive/v2/why-expressive/';
   });
 </script>


### PR DESCRIPTION
For example:
https://docs.zendframework.com/zend-expressive/features/router/piping/
redirects to:
https://docs.zendframework.com/v2/features/router/piping/
instead of:
https://docs.zendframework.com/zend-expressive/v2/features/router/piping/

Also removed index.md as we have there index.html.

**There is another issue:**
- https://docs.zendframework.com/zend-expressive/v1/ - works, loads index.md from `v1/`
- https://docs.zendframework.com/zend-expressive/v2/ - shows 404, why? There is index.md in `v2/`.

Maybe this is not an issue, because we don't have this link anywhere, but I think we should see there something, especially the file is there.

/cc @weierophinney @froschdesign 