### PR TITLE
Document new zend-expressive-helpers features from 5.2 and 5.3

### DIFF
--- a/docs/book/v3/features/helpers/template-variable-container.md
+++ b/docs/book/v3/features/helpers/template-variable-container.md
@@ -67,7 +67,7 @@ return function (Application $app, MiddlewareFactory $factory, ContainerInterfac
     $app->pipe(ErrorHandler::class);
     $app->pipe(ServerUrlMiddleware::class);
 
-		// The following entry is specific to this example:
+        // The following entry is specific to this example:
     $app->pipe(path(
         '/api/doc',
         $factory->lazy(TemplateVariableContainerMiddleware::class)
@@ -102,26 +102,26 @@ use Zend\Expressive\Router\RouteResult;
 
 class InjectUserAndRouteVariablesMiddleware implements MiddlewareInterface
 {
-		public function process(
-				ServerRequestInterface $request,
-				 RequestHandlerInterface $handler
-			) : ResponseInterface {
-					$container = $request->getAttribute(
-							TemplateVariableContainer::class,
-							new TemplateVariableContainer()
-					);
+    public function process(
+        ServerRequestInterface $request,
+            RequestHandlerInterface $handler
+    ) : ResponseInterface {
+        $container = $request->getAttribute(
+            TemplateVariableContainer::class,
+            new TemplateVariableContainer()
+        );
 
-					// Since containers are immutable, we re-populate the request:
-					$request = $request->withAttribute(
-							TemplateVariableContainer::class,
-							$container->merge([
-									'user'  => $user,
-									'route' => $request->getAttribute(RouteResult::class),
-							])
-					);
+        // Since containers are immutable, we re-populate the request:
+        $request = $request->withAttribute(
+            TemplateVariableContainer::class,
+            $container->merge([
+                'user'  => $user,
+                'route' => $request->getAttribute(RouteResult::class),
+            ])
+        );
 
-					return $handler->handle($request);
-			}
+        return $handler->handle($request);
+    }
 }
 ```
 
@@ -139,37 +139,37 @@ use Zend\Expressive\Template\TemplateRendererInterface;
 
 class SomeHandler implements RequestHandlerInterface
 {
-		private $renderer;
-		private $responseFactory;
-		private $streamFactory;
+    private $renderer;
+    private $responseFactory;
+    private $streamFactory;
 
-		public function __construct(
-				TemplateRendererInterface $renderer,
-				ResponseFactoryInterface $responseFactory,
-				StreamFactoryInterface $streamFactory
-		) {
-				$this->renderer        = $renderer;
-				$this->responseFactory = $responseFactory;
-				$this->streamFactory   = $streamFactory;
-		}
+    public function __construct(
+        TemplateRendererInterface $renderer,
+        ResponseFactoryInterface $responseFactory,
+        StreamFactoryInterface $streamFactory
+    ) {
+        $this->renderer        = $renderer;
+        $this->responseFactory = $responseFactory;
+        $this->streamFactory   = $streamFactory;
+    }
 
-		public function handle(ServerRequestInterface $request) : ResponseInterface
-		{
-				$value = $request->getParsedBody()['key'] ?? null;
+    public function handle(ServerRequestInterface $request) : ResponseInterface
+    {
+        $value = $request->getParsedBody()['key'] ?? null;
 
-				$content = $this->renderer->render(
-						'some::template',
-						$request
-								->getAttribute(TemplateVariableContainer::class)
-								->mergeForTemplate([
-										'local' => $value,
-								])
-				);
+        $content = $this->renderer->render(
+            'some::template',
+            $request
+                ->getAttribute(TemplateVariableContainer::class)
+                ->mergeForTemplate([
+                    'local' => $value,
+                ])
+        );
 
-				$body = $this->streamFactory()->createStream($content);
+        $body = $this->streamFactory()->createStream($content);
 
-				return $this->responseFactory()->createResponse(200)->withBody($body);
-		}
+        return $this->responseFactory()->createResponse(200)->withBody($body);
+    }
 }
 ```
 

--- a/docs/book/v3/features/helpers/template-variable-container.md
+++ b/docs/book/v3/features/helpers/template-variable-container.md
@@ -1,0 +1,149 @@
+# Template Variable Container
+
+> - Since zend-expressive-helpers 5.3.0
+
+[zend-expressive-template](../template/intro.md) provides the method
+[Zend\Expressive\Template\TemplateRendererInterface::addDefaultParam()](../template/interface.md#default-params)
+for providing template variables that should be available to any template.
+
+One common use case for this is to set things such as the current user, current
+section of the website, currently matched route, etc. Unfortunately, because the
+method changes the internal state of the renderer, this can cause problems in an
+async environment, such as [Swoole](https://docs.zendframework.com/zend-expressive-swoole), 
+where those changes will persist for parallel and subsequent requests.
+
+To provide a stateless alternative, you can create a `Zend\Expressive\Helper\Template\TemplateVariableContainer`
+and persist it as a request attribute. This allows you to set template variables
+that are pipeline-specific, and later extract and merge them with
+handler-specific values when rendering.
+
+To facilitate this further, we provide `Zend\Expressive\Helper\Template\TemplateVariableContainerMiddleware`,
+which will populate the attribute for you if it has not yet been.
+
+The container is **immutable**, and any changes will result in a new instance.
+As such, any middleware that is providing additional values or removing values
+**must** call `$request->withAttribute()` to replace the instance, per the
+examples below.
+
+As an example, consider the following pipeline:
+
+```php
+use Psr\Container\ContainerInterface;
+use Zend\Expressive\Application;
+use Zend\Expressive\Handler\NotFoundHandler;
+use Zend\Expressive\Helper\ServerUrlMiddleware;
+use Zend\Expressive\Helper\Template\TemplateVariableContainerMiddleware;
+use Zend\Expressive\Helper\UrlHelperMiddleware;
+use Zend\Expressive\MiddlewareFactory;
+use Zend\Expressive\Router\Middleware\DispatchMiddleware;
+use Zend\Expressive\Router\Middleware\ImplicitHeadMiddleware;
+use Zend\Expressive\Router\Middleware\ImplicitOptionsMiddleware;
+use Zend\Expressive\Router\Middleware\MethodNotAllowedMiddleware;
+use Zend\Expressive\Router\Middleware\RouteMiddleware;
+use Zend\Stratigility\Middleware\ErrorHandler;
+
+use function Zend\Stratigility\path;
+
+return function (Application $app, MiddlewareFactory $factory, ContainerInterface $container) : void {
+    $app->pipe(ErrorHandler::class);
+    $app->pipe(ServerUrlMiddleware::class);
+
+    $app->pipe(path(
+        '/api/doc',
+        $factory->lazy(TemplateVariableContainerMiddleware::class)
+    ));
+
+    $app->pipe(RouteMiddleware::class);
+
+    $app->pipe(ImplicitHeadMiddleware::class);
+    $app->pipe(ImplicitOptionsMiddleware::class);
+    $app->pipe(MethodNotAllowedMiddleware::class);
+    $app->pipe(UrlHelperMiddleware::class);
+
+    $app->pipe(DispatchMiddleware::class);
+
+    $app->pipe(NotFoundHandler::class);
+};
+```
+
+Any middleware or handler that responds to a path beginning with `/api/doc` will
+now have a `Zend\Expressive\Helper\Template\TemplateVariableContainer` attribute
+that contains an instance of that class.
+
+Within middleware that responds on that path, you can then do the following:
+
+```php
+use Zend\Expressive\Helper\Template\TemplateVariableContainer;
+use Zend\Expressive\Router\RouteResult;
+
+$container = $request->getAttribute(
+    TemplateVariableContainer::class,
+    new TemplateVariableContainer()
+);
+
+// Since containers are immutable, we re-populate the request:
+$request = $request->withAttribute(
+    TemplateVariableContainer::class,
+    $container->merge([
+        'user'  => $user,
+        'route' => $request->getAttribute(RouteResult::class),
+    ])
+);
+```
+
+In a handler, you will call `mergeForTemplate()` with any local variables you
+want to use, including those that might override the defaults:
+
+```php
+use Zend\Expressive\Helper\Template\TemplateVariableContainer;
+
+$content = $this->renderer->render(
+    'some::template',
+    $request
+        ->getAttribute(TemplateVariableContainer::class)
+        ->mergeForTemplate([
+            'local' => $value,
+        ])
+);
+```
+
+The `TemplateVariableContainer` contains the following methods:
+
+- `count() : int`: return a count of variables in the container.
+- `get(string $key) : mixed`: return the value associated with `$key`; if not
+  present, a `null` is returned.
+- `has(string $key) : bool`: does the container have an entry associated with
+  `$key`?
+- `with(string $key, mixed $value) : self`: return a new container instance
+  containing the key/value pair provided.
+- `without(string $key) : self`: return a new container instance that does not
+  contain the given `$key`.
+- `merge(array $values) : self`: return a new container that merge the `$values`
+  provided with those in the original container. This is useful for setting
+  many values at once.
+- `mergeForTemplate(array $values) : array`: merge `$values` with any values in
+  the container, and return the result. This method has no side effects, and
+  should be used when preparing variables to pass to the renderer.
+
+## Route template variable middleware
+
+> - Since zend-expressive-helpers 5.3.0
+
+`Zend\Expressive\Helper\Template\RouteTemplateVariableMiddleware` will inject
+the currently matched route into the [template variable container](#template-variable-container).
+
+This middleware relies on the `TemplateVariableContainerMiddleware` preceding
+it in the middleware pipeline, or having the `TemplateVariableContainer`
+request attribute present; if neither is present, it will generate a new
+instance.
+
+It then populates the container's `route` parameter using the results of
+retrieving the `Zend\Expressive\Router\RouteResult` request attribute; the value
+will be either an instance of that class, or `null`.
+
+Templates rendered using the container can then access that value, and test for
+routing success/failure status, pull the matched route name, route, and/or
+parameters from it.
+
+This middleware can replace the [UrlHelperMiddleware](url-helper.md) in your
+pipeline.

--- a/docs/book/v3/features/helpers/url-helper.md
+++ b/docs/book/v3/features/helpers/url-helper.md
@@ -70,6 +70,15 @@ Each method will raise an exception if:
 > zendframework/zend-expressive-helpers. Prior to that version, the helper only
 > accepted the route name and route parameters.
 
+### Other methods available
+
+- `getRouteResult() : ?Zend\Expressive\Router\RouteResult` (since
+  zend-expressive-helpers 5.2.0): if you want access to the result of routing —
+  and, consequently, the matched route name, matched route parameters, and
+  matched route — you can use this method. The method returns `null` if no route
+  result has been injected yet — which typically happens in the
+  `UrlHelperMiddleware`, discussed in the next section.
+
 ### Registering the pipeline middleware
 
 For the `UrlHelper` to work, you must first register the `UrlHelperMiddleware`

--- a/docs/book/v3/features/helpers/url-helper.md
+++ b/docs/book/v3/features/helpers/url-helper.md
@@ -79,6 +79,18 @@ Each method will raise an exception if:
   result has been injected yet — which typically happens in the
   `UrlHelperMiddleware`, discussed in the next section.
 
+  As an example:
+
+  ```php
+  $templateParams = [];
+  $routeResult    = $this->urlHelper->getRouteResult();
+  if ($routeResult->isSuccess()) {
+      $templateParams['route']        = $routeResult->getMatchedRouteName();
+      $templateParams['route_params'] = $routeResult->getMatchedParams();
+  }
+  ```
+
+
 ### Registering the pipeline middleware
 
 For the `UrlHelper` to work, you must first register the `UrlHelperMiddleware`

--- a/docs/book/v3/features/template/plates.md
+++ b/docs/book/v3/features/template/plates.md
@@ -60,6 +60,8 @@ The factory looks for the following configuration in the `config` service, using
 any it finds:
 
 ```php
+// In config/autoload/templates.global.php:
+
 return [
     'plates' => [
         'extensions' => [
@@ -106,12 +108,29 @@ public function serverurl(string $path = null) : string;
 public function route() : ?Zend\Expressive\Router\RouteResult
 ```
 
-### EscaperExtension
-
-`Zend\Expressive\Plates\Extension\UrlExtension` looks for the following
-configuration in the `config` service:
+As an example:
 
 ```php
+<a href="<?= $this->url('blog', ['stub' => $this->stub]) ?>">A blog post on this</a>
+
+<?php
+$routing        = $this->route();
+$routingIsValid = $routing && $routing->isSuccess();
+$route       = $routingIsValid ? $routing->getMatchedRouteName() : 'blog';
+$routeParams = $routingIsValid ? $routing->getMatchedParams() : [];
+?>
+<a href="<?= $this->url($route, $routeParams) ?>">For more information</a>
+```
+
+### EscaperExtension
+
+`Zend\Expressive\Plates\Extension\EscaperExtension` proxies to functionality
+provided in the [zend-escaper](https://docs.zendframework.com/zend-escaper/)
+package. It looks for the following configuration in the `config` service:
+
+```php
+// In config/autoload/templates.global.php:
+
 return [
     'plates' => [
         'encoding' => ?string, // character encoding of generated content
@@ -129,4 +148,21 @@ public function escapeHtmlAttr(string $attribute) : string;
 public function escapeJs(string $js) : string;
 public function escapeCss(string $css) : string;
 public function escapeUrl(string $url) : string;
+```
+
+As examples:
+
+```php
+<html>
+  <head>
+    <meta name="author" content="<?= $this->escapeHmtmlAttr($this->author) ?>">
+    <link rel="alternative" href="<?= $this->escapeUrl($this->alternative) ?>">
+    <style><?= $this->escapeCss($this->styles) ?></style>
+    <script><?= $this->escapeJs($this->script) ?></script>
+  </head>
+
+  <body>
+    <?= $this->escapeHtml($this->content) ?>
+  </body>
+</html>
 ```

--- a/docs/book/v3/features/template/plates.md
+++ b/docs/book/v3/features/template/plates.md
@@ -47,3 +47,86 @@ $plates->loadExtension(new CustomExtension());
 // Inject:
 $renderer = new PlatesRenderer($plates);
 ```
+
+## Configuration and Factory
+
+zend-expressive-platesrenderer ships with the factory
+`Zend\Expressive\Plates\PlatesRendererFactory`, which will both create the
+Plates engine instance, and the `PlatesRenderer` instance. If you are using
+[zend-component-installer](https://docs.zendframework.com/zend-component-installer/),
+this will be automatically wired for you during installation.
+
+The factory looks for the following configuration in the `config` service, using
+any it finds:
+
+```php
+return [
+    'plates' => [
+        'extensions' => [
+            // string service names or class names of Plates extensions
+        ],
+    ],
+    'templates' => [
+        'extension' => 'phtml', // change this if you use a different file
+                                // extension for templates
+        'paths' => [
+            // namespace => [paths] pairs
+        ],
+    ],
+];
+```
+
+The factory will also inject two extensions by default,
+`Zend\Expressive\Plates\Extension\UrlExtension` and
+`Zend\Expressive\Plates\Extension\EscaperExtension`, both listed in more detail
+below.
+
+## Shipped Extensions
+
+zend-expressive-plates provides the following extensions.
+
+### UrlExtension
+
+`Zend\Expressive\Plates\Extension\UrlExtension` composes each of the
+[UrlHelper](../helpers/url-helper.md) and [ServerUrlHelper](../helpers/server-url-helper),
+and provides the following template methods:
+
+```php
+public function url(
+   string $routeName = null,
+   array $routeParams = [],
+   array $queryParams = [],
+   ?string $fragmentIdentifier = null,
+   array $options = []
+) : string;
+
+public function serverurl(string $path = null) : string;
+
+// Since zend-expressive-platesrender 2.1.0:
+public function route() : ?Zend\Expressive\Router\RouteResult
+```
+
+### EscaperExtension
+
+`Zend\Expressive\Plates\Extension\UrlExtension` looks for the following
+configuration in the `config` service:
+
+```php
+return [
+    'plates' => [
+        'encoding' => ?string, // character encoding of generated content
+    ],
+];
+```
+
+By default it assumes UTF-8 for the encoding.
+
+The extension registers the following template methods:
+
+```php
+public function escapeHtml(string $html) : string;
+public function escapeHtmlAttr(string $attribute) : string;
+public function escapeJs(string $js) : string;
+public function escapeCss(string $css) : string;
+public function escapeUrl(string $url) : string;
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ pages:
             - ServerUrlHelper: v3/features/helpers/server-url-helper.md
             - 'Body Parsing Middleware': v3/features/helpers/body-parse.md
             - 'Content-Length Middleware': v3/features/helpers/content-length.md
+            - 'Template Variable Container': v3/features/helpers/template-variable-container.md
         - Emitters: v3/features/emitters.md
     - Cookbook:
         - 'Autowiring routes and pipeline middleware': v3/cookbook/autowiring-routes-and-pipelines.md


### PR DESCRIPTION
This patch documents each of:

- `UrlHelper::getRouteResult()`
- The new `TemplateVariableContainer` and associated middleware
- The new `route()` method available via the PlatesRenderer's `UrlExtension`. This required actually documenting the configuration and factory for the PlatesRenderer, as well as the existing extensions.