### PR TITLE
Closing bracket missing in documentation

### DIFF
--- a/docs/book/v3/getting-started/quick-start.md
+++ b/docs/book/v3/getting-started/quick-start.md
@@ -564,7 +564,7 @@ $target = htmlspecialchars($target, ENT_HTML5, 'UTF-8');
 return new HtmlResponse($this->renderer->render(
     'app::hello',
     ['target' => $target]
-);
+));
 ```
 
 > #### Templateless handler


### PR DESCRIPTION
The code sample was missing a closing bracket, which could lead to confusing errors and affecting the user experience.

- [x] Is this related to documentation?
  <!-- Is it a typographical and/or grammatical fix? -->
  The documentation was missing a closing bracket, which I added
  <!-- Is it new documentation? -->
