### PR TITLE
individual checks before calling `inject*` methods

### DIFF
--- a/src/Container/ApplicationConfigInjectionDelegator.php
+++ b/src/Container/ApplicationConfigInjectionDelegator.php
@@ -55,10 +55,10 @@ class ApplicationConfigInjectionDelegator
 
         $config = $container->get('config');
 
-        if (!empty($config['middleware_pipeline'])) {
+        if (! empty($config['middleware_pipeline'])) {
             self::injectPipelineFromConfig($application, (array) $config);
         }
-        if (!empty($config['routes'])) {
+        if (! empty($config['routes'])) {
             self::injectRoutesFromConfig($application, (array) $config);
         }
 

--- a/src/Container/ApplicationConfigInjectionDelegator.php
+++ b/src/Container/ApplicationConfigInjectionDelegator.php
@@ -54,12 +54,13 @@ class ApplicationConfigInjectionDelegator
         }
 
         $config = $container->get('config');
-        if (! isset($config['routes']) && ! isset($config['middleware_pipeline'])) {
-            return $application;
-        }
 
-        self::injectPipelineFromConfig($application, (array) $config);
-        self::injectRoutesFromConfig($application, (array) $config);
+        if (!empty($config['middleware_pipeline'])) {
+            self::injectPipelineFromConfig($application, (array) $config);
+        }
+        if (!empty($config['routes'])) {
+            self::injectRoutesFromConfig($application, (array) $config);
+        }
 
         return $application;
     }
@@ -172,7 +173,7 @@ class ApplicationConfigInjectionDelegator
      */
     public static function injectRoutesFromConfig(Application $application, array $config) : void
     {
-        if (! isset($config['routes']) || ! is_array($config['routes'])) {
+        if (empty($config['routes']) || ! is_array($config['routes'])) {
             return;
         }
 


### PR DESCRIPTION
This could be considered just as a tiny refactoring / code-style change: no bugs, no new features

1. don't call an `inject*` method with missing/empty related config values
2. check for empty routes in `injectRoutesFromConfig` before checking is_array and running the loop on an empty array (this make more sense if the method is called outside this delegator, which, now, already checks for emptiness before calling it)
