### PR TITLE
allow config-route string key as name

### DIFF
--- a/docs/book/v3/cookbook/autowiring-routes-and-pipelines.md
+++ b/docs/book/v3/cookbook/autowiring-routes-and-pipelines.md
@@ -40,6 +40,15 @@ return [
                 'the'   => 'underlying router',
             ],
         ],
+        'another.route.name' => [
+            'path' => '/another/path/to/match',
+            'middleware' => 'Middleware service or pipeline',
+            'allowed_methods' => ['GET', 'POST'],
+            'options' => [
+                'more'    => 'router',
+                'options' => 'here',
+            ],
+        ],
     ],
 ];
 ```
@@ -97,7 +106,9 @@ following keys:
   the HTTP methods allowed for the route. If this is omitted, the assumption is
   any method is allowed.
 - `name` (optional, string): the name of the route, if any; this can be used
-  later to generate a URI based on the route, and must be unique.
+  later to generate a URI based on the route, and must be unique. The name may
+  also be set using a string key in the routes configuration array. If both are
+  set the name assigned in the spec will be used.
 - `options` (optional, array): any options to provide to the generated route.
   These might be default values or constraints, depending on the router
   implementation.

--- a/src/Container/ApplicationConfigInjectionDelegator.php
+++ b/src/Container/ApplicationConfigInjectionDelegator.php
@@ -176,7 +176,7 @@ class ApplicationConfigInjectionDelegator
             return;
         }
 
-        foreach ($config['routes'] as $spec) {
+        foreach ($config['routes'] as $key => $spec) {
             if (! isset($spec['path']) || ! isset($spec['middleware'])) {
                 continue;
             }
@@ -192,7 +192,7 @@ class ApplicationConfigInjectionDelegator
                 }
             }
 
-            $name  = $spec['name'] ?? null;
+            $name  = $spec['name'] ?? (is_string($key) ? $key : null);
             $route = $application->route(
                 $spec['path'],
                 $spec['middleware'],

--- a/test/Container/ApplicationConfigInjectionDelegatorTest.php
+++ b/test/Container/ApplicationConfigInjectionDelegatorTest.php
@@ -391,6 +391,49 @@ class ApplicationConfigInjectionDelegatorTest extends TestCase
         $this->assertEquals([], $app->getRoutes());
     }
 
+    public function testInjectRoutesFromConfigSetRouteNameViaArrayKey()
+    {
+        $config = [
+            'routes' => [
+                'home' => [
+                    'path' => '/',
+                    'middleware' => new TestAsset\InteropMiddleware(),
+                ],
+            ],
+        ];
+        $this->container->has('config')->willReturn(false);
+        $app = $this->createApplication();
+
+        ApplicationConfigInjectionDelegator::injectRoutesFromConfig($app, $config);
+
+        $routes = $app->getRoutes();
+
+        $route = array_shift($routes);
+        $this->assertEquals('home', $route->getName());
+    }
+
+    public function testInjectRoutesFromConfigRouteSpecNameOverrideArrayKeyName()
+    {
+        $config = [
+            'routes' => [
+                'home' => [
+                    'name' => 'homepage',
+                    'path' => '/',
+                    'middleware' => new TestAsset\InteropMiddleware(),
+                ],
+            ],
+        ];
+        $this->container->has('config')->willReturn(false);
+        $app = $this->createApplication();
+
+        ApplicationConfigInjectionDelegator::injectRoutesFromConfig($app, $config);
+
+        $routes = $app->getRoutes();
+
+        $route = array_shift($routes);
+        $this->assertEquals('homepage', $route->getName());
+    }
+
     public function testInjectPipelineFromConfigRaisesExceptionForSpecsOmittingMiddlewareKey()
     {
         $config = [


### PR DESCRIPTION
Hello..just a thought...

Preamble: I still prefer configuration driven pipelines and routes for non trivial projects. 

The current implementation searches for a 'name' key inside each defined route spec, but since the name must be unique we could use the routes array keys to define the name of each route. 
I believe this is also a little more readable: 1 line less per route spec and, at least for me, it's easier to search among array-keys.
 
Anyway, this PR does not impose a new  "unique key as name" spec... it just allows it by using a string key AND omitting the name inside the spec. If a 'name' is still defined inside the spec that would be the one used, so there is no backward incompatibility.

kind regards
 