### PR TITLE
Fix docs inconsistency listing old provided renderer classes

### DIFF
--- a/docs/book/v1/features/container/factories.md
+++ b/docs/book/v1/features/container/factories.md
@@ -214,7 +214,7 @@ pre-configured editor types), a callable, or a service name to use.
 
 ## PlatesRendererFactory
 
-- **Provides**: `Zend\Expressive\Template\PlatesRenderer`
+- **Provides**: `Zend\Expressive\Plates\PlatesRenderer`
 - **FactoryName**: `Zend\Expressive\Plates\PlatesRendererFactory`
 - **Suggested Name**: `Zend\Expressive\Template\TemplateRendererInterface`
 - **Requires**: no additional services are required.
@@ -242,7 +242,7 @@ per namespace when using Plates.
 
 ## TwigRendererFactory
 
-- **Provides**: `Zend\Expressive\Template\TwigRenderer`
+- **Provides**: `Zend\Expressive\Twig\TwigRenderer`
 - **FactoryName**: `Zend\Expressive\Twig\TwigRendererFactory`
 - **Suggested Name**: `Zend\Expressive\Template\TemplateRendererInterface`
 - **Requires**: no additional services are required.
@@ -279,7 +279,7 @@ the `TwigExtension` instance (assuming the router was found).
 
 ## ZendViewRendererFactory
 
-- **Provides**: `Zend\Expressive\Template\ZendViewRenderer`
+- **Provides**: `Zend\Expressive\ZendView\ZendViewRenderer`
 - **FactoryName**: `Zend\Expressive\ZendView\ZendViewRendererFactory`
 - **Suggested Name**: `Zend\Expressive\Template\TemplateRendererInterface`
 - **Requires**: no additional services are required.

--- a/docs/book/v2/features/container/factories.md
+++ b/docs/book/v2/features/container/factories.md
@@ -287,7 +287,7 @@ pre-configured editor types), a callable, or a service name to use.
 
 ## PlatesRendererFactory
 
-- **Provides**: `Zend\Expressive\Template\PlatesRenderer`
+- **Provides**: `Zend\Expressive\Plates\PlatesRenderer`
 - **FactoryName**: `Zend\Expressive\Plates\PlatesRendererFactory`
 - **Suggested Name**: `Zend\Expressive\Template\TemplateRendererInterface`
 - **Requires**: no additional services are required.
@@ -315,7 +315,7 @@ per namespace when using Plates.
 
 ## TwigRendererFactory
 
-- **Provides**: `Zend\Expressive\Template\TwigRenderer`
+- **Provides**: `Zend\Expressive\Twig\TwigRenderer`
 - **FactoryName**: `Zend\Expressive\Twig\TwigRendererFactory`
 - **Suggested Name**: `Zend\Expressive\Template\TemplateRendererInterface`
 - **Requires**: no additional services are required.
@@ -352,7 +352,7 @@ the `TwigExtension` instance (assuming the router was found).
 
 ## ZendViewRendererFactory
 
-- **Provides**: `Zend\Expressive\Template\ZendViewRenderer`
+- **Provides**: `Zend\Expressive\ZendView\ZendViewRenderer`
 - **FactoryName**: `Zend\Expressive\ZendView\ZendViewRendererFactory`
 - **Suggested Name**: `Zend\Expressive\Template\TemplateRendererInterface`
 - **Requires**: no additional services are required.

--- a/docs/book/v3/features/container/factories.md
+++ b/docs/book/v3/features/container/factories.md
@@ -401,7 +401,7 @@ during installation.
 
 ### PlatesRendererFactory
 
-- **Provides**: `Zend\Expressive\Template\PlatesRenderer`
+- **Provides**: `Zend\Expressive\Plates\PlatesRenderer`
 - **FactoryName**: `Zend\Expressive\Plates\PlatesRendererFactory`
 - **Suggested Name**: `Zend\Expressive\Template\TemplateRendererInterface`
 - **Requires**: no additional services are required.
@@ -429,7 +429,7 @@ per namespace when using Plates.
 
 ### TwigRendererFactory
 
-- **Provides**: `Zend\Expressive\Template\TwigRenderer`
+- **Provides**: `Zend\Expressive\Twig\TwigRenderer`
 - **FactoryName**: `Zend\Expressive\Twig\TwigRendererFactory`
 - **Suggested Name**: `Zend\Expressive\Template\TemplateRendererInterface`
 - **Requires**: no additional services are required.
@@ -466,7 +466,7 @@ the `TwigExtension` instance (assuming the router was found).
 
 ### ZendViewRendererFactory
 
-- **Provides**: `Zend\Expressive\Template\ZendViewRenderer`
+- **Provides**: `Zend\Expressive\ZendView\ZendViewRenderer`
 - **FactoryName**: `Zend\Expressive\ZendView\ZendViewRendererFactory`
 - **Suggested Name**: `Zend\Expressive\Template\TemplateRendererInterface`
 - **Requires**: no additional services are required.


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:

- [x] Is this related to documentation?
  Listed provided renderers class names were removed in 0.5.0 release and extracted into separate packages.
