### PR TITLE
Do not cast request handlers implementing middleware to `RequestHandlerMiddleware`

### DIFF
--- a/src/MiddlewareContainer.php
+++ b/src/MiddlewareContainer.php
@@ -63,9 +63,11 @@ class MiddlewareContainer implements ContainerInterface
             ? $this->container->get($service)
             : new $service();
 
-        $middleware = $middleware instanceof RequestHandlerInterface
-            ? new RequestHandlerMiddleware($middleware)
-            : $middleware;
+        if ($middleware instanceof RequestHandlerInterface
+            && ! $middleware instanceof MiddlewareInterface
+        ) {
+            $middleware = new RequestHandlerMiddleware($middleware);
+        }
 
         if (! $middleware instanceof MiddlewareInterface) {
             throw Exception\InvalidMiddlewareException::forMiddlewareService($service, $middleware);

--- a/test/MiddlewareContainerTest.php
+++ b/test/MiddlewareContainerTest.php
@@ -101,4 +101,20 @@ class MiddlewareContainerTest extends TestCase
         $this->assertInstanceOf(RequestHandlerMiddleware::class, $middleware);
         $this->assertAttributeSame($handler, 'handler', $middleware);
     }
+
+    /**
+     * @see https://github.com/zendframework/zend-expressive/issues/645
+     */
+    public function testGetDoesNotCastMiddlewareImplementingRequestHandlerToRequestHandlerMiddleware()
+    {
+        $pipeline = $this->prophesize(RequestHandlerInterface::class);
+        $pipeline->willImplement(MiddlewareInterface::class);
+
+        $this->originContainer->has('pipeline')->willReturn(true);
+        $this->originContainer->get('pipeline')->will([$pipeline, 'reveal']);
+
+        $middleware = $this->container->get('pipeline');
+
+        $this->assertSame($middleware, $pipeline->reveal());
+    }
 }


### PR DESCRIPTION
Per #645, `MiddlewareContainer::get()` was incorrectly casting middleware that also implemented `RequestHandlerInterface` to `RequestHandlerMiddleware`. This particularly affected `Zend\Stratigility\MiddlewarePipe` instances, as they implement both interfaces; if the last middleware in a pipeline called on the handler, users would then encounter a "pipeline exhausted" error, because it would be invoked as a handler, and thus have no reference to the application's pipeline.

This change verifies that the request handler does not also implement `MiddlewareInterface` before casting.

Fixes #645