### PR TITLE
Hotfix/docs getting started

### DIFF
--- a/docs/book/v3/getting-started/quick-start.md
+++ b/docs/book/v3/getting-started/quick-start.md
@@ -590,18 +590,26 @@ The above looks for a query string parameter "target", and uses its value to
 provide to the template, which is then rendered and returned in an HTML
 response.
 
-Now, let's edit the template file to have the one of the following header lines (use the one for your chosen template renderer):
+Now, let's edit the template file to have the one of the following header lines
+(use the one for your chosen template renderer):
 
-```html
-<!-- plates -->
-<h1>Hello <?= $this->e($target) ?></h1>
+- Plates
+  ```php
+  <!-- plates -->
+  <h1>Hello <?= $this->e($target) ?></h1>
+  ```
 
-<!-- zend-view -->
-<h1>Hello <?= $this->target ?></h1>
+- zend-view
+  ```php
+  <!-- zend-view -->
+  <h1>Hello <?= $this->target ?></h1>
+  ```
 
-<!-- twig -->
-<h1>Hello {{ target }}</h1>
-```
+- Twig
+  ```twig
+  <!-- twig -->
+  <h1>Hello {{ target }}</h1>
+  ```
 
 While the handler is registered with the container, the application does not yet
 know how to get to it. Let's fix that.

--- a/docs/book/v3/getting-started/quick-start.md
+++ b/docs/book/v3/getting-started/quick-start.md
@@ -592,13 +592,14 @@ response.
 
 Now, let's edit the template file to have the following contents:
 
-```php
+```html
+<!-- plates -->
+<h1>Hello <?= $this->e($target) ?></h1>
+
+<!-- zend-view -->
 <h1>Hello <?= $this->target ?></h1>
-```
 
-If you are using Twig, use this instead:
-
-```twig
+<!-- twig -->
 <h1>Hello {{ target }}</h1>
 ```
 

--- a/docs/book/v3/getting-started/quick-start.md
+++ b/docs/book/v3/getting-started/quick-start.md
@@ -590,7 +590,7 @@ The above looks for a query string parameter "target", and uses its value to
 provide to the template, which is then rendered and returned in an HTML
 response.
 
-Now, let's edit the template file to have the following contents:
+Now, let's edit the template file to have the one of the following header lines (use the one for your chosen template renderer):
 
 ```html
 <!-- plates -->


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:

During the conversion of v2 to v3 docs the quick start text for creating a hello template was changed in such way that it unclear what code to use for which renderer. This PR adds example code for plates, zend-view and twig.

- [x] Is this related to documentation?
