### PR TITLE
Add docs for extension config parameter for zend view renderer

### DIFF
--- a/docs/book/v3/features/container/factories.md
+++ b/docs/book/v3/features/container/factories.md
@@ -493,6 +493,7 @@ It consumes the following `config` structure:
 ```php
 'templates' => [
     'layout' => 'name of layout view to use, if any',
+    'extension' => 'file extension used by templates; defaults to phtml',
     'map'    => [
         // template => filename pairs
     ],
@@ -504,6 +505,8 @@ It consumes the following `config` structure:
     ],
 ]
 ```
+
+- `extension` parameter available since `zendframework/zend-expressive-zendviewrenderer` 2.2.0
 
 When creating the `PhpRenderer` instance, it will inject it with a
 `Zend\View\HelperPluginManager` instance (either pulled from the container, or


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:

2.2.0 release of `zendframework/zend-expressive-zendviewrenderer` adds support for `extension` parameter for default suffix to be used by zend-view resolver, in line with other template renderers.

- [x] Is this related to documentation?
  Add documentation entry for `extension` config parameter.
