### PR TITLE
Add cookbook entry for accessing common data in templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- [#615](https://github.com/zendframework/zend-expressive/pull/615) adds a
+  cookbook entry for accessing common data in templates.
 
 ### Changed
 
@@ -135,9 +136,9 @@ All notable changes to this project will be documented in this file, in reverse 
     `SapiEmitter` from that same namespace as the only emitter on the stack.
     This is used as a dependency for the `Zend\HttpHandlerRunner\RequestHandlerRunner`
     service.
-  - `MiddlewareContainerFactory`: creates and returns a `Zend\Expressive\MiddlewareContainer` 
+  - `MiddlewareContainerFactory`: creates and returns a `Zend\Expressive\MiddlewareContainer`
     instance decorating the PSR-11 container passed to the factory.
-  - `MiddlewareFactoryFactory`: creates and returns a `Zend\Expressive\MiddlewareFactory` 
+  - `MiddlewareFactoryFactory`: creates and returns a `Zend\Expressive\MiddlewareFactory`
     instance decorating a `MiddlewareContainer` instance as pulled from the
     container.
   - `RequestHandlerRunnerFactory`: creates and returns a
@@ -430,47 +431,47 @@ All notable changes to this project will be documented in this file, in reverse 
   - `Zend\Expressive\AppFactory`: if you are using this, you will need to switch
     to direct usage of `Zend\Expressive\Application` or a
     `Zend\Stratigility\MiddlewarePipe` instance.
-  
+
   - `Zend\Expressive\ApplicationConfigInjectionTrait`: if you are using it, it is
     marked internal, and deprecated; it will be removed in version 3.
-  
+
   - `Zend\Expressive\Container\NotFoundDelegateFactory`: the `NotFoundDelegate`
     will be renamed to `Zend\Expressive\Handler\NotFoundHandler` in version 3,
     making this factory obsolete.
-  
+
   - `Zend\Expressive\Delegate\NotFoundDelegate`: this class becomes
     `Zend\Expressive\Handler\NotFoundHandler` in v3, and the new class is added in
     version 2.2 as well.
-  
+
   - `Zend\Expressive\Emitter\EmitterStack`: the emitter concept is extracted from
     zend-diactoros to a new component, zend-httphandlerrunner. This latter
     component is used in version 3, and defines the `EmitterStack` class. Unless
     you are extending it or interacting with it directly, this change should not
     affect you; the `Zend\Diactoros\Response\EmitterInterface` service will be
     directed to the new class in that version.
-  
+
   - `Zend\Expressive\IsCallableInteropMiddlewareTrait`: if you are using it, it is
     marked internal, and deprecated; it will be removed in version 3.
-  
+
   - `Zend\Expressive\MarshalMiddlewareTrait`: if you are using it, it is marked
     internal, and deprecated; it will be removed in version 3.
-  
+
   - `Zend\Expressive\Middleware\DispatchMiddleware`: this functionality has been
     moved to zend-expressive-router, under the `Zend\Expressive\Router\Middleware`
     namespace.
-  
+
   - `Zend\Expressive\Middleware\ImplicitHeadMiddleware`: this functionality has been
     moved to zend-expressive-router, under the `Zend\Expressive\Router\Middleware`
     namespace.
-  
+
   - `Zend\Expressive\Middleware\ImplicitOptionsMiddleware`: this functionality has been
     moved to zend-expressive-router, under the `Zend\Expressive\Router\Middleware`
     namespace.
-  
+
   - `Zend\Expressive\Middleware\NotFoundHandler`: this will be removed in
     version 3, where you can instead pipe `Zend\Expressive\Handler\NotFoundHandler`
     directly instead.
-  
+
   - `Zend\Expressive\Middleware\RouteMiddleware`: this functionality has been
     moved to zend-expressive-router, under the `Zend\Expressive\Router\Middleware`
     namespace.

--- a/docs/book/cookbook/injecting-data-into-templates.md
+++ b/docs/book/cookbook/injecting-data-into-templates.md
@@ -1,6 +1,0 @@
-<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v3/cookbook/access-common-data-in-templates/"></noscript>
-<script>
-  document.addEventListener("DOMContentLoaded", function (event) {
-    window.location.pathname = '/zend-expressive/v3/cookbook/access-common-data-in-templates/';
-  });
-</script>

--- a/docs/book/cookbook/injecting-data-into-templates.md
+++ b/docs/book/cookbook/injecting-data-into-templates.md
@@ -1,0 +1,6 @@
+<noscript><meta http-equiv="refresh" content="0; url=/zend-expressive/v3/cookbook/access-common-data-in-templates/"></noscript>
+<script>
+  document.addEventListener("DOMContentLoaded", function (event) {
+    window.location.pathname = '/zend-expressive/v3/cookbook/access-common-data-in-templates/';
+  });
+</script>

--- a/docs/book/v3/cookbook/access-common-data-in-templates.md
+++ b/docs/book/v3/cookbook/access-common-data-in-templates.md
@@ -1,0 +1,75 @@
+# How Can I Access Common Data In Templates?
+
+This is a question that's asked a lot of times. How can I make common data like
+request attributes, the current route name, etc. available into all template.
+The answer is pretty easy actually. All that is needed is a middleware and
+the `addDefaultParam()` method from the template renderer.
+
+Here is an example on how to inject the current user, matched route name and
+all flash messages with one middleware.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Zend\Expressive\Router\RouteResult;
+use Zend\Expressive\Session\Authentication\UserInterface;
+use Zend\Expressive\Session\Flash\FlashMessagesInterface;
+use Zend\Expressive\Template\TemplateRendererInterface;
+
+class TemplateDefaultsMiddleware implements MiddlewareInterface
+{
+    /** @var TemplateRendererInterface */
+    private $templateRenderer;
+
+    public function __construct(TemplateRendererInterface $templateRenderer)
+    {
+        $this->templateRenderer = $templateRenderer;
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
+    {
+        // Inject the current user or null if there isn't one
+        $this->templateRenderer->addDefaultParam(
+            TemplateRendererInterface::TEMPLATE_ALL,
+            'security', // This is named security so it will not interfere with your user admin pages
+            $request->getAttribute(UserInterface::class)
+        );
+
+        // Inject the current matched route name
+        $routeResult = $request->getAttribute(RouteResult::class);
+        $this->templateRenderer->addDefaultParam(
+            TemplateRendererInterface::TEMPLATE_ALL,
+            'matchedRouteName',
+            $routeResult ? $routeResult->getMatchedRouteName() : null
+        );
+
+        /** @var FlashMessagesInterface $flashMessages */
+        $flashMessages = $request->getAttribute(FlashMessagesInterface::class);
+        // Inject all flash messages
+        $this->templateRenderer->addDefaultParam(
+            TemplateRendererInterface::TEMPLATE_ALL,
+            'notifications',
+            $flashMessages ? $flashMessages->getFlashes() : []
+        );
+
+        // Inject any other data you always need in all your templates
+
+        return $handler->handle($request);
+    }
+}
+```
+
+Next you need to create a factory and register it. This is easy with
+[zend-expressive-tooling](../reference/cli-tooling.md):
+
+```bash
+./vendor/bin/expressive factory:create App\Middleware\TemplateDefaultsMiddleware
+```

--- a/docs/book/v3/cookbook/access-common-data-in-templates.md
+++ b/docs/book/v3/cookbook/access-common-data-in-templates.md
@@ -1,8 +1,7 @@
 # How Can I Access Common Data In Templates?
 
-This is a question that's asked a lot of times. How can I make common data like
-request attributes, the current route name, etc. available into all template.
-The answer is pretty easy actually. All that is needed is a middleware and
+How can I make frequently used data like request attributes, the current route 
+name, etc. available in all template. All that is needed is a middleware and
 the `addDefaultParam()` method from the template renderer.
 
 Here is an example on how to inject the current user, matched route name and
@@ -67,9 +66,9 @@ class TemplateDefaultsMiddleware implements MiddlewareInterface
 }
 ```
 
-Next you need to create a factory and register it. This is easy with
+Next you need to create a factory and register it. You can generate a factory with
 [zend-expressive-tooling](../reference/cli-tooling.md):
 
 ```bash
-./vendor/bin/expressive factory:create App\Middleware\TemplateDefaultsMiddleware
+$ ./vendor/bin/expressive factory:create App\Middleware\TemplateDefaultsMiddleware
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ pages:
         - 'Using Expressive from a subdirectory': v3/cookbook/using-a-base-path.md
         - 'Prepending a common path to all routes': v3/cookbook/common-prefix-for-routes.md
         - 'Passing data between middleware': v3/cookbook/passing-data-between-middleware.md
+        - 'Access Common Data In Templates': v3/cookbook/access-common-data-in-templates.md
         - 'Route-specific middleware pipelines': v3/cookbook/route-specific-pipeline.md
         - 'Segregating middleware by host': v3/cookbook/host-segregated-middleware.md
         - 'Using double-pass middleware': v3/cookbook/double-pass-middleware.md


### PR DESCRIPTION
As the title says: It adds a cookbook entry for accessing common data in templates.

- [x] Are you creating a new feature?
  - [x] Why is the new feature needed? What purpose does it serve?
  - [x] How will users use the new feature?
  - [x] Add only one feature per pull request; split multiple features over multiple pull requests
  - [x] Add documentation for the new feature.
  - [x] Add a `CHANGELOG.md` entry for the new feature.