### PR TITLE
Have `Application` compose a `RouteCollector` instead of `PathBasedRoutingMiddleware`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ All notable changes to this project will be documented in this file, in reverse 
     `Zend\HttpHandlerRunner\RequestHandlerRunner` instance, using the services
     `Zend\Expressive\Application`, `Zend\HttpHandlerRunner\Emitter\EmitterInterface`,
     `Zend\Expressive\ServerRequestFactory`, and `Zend\Expressive\ServerRequestErrorResponseGenerator`.
-  - `RouteMiddlewareFactory`: creates and returns a `Zend\Expressive\Router\PathBasedRoutingMiddleware` instance.
   - `ServerRequestFactoryFactory`: creates and returns a `callable` factory for
     generating a PSR-7 `ServerRequestInterface` instance; this returned factory is a
     dependency for the `Zend\HttpHandlerRunner\RequestHandlerRunner` service.
@@ -146,7 +145,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
   - `Zend\Expressive\MiddlewareFactory`
   - `Zend\Stratigility\MiddlewarePipe`; this is the pipeline representing the application.
-  - `Zend\Expressive\Router\PathBasedRoutingMiddleware`
+  - `Zend\Expressive\Router\RouteCollector`
   - `Zend\HttpHandlerRunner\RequestHandlerRunner`
 
   It removes all "getter" methods (as detailed in the "Removed" section of this
@@ -169,8 +168,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
   - `route(string $path, $middleware, array $methods = null, string $name) : Route`
     passes its `$middleware` argument to the `MiddlewareFactory::prepare()`
-    method, and then all arguments to the composed `PathBasedRoutingMiddleware`
-    instance's `route()` method.
+    method, and then all arguments to the composed `RouteCollector` instance's
+    `route()` method.
 
     As a result of switching to use the `MiddlewareFactory` to prepare
     middleware, you may now route to `RequestHandlerInterface` instances as
@@ -179,8 +178,7 @@ All notable changes to this project will be documented in this file, in reverse 
   - Each of `get`, `post`, `patch`, `put`, `delete`, and `any` now proxy to
     `route()` after marshaling the correct `$methods`.
 
-  - `getRoutes() : Route[]` proxies to the composed `PathBasedRoutingMiddleware`
-    instance.
+  - `getRoutes() : Route[]` proxies to the composed `RouteCollector` instance.
 
   - `handle(ServerRequestInterface $request) : ResponseInterface` proxies to the
     composed `MiddlewarePipe` instance's `handle()` method.
@@ -200,7 +198,7 @@ All notable changes to this project will be documented in this file, in reverse 
   - `Zend\Stratigility\ApplicationPipeline`, which should resolve to a
     `MiddlewarePipe` instance; use the
     `Zend\Expressive\Container\ApplicationPipelineFactory`.
-  - `Zend\Expressive\Router\PathBasedRoutingMiddleware`
+  - `Zend\Expressive\Router\RouteCollector`
   - `Zend\HttpHandlerRunner\RequestHandlerRunner`
 
 - [#581](https://github.com/zendframework/zend-expressive/pull/581)
@@ -274,9 +272,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 - [#543](https://github.com/zendframework/zend-expressive/pull/543) removes the
   class `Zend\Expressive\Middleware\RouteMiddleware`. Use the
-  `PathBasedRoutingMiddleware` or `RouteMiddleware` from zend-expressive-router
-  instead; the factory `Zend\Expressive\Container\RouteMiddlewareFactory` will
-  return a `PathBasedRoutingMiddleware` instance for you.
+  `RouteMiddleware` from zend-expressive-router instead.
 
 - [#543](https://github.com/zendframework/zend-expressive/pull/543) removes the
   class `Zend\Expressive\Middleware\DispatchMiddleware`. Use the
@@ -291,7 +287,7 @@ All notable changes to this project will be documented in this file, in reverse 
 - [#543](https://github.com/zendframework/zend-expressive/pull/543) removes the
   following methods from `Zend\Expressive\Application`:
 
-  - `pipeRoutingMiddleware()`: use `pipe(\Zend\Expressive\Router\PathBasedRoutingMiddleware::class)` instead.
+  - `pipeRoutingMiddleware()`: use `pipe(\Zend\Expressive\Router\RouteMiddleware::class)` instead.
   - `pipeDispatchMiddleware()`: use `pipe(\Zend\Expressive\Router\DispatchMiddleware::class)` instead.
   - `getContainer()`
   - `getDefaultDelegate()`: ensure you pipe middleware or a request handler

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "psr/container": "^1.0",
         "psr/http-message": "^1.0.1",
         "psr/http-server-middleware": "^1.0",
-        "zendframework/zend-expressive-router": "^3.0.0rc4",
+        "zendframework/zend-expressive-router": "^3.0.0rc5",
         "zendframework/zend-expressive-template": "^2.0.0alpha1",
         "zendframework/zend-httphandlerrunner": "^1.0.1",
         "zendframework/zend-stratigility": "^3.0.0rc1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "7de819d945c13958f83031422d14cc8c",
+    "content-hash": "ade6b84ccd703989d81a55c1afcef017",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -359,16 +359,16 @@
         },
         {
             "name": "zendframework/zend-expressive-router",
-            "version": "3.0.0rc4",
+            "version": "3.0.0rc5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-expressive-router.git",
-                "reference": "3b21fb4e1b568bfa8b0ae699b6f0bdd5d5644863"
+                "reference": "7c63fa67399ea5a1d9612d1ba156583819ac9ea1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/3b21fb4e1b568bfa8b0ae699b6f0bdd5d5644863",
-                "reference": "3b21fb4e1b568bfa8b0ae699b6f0bdd5d5644863",
+                "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/7c63fa67399ea5a1d9612d1ba156583819ac9ea1",
+                "reference": "7c63fa67399ea5a1d9612d1ba156583819ac9ea1",
                 "shasum": ""
             },
             "require": {
@@ -380,9 +380,9 @@
             },
             "require-dev": {
                 "malukenho/docheader": "^0.1.6",
-                "phpunit/phpunit": "^6.5.5",
+                "phpunit/phpunit": "^7.0.2",
                 "zendframework/zend-coding-standard": "~1.0.0",
-                "zendframework/zend-diactoros": "^1.7",
+                "zendframework/zend-diactoros": "^1.7.1",
                 "zendframework/zend-stratigility": "^3.0.0rc1"
             },
             "suggest": {
@@ -393,9 +393,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3.x-dev",
-                    "dev-develop": "2.4.x-dev",
-                    "dev-release-3.0.0": "3.0.x-dev"
+                    "dev-master": "2.4.x-dev",
+                    "dev-develop": "3.0.x-dev"
                 },
                 "zf": {
                     "config-provider": "Zend\\Expressive\\Router\\ConfigProvider"
@@ -421,7 +420,7 @@
                 "zend-expressive",
                 "zf"
             ],
-            "time": "2018-03-07T16:56:58+00:00"
+            "time": "2018-03-14T15:27:08+00:00"
         },
         {
             "name": "zendframework/zend-expressive-template",

--- a/src/Application.php
+++ b/src/Application.php
@@ -13,7 +13,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Zend\Expressive\Router\Middleware\PathBasedRoutingMiddleware;
+use Zend\Expressive\Router\RouteCollector;
 use Zend\HttpHandlerRunner\RequestHandlerRunner;
 use Zend\Stratigility\MiddlewarePipeInterface;
 
@@ -32,7 +32,7 @@ class Application implements MiddlewareInterface, RequestHandlerInterface
     private $pipeline;
 
     /**
-     * @var PathBasedRoutingMiddleware
+     * @var RouteCollector
      */
     private $routes;
 
@@ -44,7 +44,7 @@ class Application implements MiddlewareInterface, RequestHandlerInterface
     public function __construct(
         MiddlewareFactory $factory,
         MiddlewarePipeInterface $pipeline,
-        PathBasedRoutingMiddleware $routes,
+        RouteCollector $routes,
         RequestHandlerRunner $runner
     ) {
         $this->factory = $factory;

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -40,7 +40,7 @@ class ConfigProvider
                 IMPLICIT_HEAD_MIDDLEWARE    => Router\Middleware\ImplicitHeadMiddleware::class,
                 IMPLICIT_OPTIONS_MIDDLEWARE => Router\Middleware\ImplicitOptionsMiddleware::class,
                 NOT_FOUND_MIDDLEWARE        => Handler\NotFoundHandler::class,
-                ROUTE_MIDDLEWARE            => Router\Middleware\PathBasedRoutingMiddleware::class,
+                ROUTE_MIDDLEWARE            => Router\Middleware\RouteMiddleware::class,
             ],
             'factories' => [
                 Application::class                       => Container\ApplicationFactory::class,

--- a/src/Container/ApplicationFactory.php
+++ b/src/Container/ApplicationFactory.php
@@ -13,7 +13,7 @@ use Psr\Container\ContainerInterface;
 use Zend\Expressive\Application;
 use Zend\Expressive\ApplicationPipeline;
 use Zend\Expressive\MiddlewareFactory;
-use Zend\Expressive\Router\Middleware\PathBasedRoutingMiddleware;
+use Zend\Expressive\Router\RouteCollector;
 use Zend\HttpHandlerRunner\RequestHandlerRunner;
 
 /**
@@ -25,7 +25,7 @@ use Zend\HttpHandlerRunner\RequestHandlerRunner;
  * - Zend\Expressive\MiddlewareFactory.
  * - Zend\Expressive\ApplicationPipeline, which should resolve to a
  *   Zend\Stratigility\MiddlewarePipeInterface instance.
- * - Zend\Expressive\Router\Middleware\PathBasedRoutingMiddleware.
+ * - Zend\Expressive\Router\RouteCollector.
  * - Zend\HttpHandler\RequestHandlerRunner.
  */
 class ApplicationFactory
@@ -35,7 +35,7 @@ class ApplicationFactory
         return new Application(
             $container->get(MiddlewareFactory::class),
             $container->get(ApplicationPipeline::class),
-            $container->get(PathBasedRoutingMiddleware::class),
+            $container->get(RouteCollector::class),
             $container->get(RequestHandlerRunner::class)
         );
     }

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -19,8 +19,8 @@ use Psr\Http\Server\RequestHandlerInterface;
 use TypeError;
 use Zend\Expressive\Application;
 use Zend\Expressive\MiddlewareFactory;
-use Zend\Expressive\Router\Middleware\PathBasedRoutingMiddleware as RouteMiddleware;
 use Zend\Expressive\Router\Route;
+use Zend\Expressive\Router\RouteCollector;
 use Zend\HttpHandlerRunner\RequestHandlerRunner;
 use Zend\Stratigility\Middleware\PathMiddlewareDecorator;
 use Zend\Stratigility\MiddlewarePipe;
@@ -32,7 +32,7 @@ class ApplicationTest extends TestCase
     {
         $this->factory = $this->prophesize(MiddlewareFactory::class);
         $this->pipeline = $this->prophesize(MiddlewarePipeInterface::class);
-        $this->routes = $this->prophesize(RouteMiddleware::class);
+        $this->routes = $this->prophesize(RouteCollector::class);
         $this->runner = $this->prophesize(RequestHandlerRunner::class);
 
         $this->app = new Application(
@@ -333,7 +333,7 @@ class ApplicationTest extends TestCase
         $this->assertSame($route, $this->app->any('/foo', $middleware, 'foo'));
     }
 
-    public function testGetRoutesProxiesToRouteMiddleware()
+    public function testGetRoutesProxiesToRouteCollector()
     {
         $route = $this->prophesize(Route::class)->reveal();
         $this->routes->getRoutes()->willReturn([$route]);

--- a/test/Container/ApplicationFactoryTest.php
+++ b/test/Container/ApplicationFactoryTest.php
@@ -15,7 +15,7 @@ use Zend\Expressive\Application;
 use Zend\Expressive\ApplicationPipeline;
 use Zend\Expressive\Container\ApplicationFactory;
 use Zend\Expressive\MiddlewareFactory;
-use Zend\Expressive\Router\Middleware\PathBasedRoutingMiddleware;
+use Zend\Expressive\Router\RouteCollector;
 use Zend\HttpHandlerRunner\RequestHandlerRunner;
 use Zend\Stratigility\MiddlewarePipeInterface;
 
@@ -25,13 +25,13 @@ class ApplicationFactoryTest extends TestCase
     {
         $middlewareFactory = $this->prophesize(MiddlewareFactory::class)->reveal();
         $pipeline = $this->prophesize(MiddlewarePipeInterface::class)->reveal();
-        $routeMiddleware = $this->prophesize(PathBasedRoutingMiddleware::class)->reveal();
+        $routeCollector = $this->prophesize(RouteCollector::class)->reveal();
         $runner = $this->prophesize(RequestHandlerRunner::class)->reveal();
 
         $container = $this->prophesize(ContainerInterface::class);
         $container->get(MiddlewareFactory::class)->willReturn($middlewareFactory);
         $container->get(ApplicationPipeline::class)->willReturn($pipeline);
-        $container->get(PathBasedRoutingMiddleware::class)->willReturn($routeMiddleware);
+        $container->get(RouteCollector::class)->willReturn($routeCollector);
         $container->get(RequestHandlerRunner::class)->willReturn($runner);
 
         $factory = new ApplicationFactory();
@@ -41,7 +41,7 @@ class ApplicationFactoryTest extends TestCase
         $this->assertInstanceOf(Application::class, $application);
         $this->assertAttributeSame($middlewareFactory, 'factory', $application);
         $this->assertAttributeSame($pipeline, 'pipeline', $application);
-        $this->assertAttributeSame($routeMiddleware, 'routes', $application);
+        $this->assertAttributeSame($routeCollector, 'routes', $application);
         $this->assertAttributeSame($runner, 'runner', $application);
     }
 }

--- a/test/Router/IntegrationTest.php
+++ b/test/Router/IntegrationTest.php
@@ -28,7 +28,8 @@ use Zend\Expressive\Router\Middleware\DispatchMiddleware;
 use Zend\Expressive\Router\Middleware\ImplicitHeadMiddleware;
 use Zend\Expressive\Router\Middleware\ImplicitOptionsMiddleware;
 use Zend\Expressive\Router\Middleware\MethodNotAllowedMiddleware;
-use Zend\Expressive\Router\Middleware\PathBasedRoutingMiddleware as RouteMiddleware;
+use Zend\Expressive\Router\Middleware\RouteMiddleware;
+use Zend\Expressive\Router\RouteCollector;
 use Zend\Expressive\Router\RouterInterface;
 use Zend\Expressive\Router\ZendRouter;
 use Zend\HttpHandlerRunner\RequestHandlerRunner;
@@ -71,12 +72,12 @@ class IntegrationTest extends TestCase
         $container = new MiddlewareContainer($this->container->reveal());
         $factory = new MiddlewareFactory($container);
         $pipeline = new MiddlewarePipe();
-        $routeMiddleware = new RouteMiddleware($router);
+        $collector = new RouteCollector($router);
         $runner = $this->prophesize(RequestHandlerRunner::class)->reveal();
         return new Application(
             $factory,
             $pipeline,
-            $routeMiddleware,
+            $collector,
             $runner
         );
     }


### PR DESCRIPTION
This is a change proposed while updating the documentation for version 3.  Having two routing middleware is confusing, particularly since the `PathBasedRoutingMiddleware` simply provides methods for modifying the state of the the composed router.

zend-expressive-router 3.0.0rc5 updates to rename `PathBasedRoutingMiddleware` to `Zend\Expressive\Router\RouteCollector`, and to no longer extend `RouteMiddleware`. This allows it to do its one job: create and return `Route` instances that are also injected into the composed router.

This patch updates to that version, and modifies `Application` to compose a `RouteCollector` instead of `PathBasedRoutingMiddleware`.

An accompanying change will be made to the skeleton to pipe the `RouteMiddleware` instead of the `PathBasedRoutingMiddleware`.