### PR TITLE
zendframework/zend-expressive#624: add installation note

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ Additionally, you may optionally want to install a template renderer
 implementation, and/or an error handling integration. These are covered in the
 documentation.
 
+Installation of Expressive in an existing project is not currently supported.
+Installation steps are covered in detail in the documentation. Please check
+for more information.
+
 ## Documentation
 
 Documentation is [in the doc tree](docs/book/), and can be compiled using [mkdocs](http://www.mkdocs.org):

--- a/docs/book/v2/getting-started/standalone.md
+++ b/docs/book/v2/getting-started/standalone.md
@@ -29,6 +29,9 @@ have, we can install Expressive, along with a router and a container:
 $ composer require zendframework/zend-expressive zendframework/zend-expressive-fastroute zendframework/zend-servicemanager
 ```
 
+*Note: Installation of Expressive in an existing project is not currently supported.
+As such we recommend it should be installed in an empty directory.*
+
 > ### Routers
 >
 > Expressive needs a routing implementation in order to create routed


### PR DESCRIPTION
Add note to installation steps with regards to not being supported in existing projects.

- [x] Is this related to documentation?

This is adding a short note to the main installation and the getting started documentation to note that installation in existing projects is not currently supported. See https://github.com/zendframework/zend-expressive/issues/624#issuecomment-403832747 for details.
