### PR TITLE
Add middlewareName getter to LazyLoadingMiddleware

### DIFF
--- a/src/Middleware/LazyLoadingMiddleware.php
+++ b/src/Middleware/LazyLoadingMiddleware.php
@@ -45,7 +45,7 @@ class LazyLoadingMiddleware implements MiddlewareInterface
         $middleware = $this->container->get($this->middlewareName);
         return $middleware->process($request, $handler);
     }
-    
+
     public function getMiddlewareName() : string
     {
         return $this->middlewareName;

--- a/src/Middleware/LazyLoadingMiddleware.php
+++ b/src/Middleware/LazyLoadingMiddleware.php
@@ -45,4 +45,9 @@ class LazyLoadingMiddleware implements MiddlewareInterface
         $middleware = $this->container->get($this->middlewareName);
         return $middleware->process($request, $handler);
     }
+    
+    public function getMiddlewareName() : string
+    {
+        return $this->middlewareName;
+    }
 }


### PR DESCRIPTION
In some cases it is necessary to get a middleware name that is corresponding to the route and since that was possible to do in previous versions of Expressive, it would be nice to keep that functionality.
We are currently using input filters written in config files and they are maintained by middleware class name and currently only possible way of doing that is by overriding closure.