### PR TITLE
Correct ZendViewRendererFactory feature description

### DIFF
--- a/docs/book/v3/features/container/factories.md
+++ b/docs/book/v3/features/container/factories.md
@@ -459,9 +459,9 @@ the `TwigExtension` instance (assuming the router was found).
 - **FactoryName**: `Zend\Expressive\ZendView\ZendViewRendererFactory`
 - **Suggested Name**: `Zend\Expressive\Template\TemplateRendererInterface`
 - **Requires**: no additional services are required.
+- **Optional**:
     - `Zend\Expressive\Router\RouterInterface`, in order to inject the custom
       url helper implementation.
-- **Optional**:
     - `config`, an array or `ArrayAccess` instance. This will be used to further
       configure the `ZendView` instance, specifically with the layout template
       name, entries for a `TemplateMapResolver`, and and template paths to


### PR DESCRIPTION
See here:
https://docs.zendframework.com/zend-expressive/v3/features/container/factories/#zendviewrendererfactory

Says "no additional services are required", but then lists a dependency.

I made a separate pull request for this since this case might be a bit more complex. My understanding is that the actual dependency is the `UrlHelper`.
The `ZendViewRendererFactory` comments added some more confusion:
> Requires the Zend\Expressive\Router\RouterInterface service (for creating the UrlHelper instance).

https://github.com/zendframework/zend-expressive-zendviewrenderer/blob/master/src/ZendViewRendererFactory.php

In any case, I think this small change should suffice to relieve most of the confusion.

- [x] Is this related to documentation?
  - [x] Is it a typographical and/or grammatical fix?
   - [ ] Is it new documentation?
