### PR TITLE
Fix deprecation notice with zend-expressive-router 2.4 for config driven apps

### DIFF
--- a/src/ApplicationConfigInjectionTrait.php
+++ b/src/ApplicationConfigInjectionTrait.php
@@ -163,7 +163,14 @@ trait ApplicationConfigInjectionTrait
             }
 
             $name  = isset($spec['name']) ? $spec['name'] : null;
-            $route = $this->route($spec['path'], $spec['middleware'], $methods, $name);
+            $middleware = $this->prepareMiddleware(
+                $spec['middleware'],
+                $this->router,
+                $this->responsePrototype,
+                $this->container
+            );
+
+            $route = $this->route($spec['path'], $middleware, $methods, $name);
 
             if (isset($spec['options'])) {
                 $options = $spec['options'];

--- a/src/ApplicationConfigInjectionTrait.php
+++ b/src/ApplicationConfigInjectionTrait.php
@@ -8,7 +8,6 @@
 namespace Zend\Expressive;
 
 use SplPriorityQueue;
-use Zend\Expressive\Router\Route;
 
 trait ApplicationConfigInjectionTrait
 {
@@ -152,7 +151,7 @@ trait ApplicationConfigInjectionTrait
                 continue;
             }
 
-            $methods = Route::HTTP_METHOD_ANY;
+            $methods = null;
             if (isset($spec['allowed_methods'])) {
                 $methods = $spec['allowed_methods'];
                 if (! is_array($methods)) {
@@ -164,7 +163,7 @@ trait ApplicationConfigInjectionTrait
             }
 
             $name  = isset($spec['name']) ? $spec['name'] : null;
-            $route = new Route($spec['path'], $spec['middleware'], $methods, $name);
+            $route = $this->route($spec['path'], $spec['middleware'], $methods, $name);
 
             if (isset($spec['options'])) {
                 $options = $spec['options'];
@@ -177,8 +176,6 @@ trait ApplicationConfigInjectionTrait
 
                 $route->setOptions($options);
             }
-
-            $this->route($route);
         }
     }
 

--- a/test/Application/ConfigInjectionTest.php
+++ b/test/Application/ConfigInjectionTest.php
@@ -7,6 +7,7 @@
 
 namespace ZendTest\Expressive\Application;
 
+use Interop\Http\ServerMiddleware\MiddlewareInterface;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
@@ -58,7 +59,7 @@ class ConfigInjectionTest extends TestCase
                     return false;
                 }
 
-                if ($route->getMiddleware() !== $spec['middleware']) {
+                if (! $route->getMiddleware()) {
                     return false;
                 }
 
@@ -99,7 +100,7 @@ class ConfigInjectionTest extends TestCase
     public function callableMiddlewares()
     {
         return [
-            ['HelloWorld'],
+            [InvokableMiddleware::class],
             [
                 function () {
                 },
@@ -115,6 +116,7 @@ class ConfigInjectionTest extends TestCase
      */
     public function testInjectRoutesFromConfigSetsUpRoutesFromConfig($middleware)
     {
+        $pingMiddleware = $this->prophesize(MiddlewareInterface::class)->reveal();
         $config = [
             'routes' => [
                 [
@@ -124,7 +126,7 @@ class ConfigInjectionTest extends TestCase
                 ],
                 [
                     'path' => '/ping',
-                    'middleware' => 'Ping',
+                    'middleware' => $pingMiddleware,
                     'allowed_methods' => ['GET'],
                 ],
             ],

--- a/test/Container/ApplicationFactoryTest.php
+++ b/test/Container/ApplicationFactoryTest.php
@@ -9,6 +9,7 @@ namespace ZendTest\Expressive\Container;
 
 use ArrayObject;
 use Interop\Http\ServerMiddleware\DelegateInterface;
+use Interop\Http\ServerMiddleware\MiddlewareInterface;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Prophecy\ObjectProphecy;
@@ -80,7 +81,7 @@ class ApplicationFactoryTest extends TestCase
                     return false;
                 }
 
-                if ($route->getMiddleware() !== $spec['middleware']) {
+                if (! $route->getMiddleware()) {
                     return false;
                 }
 
@@ -123,8 +124,8 @@ class ApplicationFactoryTest extends TestCase
 
     public function callableMiddlewares()
     {
-        $middleware = [
-            'service-name' => 'HelloWorld',
+        $middlewareTypes = [
+            'service-name' => InvokableMiddleware::class,
             'closure' => function () {
             },
             'callable' => [InvokableMiddleware::class, 'staticallyCallableMiddleware'],
@@ -136,7 +137,7 @@ class ApplicationFactoryTest extends TestCase
         ];
 
         foreach ($configTypes as $configType => $config) {
-            foreach ($middleware as $middlewareType => $middleware) {
+            foreach ($middlewareTypes as $middlewareType => $middleware) {
                 $name = sprintf('%s-%s', $configType, $middlewareType);
                 yield $name => [$middleware, $config];
             }
@@ -151,6 +152,7 @@ class ApplicationFactoryTest extends TestCase
      */
     public function testFactorySetsUpRoutesFromConfig($middleware, $configType)
     {
+        $pingMiddleware = $this->prophesize(MiddlewareInterface::class)->reveal();
         $config = [
             'routes' => [
                 [
@@ -160,7 +162,7 @@ class ApplicationFactoryTest extends TestCase
                 ],
                 [
                     'path' => '/ping',
-                    'middleware' => 'Ping',
+                    'middleware' => $pingMiddleware,
                     'allowed_methods' => ['GET'],
                 ],
             ],
@@ -238,7 +240,7 @@ class ApplicationFactoryTest extends TestCase
             'routes' => [
                 [
                     'path' => '/',
-                    'middleware' => 'HelloWorld',
+                    'middleware' => $this->prophesize(MiddlewareInterface::class)->reveal(),
                 ],
             ],
         ];
@@ -275,7 +277,7 @@ class ApplicationFactoryTest extends TestCase
             'routes' => [
                 [
                     'path' => '/',
-                    'middleware' => 'HelloWorld',
+                    'middleware' => $this->prophesize(MiddlewareInterface::class)->reveal(),
                     'name' => 'home',
                     'allowed_methods' => ['GET'],
                     'options' => $expected,
@@ -333,7 +335,7 @@ class ApplicationFactoryTest extends TestCase
             'routes' => [
                 [
                     'path' => '/',
-                    'middleware' => 'HelloWorld',
+                    'middleware' => $this->prophesize(MiddlewareInterface::class)->reveal(),
                     'options' => 'invalid',
                 ],
             ],


### PR DESCRIPTION
See: https://discourse.zendframework.com/t/strange-behaviour-of-implicitoptionsmiddleware-with-multiple-route-on-same-path/496

There is more tests failing now, so it needs some improvements...