### PR TITLE
Use 3rd lvl header for blockquote

### DIFF
--- a/docs/book/v1/cookbook/setting-locale-depending-routing-parameter.md
+++ b/docs/book/v1/cookbook/setting-locale-depending-routing-parameter.md
@@ -4,7 +4,7 @@ Localized web applications often set the locale (and therefor the language)
 based on a routing parameter, the session, or a specialized sub-domain.
 In this recipe we will concentrate on using a routing parameter.
 
-> ## Routing parameters
+> ### Routing parameters
 >
 > Using the approach in this chapter requires that you add a `/:locale` (or
 > similar) segment to each and every route that can be localized, and, depending

--- a/docs/book/v1/cookbook/setting-locale-without-routing-parameter.md
+++ b/docs/book/v1/cookbook/setting-locale-without-routing-parameter.md
@@ -6,7 +6,7 @@ In this recipe we will concentrate on introspecting the URI path via middleware,
 which allows you to have a global mechanism for detecting the locale without
 requiring any changes to existing routes.
 
-> ## Distinguishing between routes that require localization
+> ### Distinguishing between routes that require localization
 >
 > If your application has a mixture of routes that require localization, and
 > those that do not, the solution in this recipe may lead to multiple URIs

--- a/docs/book/v1/cookbook/using-routed-middleware-class-as-controller.md
+++ b/docs/book/v1/cookbook/using-routed-middleware-class-as-controller.md
@@ -45,7 +45,7 @@ The above defines a route that will match any of the following:
 The `action` attribute can thus be one of `add` or `edit`, and we can optionally
 also receive an `id` attribute (in the latter example, it would be `3`).
 
-> ## Routing definitions may vary
+> ### Routing definitions may vary
 >
 > Depending on the router you chose when starting your project, your routing
 > definition may differ. The above example uses the default `FastRoute`
@@ -157,7 +157,7 @@ concatenates it with the word `Action`. It then uses this value to determine if
 a corresponding method exists in the current class, and, if so, calls it with
 the arguments it received; otherwise, it returns a 404 response.
 
-> ## Invoking the error stack
+> ### Invoking the error stack
 >
 > Instead of returning a 404 response, you could also invoke `$next()` with an
 > error:
@@ -196,7 +196,7 @@ class AlbumPage extends AbstractPage
 }
 ```
 
-> ## Or use a trait
+> ### Or use a trait
 >
 > As an alternative to an abstract class, you could define the `__invoke()`
 > logic in a trait, which you then compose into your middleware:

--- a/docs/book/v1/features/container/intro.md
+++ b/docs/book/v1/features/container/intro.md
@@ -26,7 +26,7 @@ At this time, we document support for the following specific containers:
 - [pimple-interop](pimple.md)
 - [aura.di](aura-di.md)
 
-> ## Service Names
+> ### Service Names
 >
 > We recommend using fully-qualified class names whenever possible as service
 > names, with one exception: in cases where a service provides an implementation

--- a/docs/book/v1/reference/usage-examples.md
+++ b/docs/book/v1/reference/usage-examples.md
@@ -23,7 +23,7 @@ We assume also that:
 - Your own classes are under `src/` with the top-level namespace `Application`,
   and you have configured [autoloading](https://getcomposer.org/doc/01-basic-usage.md#autoloading) in your `composer.json` for those classes.
 
-> ## Using the built-in web server
+> ### Using the built-in web server
 >
 > You can use the built-in web server to run the examples. Run:
 >
@@ -39,7 +39,7 @@ We assume also that:
 > $ composer serve
 > ```
 
-> ## Setting up autoloading for the Application namespace
+> ### Setting up autoloading for the Application namespace
 >
 > In your `composer.json` file, place the following:
 >

--- a/docs/book/v2/cookbook/setting-locale-without-routing-parameter.md
+++ b/docs/book/v2/cookbook/setting-locale-without-routing-parameter.md
@@ -6,7 +6,7 @@ In this recipe we will concentrate on introspecting the URI path via middleware,
 which allows you to have a global mechanism for detecting the locale without
 requiring any changes to existing routes.
 
-> ## Distinguishing between routes that require localization
+> ### Distinguishing between routes that require localization
 >
 > If your application has a mixture of routes that require localization, and
 > those that do not, the solution in this recipe may lead to multiple URIs

--- a/docs/book/v2/cookbook/using-routed-middleware-class-as-controller.md
+++ b/docs/book/v2/cookbook/using-routed-middleware-class-as-controller.md
@@ -51,7 +51,7 @@ The above each define a route that will match any of the following:
 The `action` attribute can thus be one of `add` or `edit`, and we can optionally
 also receive an `id` attribute (in the latter example, it would be `3`).
 
-> ## Routing definitions may vary
+> ### Routing definitions may vary
 >
 > Depending on the router you chose when starting your project, your routing
 > definition may differ. The above example uses the default `FastRoute`
@@ -183,7 +183,7 @@ class AlbumPage extends AbstractPage
 }
 ```
 
-> ## Or use a trait
+> ### Or use a trait
 >
 > As an alternative to an abstract class, you could define the `__invoke()`
 > logic in a trait, which you then compose into your middleware:

--- a/docs/book/v2/features/container/intro.md
+++ b/docs/book/v2/features/container/intro.md
@@ -26,7 +26,7 @@ At this time, we document support for the following specific containers:
 - [pimple-interop](pimple.md)
 - [aura.di](aura-di.md)
 
-> ## Service Names
+> ### Service Names
 >
 > We recommend using fully-qualified class names whenever possible as service
 > names, with one exception: in cases where a service provides an implementation

--- a/docs/book/v2/features/emitters.md
+++ b/docs/book/v2/features/emitters.md
@@ -40,7 +40,7 @@ $stack->push($emitterInstance);
 As a stack, execution is in LIFO (last in, first out) order; the first emitter
 on the stack will be evaluated last.
 
-> ## Deprecated with version 2.2
+> ### Deprecated with version 2.2
 >
 > Starting in version 2.2, the `EmitterStack` is deprecated, and moved, along with the
 > zend-diactoros `EmitterInterface` and implementations, to a new package,

--- a/docs/book/v2/features/middleware/implicit-methods-middleware.md
+++ b/docs/book/v2/features/middleware/implicit-methods-middleware.md
@@ -7,7 +7,7 @@ _must_ support `HEAD` requests for any given URI, and that they _should_ support
 layer, and middleware that can detect _implicit_  support for these methods
 (i.e., the route was not registered _explicitly_ with the method).
 
-> ## Versions prior to 2.2
+> ### Versions prior to 2.2
 >
 > If you are using Expressive versions earlier than 2.2, you may define a
 > `Zend\Expressive\Middleware\ImplicitHeadMiddleware` or

--- a/docs/book/v2/getting-started/standalone.md
+++ b/docs/book/v2/getting-started/standalone.md
@@ -4,7 +4,7 @@ Expressive allows you to get started at your own pace. You can start with
 the simplest example, detailed below, or move on to a more structured,
 configuration-driven approach as detailed in the [use case examples](../reference/usage-examples.md).
 
-> ## Deprecated with version 2.2
+> ### Deprecated with version 2.2
 >
 > The `Zend\Expressive\AppFactory` detailed in this chapter is deprecated as of
 > version 2.2, and will be removed in version 3.0. We recommend instead

--- a/docs/book/v2/reference/usage-examples.md
+++ b/docs/book/v2/reference/usage-examples.md
@@ -25,7 +25,7 @@ We assume also that:
   in your `composer.json` for those classes (this should be done for you during
   installation).
 
-> ## Using the built-in web server
+> ### Using the built-in web server
 >
 > You can use the built-in web server to run the examples. Run:
 >
@@ -41,7 +41,7 @@ We assume also that:
 > $ composer run --timeout=0 serve
 > ```
 
-> ## Setting up autoloading for the Application namespace
+> ### Setting up autoloading for the Application namespace
 >
 > In your `composer.json` file, place the following:
 >

--- a/docs/book/v3/cookbook/setting-locale-without-routing-parameter.md
+++ b/docs/book/v3/cookbook/setting-locale-without-routing-parameter.md
@@ -6,7 +6,7 @@ In this recipe we will concentrate on introspecting the URI path via middleware,
 which allows you to have a global mechanism for detecting the locale without
 requiring any changes to existing routes.
 
-> ## Distinguishing between routes that require localization
+> ### Distinguishing between routes that require localization
 >
 > If your application has a mixture of routes that require localization, and
 > those that do not, the solution in this recipe may lead to multiple URIs

--- a/docs/book/v3/features/container/intro.md
+++ b/docs/book/v3/features/container/intro.md
@@ -31,7 +31,7 @@ At this time, we document support for the following specific containers:
 - [pimple-interop](pimple.md)
 - [aura.di](aura-di.md)
 
-> ## Service Names
+> ### Service Names
 >
 > We recommend using fully-qualified class names whenever possible as service
 > names, with one exception: in cases where a service provides an implementation


### PR DESCRIPTION
2nd level header is rendered with line above, it looks quite odd
in blockquotes

Before:

![image](https://user-images.githubusercontent.com/7423207/67429771-c21e0880-f5d8-11e9-9607-fefdf800c15a.png)

After:

![image](https://user-images.githubusercontent.com/7423207/67430027-4e303000-f5d9-11e9-9216-f151355c4bdf.png)


- [x] Is this related to documentation?
  <!-- Is it a typographical and/or grammatical fix? -->
  <!-- Is it new documentation? -->
