### PR TITLE
Fix DispatchMiddlewareFactory duplicate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 2.2.1 - TBD
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- [#592](https://github.com/zendframework/zend-expressive/pull/592) fixes
+  a v3 to v2 backwards port issue where the `Router\Middleware\DispatchMiddleware`
+  is registered as an invokable and it should be registered with the
+  `Router\Middleware\DispatchMiddlewareFactory`. This caused a
+  "`DispatchMiddleware` already exists and cannot be overridden" exception.
+
 ## 2.2.0 - 2018-03-12
 
 ### Added
@@ -46,47 +72,47 @@ All notable changes to this project will be documented in this file, in reverse 
   - `Zend\Expressive\AppFactory`: if you are using this, you will need to switch
     to direct usage of `Zend\Expressive\Application` or a
     `Zend\Stratigility\MiddlewarePipe` instance.
-  
+
   - `Zend\Expressive\ApplicationConfigInjectionTrait`: if you are using it, it is
     marked internal, and deprecated; it will be removed in version 3.
-  
+
   - `Zend\Expressive\Container\NotFoundDelegateFactory`: the `NotFoundDelegate`
     will be renamed to `Zend\Expressive\Handler\NotFoundHandler` in version 3,
     making this factory obsolete.
-  
+
   - `Zend\Expressive\Delegate\NotFoundDelegate`: this class becomes
     `Zend\Expressive\Handler\NotFoundHandler` in v3, and the new class is added in
     version 2.2 as well.
-  
+
   - `Zend\Expressive\Emitter\EmitterStack`: the emitter concept is extracted from
     zend-diactoros to a new component, zend-httphandlerrunner. This latter
     component is used in version 3, and defines the `EmitterStack` class. Unless
     you are extending it or interacting with it directly, this change should not
     affect you; the `Zend\Diactoros\Response\EmitterInterface` service will be
     directed to the new class in that version.
-  
+
   - `Zend\Expressive\IsCallableInteropMiddlewareTrait`: if you are using it, it is
     marked internal, and deprecated; it will be removed in version 3.
-  
+
   - `Zend\Expressive\MarshalMiddlewareTrait`: if you are using it, it is marked
     internal, and deprecated; it will be removed in version 3.
-  
+
   - `Zend\Expressive\Middleware\DispatchMiddleware`: this functionality has been
     moved to zend-expressive-router, under the `Zend\Expressive\Router\Middleware`
     namespace.
-  
+
   - `Zend\Expressive\Middleware\ImplicitHeadMiddleware`: this functionality has been
     moved to zend-expressive-router, under the `Zend\Expressive\Router\Middleware`
     namespace.
-  
+
   - `Zend\Expressive\Middleware\ImplicitOptionsMiddleware`: this functionality has been
     moved to zend-expressive-router, under the `Zend\Expressive\Router\Middleware`
     namespace.
-  
+
   - `Zend\Expressive\Middleware\NotFoundHandler`: this will be removed in
     version 3, where you can instead pipe `Zend\Expressive\Handler\NotFoundHandler`
     directly instead.
-  
+
   - `Zend\Expressive\Middleware\RouteMiddleware`: this functionality has been
     moved to zend-expressive-router, under the `Zend\Expressive\Router\Middleware`
     namespace.

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -43,9 +43,6 @@ class ConfigProvider
                 Middleware\RouteMiddleware::class           => Router\Middleware\RouteMiddleware::class,
                 'Zend\Expressive\Delegate\DefaultDelegate'  => Handler\NotFoundHandler::class,
             ],
-            'invokables' => [
-                Router\Middleware\DispatchMiddleware::class => Router\Middleware\DispatchMiddleware::class,
-            ],
             'factories' => [
                 Application::class                       => Container\ApplicationFactory::class,
                 ErrorHandler::class                      => Container\ErrorHandlerFactory::class,
@@ -57,6 +54,7 @@ class ConfigProvider
                 StreamInterface::class                   => Container\StreamFactoryFactory::class,
 
                 // These are duplicates, in case the zend-expressive-router package ConfigProvider is not wired:
+                Router\Middleware\DispatchMiddleware::class        => Router\Middleware\DispatchMiddlewareFactory::class,
                 Router\Middleware\ImplicitHeadMiddleware::class    => Router\Middleware\ImplicitHeadMiddlewareFactory::class,
                 Router\Middleware\ImplicitOptionsMiddleware::class => Router\Middleware\ImplicitOptionsMiddlewareFactory::class,
                 Router\Middleware\RouteMiddleware::class           => Router\Middleware\RouteMiddlewareFactory::class,


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:

In version 2.2.0 The [`DispatchMiddleware::class`](https://github.com/zendframework/zend-expressive/blob/2.2.0/src/ConfigProvider.php#L46-L48) is an invokable, but it also has a factory. The factory is used in [zend-expressive-router](https://github.com/zendframework/zend-expressive-router/blob/2.4.1/src/ConfigProvider.php#L30) and is causing a conflict. The DispatchMiddlewareFactory should be used instead.

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] ~~Add a regression test that demonstrates the bug, and proves the fix.~~
  - [x] Add a `CHANGELOG.md` entry for the fix.