### PR TITLE
Add note about needing to quote or escape backslashes.

### DIFF
--- a/docs/book/v3/reference/cli-tooling.md
+++ b/docs/book/v3/reference/cli-tooling.md
@@ -73,7 +73,10 @@ Commands supported include:
 - **`handler:create [options] <handler>`**: Create a request handler named after
   `<handler>`. By default, the command will also generate a factory, register
   both with the application container, and, if a template renderer is
-  discovered, generate a template in an appropriate location.
+  discovered, generate a template in an appropriate location. **Note:**
+  `<handler>` will either need to be quoted or the backslashes escaped.
+  **Example:** `handler:create ModuleName\\Handler\\IndexHandler` or
+  `handler:create "ModuleName\Handler\IndexHandler"`.
 
 - **`middleware:create <middleware>`**: Create a class file for the named
   middleware class. The class _must_ use a namespace already declared in your


### PR DESCRIPTION
- [x] Is this related to documentation?

It took me awhile to figure out that I needed to escape the backslashes on command line while trying to generate a handler. It seems obvious now that I tried it and it worked, but it'd be nice to have it noted in the documentation regardless.