### PR TITLE
Fix syntax error

### DIFF
--- a/docs/book/v1/features/template/plates.md
+++ b/docs/book/v1/features/template/plates.md
@@ -42,7 +42,7 @@ $plates = new PlatesEngine();
 
 // Configure it:
 $plates->addFolder('error', 'templates/error/');
-$plates->loadExtension(new CustomExtension();
+$plates->loadExtension(new CustomExtension());
 
 // Inject:
 $renderer = new PlatesRenderer($plates);


### PR DESCRIPTION
Documentation correction, added a missing parentheses on "Using Plates" page.