### PR TITLE
Added missing documentation about configuration option "auto_reload"

### DIFF
--- a/docs/book/v3/features/template/twig.md
+++ b/docs/book/v3/features/template/twig.md
@@ -130,6 +130,7 @@ return [
             // runtime loader names or instances
         ],
         'timezone' => 'default timezone identifier, e.g. America/New_York',
+        'auto_reload' => true, // Recompile the template whenever the source code changes
     ],
 ];
 ```


### PR DESCRIPTION
For reference please see: zendframework/zend-expressive-twigrenderer#53

- [x] Is this related to documentation?
  <!-- Is it a typographical and/or grammatical fix? -->
  <!-- Is it new documentation? -->
