### PR TITLE
Fix flash message on "Common Data In Templates" cookbook

### DIFF
--- a/docs/book/v3/cookbook/access-common-data-in-templates.md
+++ b/docs/book/v3/cookbook/access-common-data-in-templates.md
@@ -27,7 +27,8 @@ use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Zend\Expressive\Router\RouteResult;
 use Zend\Expressive\Session\Authentication\UserInterface;
-use Zend\Expressive\Session\Flash\FlashMessagesInterface;
+use Zend\Expressive\Flash\FlashMessagesInterface;
+use Zend\Expressive\Flash\FlashMessageMiddleware;
 use Zend\Expressive\Template\TemplateRendererInterface;
 
 class TemplateDefaultsMiddleware implements MiddlewareInterface
@@ -59,7 +60,7 @@ class TemplateDefaultsMiddleware implements MiddlewareInterface
 
         // Inject all flash messages
         /** @var FlashMessagesInterface $flashMessages */
-        $flashMessages = $request->getAttribute(FlashMessagesInterface::class);
+        $flashMessages = $request->getAttribute(FlashMessageMiddleware::FLASH_ATTRIBUTE);
         $this->templateRenderer->addDefaultParam(
             TemplateRendererInterface::TEMPLATE_ALL,
             'notifications',


### PR DESCRIPTION
Fix namespace and flash message attribute, in accordance with [zend-expressive-flash](https://docs.zendframework.com/zend-expressive-flash/messages/).

- [x] Is this related to documentation?
  <!-- Is it a typographical and/or grammatical fix? -->
  <!-- Is it new documentation? -->
