### PR TITLE
Update links in documentation

### DIFF
--- a/docs/book/v3/features/container/config.md
+++ b/docs/book/v3/features/container/config.md
@@ -256,4 +256,4 @@ Examples of how the above capabilities may be implemented include:
 
 - [zendframework/zend-auradi-config](https://github.com/zendframework/zend-auradi-config)
 - [zendframework/zend-pimple-config](https://github.com/zendframework/zend-pimple-config)
-- [jsoumelidis/zend-sf-di-config](https://github.com/zendframework/jsoumelidis/zend-sf-di-config)
+- [jsoumelidis/zend-sf-di-config](https://github.com/jsoumelidis/zend-sf-di-config)

--- a/docs/book/v3/features/container/config.md
+++ b/docs/book/v3/features/container/config.md
@@ -255,5 +255,5 @@ container configuration.
 Examples of how the above capabilities may be implemented include:
 
 - [zendframework/zend-auradi-config](https://github.com/zendframework/zend-auradi-config)
-- [zendframework/zend-pimple-config](https://github.com/zendframework/zend-auradi-config)
-- [jsoumelidis/zend-sf-di-config](https://github.com/zendframework/zend-auradi-config)
+- [zendframework/zend-pimple-config](https://github.com/zendframework/zend-pimple-config)
+- [jsoumelidis/zend-sf-di-config](https://github.com/zendframework/jsoumelidis/zend-sf-di-config)


### PR DESCRIPTION
Two of the links in the end are a copy-paste of the one above. This commit fixes it.