### PR TITLE
improve the "setting-locale w/o" cookbook example

### DIFF
--- a/docs/book/v3/cookbook/setting-locale-without-routing-parameter.md
+++ b/docs/book/v3/cookbook/setting-locale-without-routing-parameter.md
@@ -68,8 +68,10 @@ class SetLocaleMiddleware implements MiddlewareInterface
         Locale::setDefault(Locale::canonicalize($locale));
         $this->helper->setBasePath($locale);
 
+        $path = substr($path, strlen($locale) + 1);
+
         return $handler->handle($request->withUri(
-            $uri->withPath(substr($path, strlen($locale) + 1))
+            $uri->withPath(path ?: '/')
         ));
     }
 }

--- a/docs/book/v3/cookbook/setting-locale-without-routing-parameter.md
+++ b/docs/book/v3/cookbook/setting-locale-without-routing-parameter.md
@@ -71,7 +71,7 @@ class SetLocaleMiddleware implements MiddlewareInterface
         $path = substr($path, strlen($locale) + 1);
 
         return $handler->handle($request->withUri(
-            $uri->withPath(path ?: '/')
+            $uri->withPath($path ?: '/')
         ));
     }
 }

--- a/docs/book/v3/cookbook/setting-locale-without-routing-parameter.md
+++ b/docs/book/v3/cookbook/setting-locale-without-routing-parameter.md
@@ -98,7 +98,7 @@ class SetLocaleMiddlewareFactory
 {
     public function __invoke(ContainerInterface $container)
     {
-        $config = $container->get('config');
+        $config = $container->has('config') ? $container->get('config') : [];
         
         return new SetLocaleMiddleware(
             $container->get(UrlHelper::class),


### PR DESCRIPTION
[x]  Is this related to documentation?

- the current regex allows `/eng-us/`, I believe only `en`, `eng`, `en-us`, `en-US`, `en_us`, `en_US` (well, i would remove the last 2 as well) should be allowed
- the current regex requires a trailing `/` after the locale, we should allow base paths like `/en`, `/de` as well
- the stripped part length is variable and should be computed from $locale (adding 1 for the root `/` char)
- provide an example for using a default locale from app configuration
